### PR TITLE
Minor Fix to xDNSServerAddress to correct verbose logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+DSCResource.Tests

--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -102,8 +102,8 @@ function Set-TargetResource
         Set-DnsClientServerAddress `
             -InterfaceAlias $InterfaceAlias `
             -ServerAddresses $Address `
-            -Validate
-
+            -Validate `
+            -ErrorAction Stop
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
             $($LocalizedData.DNSServersHaveBeenSetCorrectlyMessage)
             ) -join '' )

--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -13,6 +13,7 @@ DNSServersSetCorrectlyMessage=DNS Servers are set correctly.
 DNSServersAlreadySetMessage=DNS Servers are already set correctly.
 CheckingDNSServerAddressesMessage=Checking the DNS Server Addresses.
 DNSServersNotCorrectMessage=DNS Servers are not correct. Expected "{0}", actual "{1}".
+DNSServersHaveBeenSetCorrectlyMessage=DNS Servers were set to the desired state.
 InterfaceNotAvailableError=Interface "{0}" is not available. Please select a valid interface and try again.
 AddressFormatError=Address "{0}" is not in the correct format. Please correct the Address parameter in the configuration and try again.
 AddressIPv4MismatchError=Address "{0}" is in IPv4 format, which does not match server address family {1}. Please correct either of them in the configuration and try again.
@@ -90,20 +91,21 @@ function Set-TargetResource
         -ErrorAction Stop).ServerAddresses
 
     #Check if the Server addresses are the same as the desired addresses.
-    [Boolean] $addressCompare = (Compare-Object `
+    [Boolean] $addressDifferent = (@(Compare-Object `
             -ReferenceObject $currentAddress `
             -DifferenceObject $Address `
-            -SyncWindow 0).Length -gt 0
+            -SyncWindow 0).Length -gt 0)
 
-    if ($addressCompare)
+    if ($addressDifferent)
     {
         # Set the DNS settings as well
         Set-DnsClientServerAddress `
             -InterfaceAlias $InterfaceAlias `
             -ServerAddresses $Address `
             -Validate
+
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.DNSServersSetCorrectlyMessage)
+            $($LocalizedData.DNSServersHaveBeenSetCorrectlyMessage)
             ) -join '' )
     }
     else 
@@ -158,14 +160,17 @@ function Test-TargetResource
         -ErrorAction Stop).ServerAddresses
 
     #Check if the Server addresses are the same as the desired addresses.
-    if (@(Compare-Object `
-        -ReferenceObject $currentAddress `
-        -DifferenceObject $Address `
-        -SyncWindow 0).Length -gt 0)
+    [Boolean] $addressDifferent = (@(Compare-Object `
+            -ReferenceObject $currentAddress `
+            -DifferenceObject $Address `
+            -SyncWindow 0).Length -gt 0)
+
+    if ($addressDifferent)
     {
         $desiredConfigurationMatch = $false
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.DNSServersNotCorrectMessage) -f $Address,$currentAddress
+            $($LocalizedData.DNSServersNotCorrectMessage) `
+                -f ($Address -join ','),($currentAddress -join ',')
             ) -join '' )
     }
     else 

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ## Versions
 
+### Unreleased Version
+* MSFT_xDNSServerAddress: Corrected Verbose logging messages when multiple DNS adddressed specified.
+* MSFT_xDNSServerAddress: Change to ensure resource terminates if DNS Server validation fails.
+
 ### 2.4.0.0
 * Added following resources:
   * MSFT_xDefaultGatewayAddress

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased Version
-* MSFT_xDNSServerAddress: Corrected Verbose logging messages when multiple DNS adddressed specified.
+* MSFT_xDNSServerAddress: Correct Verbose logging messages when multiple DNS adddressed specified.
 * MSFT_xDNSServerAddress: Change to ensure resource terminates if DNS Server validation fails.
 
 ### 2.4.0.0

--- a/README.md
+++ b/README.md
@@ -54,7 +54,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Versions
 
 ### Unreleased Version
-* MSFT_xDNSServerAddress: Correct Verbose logging messages when multiple DNS adddressed specified.
+* MSFT_xDNSServerAddress: Corrected Verbose logging messages when multiple DNS adddressed specified.
 * MSFT_xDNSServerAddress: Change to ensure resource terminates if DNS Server validation fails.
 
 ### 2.4.0.0

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -52,7 +52,7 @@ InModuleScope MSFT_xDNSServerAddress {
         }
         #endregion
 
