### PR TITLE
Modifying pester tests to not copy file to Program Files

### DIFF
--- a/Tests/MSFT_xFirewall.Tests.ps1
+++ b/Tests/MSFT_xFirewall.Tests.ps1
@@ -1,15 +1,27 @@
-Remove-Module -Name MSFT_xFirewall -Force -ErrorAction SilentlyContinue
-Import-Module -Name $PSScriptRoot\..\DSCResources\MSFT_xFirewall -Force -DisableNameChecking
+$here = Split-Path -Parent $MyInvocation.MyCommand.Path
 
 if (! (Get-Module xDSCResourceDesigner))
 {
-    Import-Module -Name xDSCResourceDesigner -ErrorAction SilentlyContinue
+    Import-Module -Name xDSCResourceDesigner
 }
 
-Describe 'Schema Validation for MSFT_xFirewall' {
-    Copy-Item -Path ((get-item .).parent.FullName) -Destination $(Join-Path -Path $env:ProgramFiles -ChildPath 'WindowsPowerShell\Modules\') -Force -Recurse
-    $result = Test-xDscResource MSFT_xFirewall
+Describe 'Schema Validation MSFT_xFirewall' {
     It 'should pass Test-xDscResource' {
+        $path = Join-Path -Path $((Get-Item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xFirewall'
+        $result = Test-xDscResource $path
+        $result | Should Be $true
+    }
+
+    It 'should pass Test-xDscResource' {
+        $path = Join-Path -Path $((get-item $here).parent.FullName) -ChildPath 'DSCResources\MSFT_xFirewall\MSFT_xFirewall.schema.mof'
+        $result = Test-xDscSchema $path
         $result | Should Be $true
     }
 }
+
+if (Get-Module MSFT_xFirewall -All)
+{
+    Get-Module MSFT_xFirewall -All | Remove-Module
+}
+
+Import-Module -Name $PSScriptRoot\..\DSCResources\MSFT_xFirewall -Force -DisableNameChecking


### PR DESCRIPTION
Partial fix for #7.

This will not fix the fact that the user will need xDSCResourceDesigner to run the tests.