### PR TITLE
Test all parameters

### DIFF
--- a/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -259,7 +259,6 @@ function ValidateProperties
 
                 if(-not $NoReset)
                 {
-                    Write-Verbose -Message "Catch1"
                     # Remove any default routes on the specified interface -- it is important to do
                     # this *before* removing the IP address, particularly in the case where the IP
                     # address was auto-configured by DHCP
@@ -267,14 +266,12 @@ function ValidateProperties
                     {
                         $defaultRoutes | Remove-NetRoute -confirm:$false -ErrorAction Stop
                     }
-                    Write-Verbose -Message "Catch2"
 
                     # Remove any IP addresses on the specified interface
                     if($currentIP)
                     {
                         $currentIP | Remove-NetIPAddress -confirm:$false -ErrorAction Stop
                     }
-                    Write-Verbose -Message "Catch3"
                 }
                 else
                 {

--- a/Tests/MSFT_xIPAddress.Tests.ps1
+++ b/Tests/MSFT_xIPAddress.Tests.ps1
@@ -90,13 +90,12 @@ InModuleScope MSFT_xIPAddress {
             }
         }
 
-        Mock Get-NetIPConfiguration {
+        Mock Get-NetRoute {
             [PSCustomObject]@{
                 InterfaceAlias = 'Ethernet'
-                InterfaceIndex = 1
-                IPv4DefaultGateway = [PSCustomObject]@{
-                    NextHop = '192.168.0.254'
-                }
+                AddressFamily = 'IPv4'
+                NextHop = '192.168.0.254'
+                DestinationPrefix = '0.0.0.0/0'
             }
         }
 
@@ -112,6 +111,8 @@ InModuleScope MSFT_xIPAddress {
         Mock Set-NetConnectionProfile {}
 
         Mock Remove-NetIPAddress {}
+
+        Mock Remove-NetRoute {}
         #endregion
 
         Context 'invoking without -Apply switch' {

--- a/Tests/MSFT_xIPAddress.Tests.ps1
+++ b/Tests/MSFT_xIPAddress.Tests.ps1
@@ -73,6 +73,7 @@ InModuleScope MSFT_xIPAddress {
             [PSCustomObject]@{
                 IPAddress = '192.168.0.1'
                 InterfaceAlias = 'Ethernet'
+                PrefixLength = [byte]16
             }
         }
 
@@ -89,14 +90,35 @@ InModuleScope MSFT_xIPAddress {
             }
         }
 
+        Mock Get-NetIPConfiguration {
+            [PSCustomObject]@{
+                InterfaceAlias = 'Ethernet'
+                InterfaceIndex = 1
+                IPv4DefaultGateway = [PSCustomObject]@{
+                    NextHop = '192.168.0.254'
+                }
+            }
+        }
+
+        Mock Get-NetIPInterface {
+            [PSCustomObject]@{
+                InterfaceAlias = 'Ethernet'
+                InterfaceIndex = 1
+                AddressFamily = 'IPv4'
+                Dhcp = 'Disabled'
+            }
+        }
+
         Mock Set-NetConnectionProfile {}
+
+        Mock Remove-NetIPAddress {}
         #endregion
 
         Context 'invoking without -Apply switch' {
 
             It 'should be $false' {
                 $Splat = @{
-                    IPAddres = '10.0.0.2'
+                    IPAddress = '10.0.0.2'
                     InterfaceAlias = 'Ethernet'
                 }
                 $Result = ValidateProperties @Splat
@@ -105,7 +127,7 @@ InModuleScope MSFT_xIPAddress {
 
             It 'should be $true' {
                 $Splat = @{
-                    IPAddres = '192.168.0.1'
+                    IPAddress = '192.168.0.1'
                     InterfaceAlias = 'Ethernet'
                 }
                 $Result = ValidateProperties @Splat
@@ -117,7 +139,7 @@ InModuleScope MSFT_xIPAddress {
 
             It 'should be $null' {
                 $Splat = @{
-                    IPAddres = '10.0.0.2'
+                    IPAddress = '10.0.0.2'
                     InterfaceAlias = 'Ethernet'
                 }
                 $Result = ValidateProperties @Splat -Apply

--- a/Tests/MSFT_xIPAddress.Tests.ps1
+++ b/Tests/MSFT_xIPAddress.Tests.ps1
@@ -134,6 +134,18 @@ InModuleScope MSFT_xIPAddress {
                 $Result = ValidateProperties @Splat
                 $Result | Should Be $true
             }
+
+            It 'should call Get-NetIPAddress once' {
+                Assert-MockCalled -commandName Get-NetIPAddress
+            }
+
+            It 'should call Get-NetRoute once' {
+                Assert-MockCalled -commandName Get-NetRoute
+            }
+
+            It 'should call Get-NetIPInterface once' {
+                Assert-MockCalled -commandName Get-NetIPInterface
+            }
         }
 
         Context 'invoking with -Apply switch' {
@@ -145,6 +157,17 @@ InModuleScope MSFT_xIPAddress {
                 }
                 $Result = ValidateProperties @Splat -Apply
                 $Result | Should BeNullOrEmpty
+            }
+
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-NetIPAddress
+                Assert-MockCalled -commandName Get-NetConnectionProfile
+                Assert-MockCalled -commandName Get-NetRoute
+                Assert-MockCalled -commandName Get-NetIPInterface
+                Assert-MockCalled -commandName Remove-NetRoute
+                Assert-MockCalled -commandName Remove-NetIPAddress
+                Assert-MockCalled -commandName New-NetIPAddress
+                Assert-MockCalled -commandName Set-NetConnectionProfile
             }
         }
     }


### PR DESCRIPTION
Previously, xIPAddress only checked whether the configured IP Address matched the IPAddress parameter. This pull request checks all parameters against the existing configuration. 

Fixes #9