-        Context 'comparing IPAddress' {
+        Context 'comparing IPv4 Address' {
             It 'should return true' {
 
                 $Splat = @{
@@ -64,11 +64,38 @@ InModuleScope MSFT_xDNSServerAddress {
                 $Result.IPAddress | Should Be $Splat.IPAddress
             }
         }
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = 'fe80:ab04:30F5:002b::1'
+                InterfaceAlias = 'Ethernet'
+                AddressFamily = 'IPv6'
+            }
+        }
+        #endregion
+
+        Context 'comparing IPv6 Address' {
+            It 'should return true' {
+
+                $Splat = @{
+                    Address = 'fe80:ab04:30F5:002b::1'
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                $Result = Get-TargetResource @Splat
+                $Result.IPAddress | Should Be $Splat.IPAddress
+            }
+        }
+
     }
 
     #######################################################################################
 
     Describe 'Set-TargetResource' {
+
+        # Test IPv4
 
         #region Mocks
         Mock Get-DnsClientServerAddress -MockWith {
@@ -82,7 +109,7 @@ InModuleScope MSFT_xDNSServerAddress {
         Mock Set-DnsClientServerAddress
         #endregion
 
-        Context 'invoking with single Server Address that is the same as current' {
+        Context 'invoking with single IPv4 Server Address that is the same as current' {
             It 'should not throw an exception' {
 
                 $Splat = @{
@@ -97,7 +124,7 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0
             }
         }
-        Context 'invoking with single Server Address that is different to current' {
+        Context 'invoking with single IPv4 Server Address that is different to current' {
             It 'should not throw an exception' {
 
                 $Splat = @{
@@ -112,7 +139,7 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
             }
         }
-        Context 'invoking with multiple Server Addresses that are different to current' {
+        Context 'invoking with multiple IPv4 Server Addresses that are different to current' {
             It 'should not throw an exception' {
 
                 $Splat = @{
@@ -127,11 +154,130 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
             }
         }
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @()
+                InterfaceAlias = 'Ethernet'
+                AddressFamily = 'IPv4'
+            }
+        }
+        Mock Set-DnsClientServerAddress
+        #endregion
+
+        Context 'invoking with multiple IPv4 Server Addresses When there are no address assiged' {
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2','192.168.0.3')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv4'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+            }
+        }
+
+        # Test IPv6 
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @('fe80:ab04:30F5:002b::1')
+                InterfaceAlias = 'Ethernet'
+                AddressFamily = 'IPv6'
+            }
+        }
+        Mock Set-DnsClientServerAddress
+        #endregion
+
+        Context 'invoking with single IPv6 Server Address that is the same as current' {
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0
+            }
+        }
+        Context 'invoking with single IPv6 Server Address that is different to current' {
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+            }
+        }
+        Context 'invoking with multiple IPv6 Server Addresses that are different to current' {
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+            }
+        }
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @()
+                InterfaceAlias = 'Ethernet'
+                AddressFamily = 'IPv6'
+            }
+        }
+        Mock Set-DnsClientServerAddress
+        #endregion
+
+        Context 'invoking with multiple IPv6 Server Addresses When there are no address assiged' {
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::1')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+            }
+        }
+
     }
 
     #######################################################################################
 
     Describe 'Test-TargetResource' {
+
+        # Test IPv4 
 
         #region Mocks
         Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
@@ -145,7 +291,7 @@ InModuleScope MSFT_xDNSServerAddress {
         }
         #endregion
 
-        Context 'invoking with single Server Address that is the same as current' {
+        Context 'invoking with single IPv4 Server Address that is the same as current' {
             It 'should return true' {
 
                 $Splat = @{
@@ -159,7 +305,7 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
             }
         }
-        Context 'invoking with single Server Address that is different to current' {
+        Context 'invoking with single IPv4 Server Address that is different to current' {
             It 'should return false' {
 
                 $Splat = @{
@@ -173,7 +319,7 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
             }
         }
-        Context 'invoking with multiple Server Addresses that are different to current' {
+        Context 'invoking with multiple IPv4 Server Addresses that are different to current' {
             It 'should return false' {
 
                 $Splat = @{
@@ -187,6 +333,118 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
             }
         }
+
+        #region Mocks
+        Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @()
+                InterfaceAlias = 'Ethernet'
+                AddressFamily = 'IPv4'
+            }
+        }
+        #endregion
+
+        Context 'invoking with multiple IPv4 Server Addresses that are no addresses assigned' {
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2','192.168.0.3')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv4'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+            }
+        }
+
+        # Test IPv6 
+
+        #region Mocks
+        Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @('fe80:ab04:30F5:002b::1')
+                InterfaceAlias = 'Ethernet'
+                AddressFamily = 'IPv6'
+            }
+        }
+        #endregion
+
+        Context 'invoking with single IPv6 Server Address that is the same as current' {
+            It 'should return true' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                Test-TargetResource @Splat | Should Be $True
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+            }
+        }
+        Context 'invoking with single IPv6 Server Address that is different to current' {
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+            }
+        }
+        Context 'invoking with multiple IPv6 Server Addresses that are different to current' {
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+            }
+        }
+
+        #region Mocks
+        Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @()
+                InterfaceAlias = 'Ethernet'
+                AddressFamily = 'IPv6'
+            }
+        }
+        #endregion
+
+        Context 'invoking with multiple IPv6 Server Addresses that are no addresses assigned' {
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+            }
+        }
+
     }
 
     #######################################################################################

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -41,6 +41,8 @@ InModuleScope MSFT_xDNSServerAddress {
 
     Describe 'Get-TargetResource' {
 
+        # Test IPv4
+
         #region Mocks
         Mock Get-DnsClientServerAddress -MockWith {
 
@@ -52,7 +54,7 @@ InModuleScope MSFT_xDNSServerAddress {
         }
         #endregion
 
-        Context 'comparing IPv4 Address' {
+        Context 'invoking with an IPv4 address' {
             It 'should return true' {
 
                 $Splat = @{
@@ -65,6 +67,8 @@ InModuleScope MSFT_xDNSServerAddress {
             }
         }
 
+        # Test IPv6 
+
         #region Mocks
         Mock Get-DnsClientServerAddress -MockWith {
 
@@ -76,7 +80,7 @@ InModuleScope MSFT_xDNSServerAddress {
         }
         #endregion
 
-        Context 'comparing IPv6 Address' {
+        Context 'invoking with an IPv6 address' {
             It 'should return true' {
 
                 $Splat = @{


### PR DESCRIPTION
This change does:
1. corrects verbose logging in xDNSServerAddress when mulitple DNS Server Addresses are passed.
2. Adds an ErrorAction Stop parameter to the Set-DnsClientServerAddress cmdlet to ensure it stops if validation DNS Server validation fails.
3. Assigns result of address comparison to variable to make it easier to read and understand the logic and changes the variable name to make it more obvious.
4. Ensure that result of Object-Compare always results in an Array.