### PR TITLE
Issue34 and loging correction

### DIFF
--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.Schema.mof
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.Schema.mof
@@ -13,6 +13,6 @@ class MSFT_xFirewall : OMI_BaseResource
   [Write, Description("Local Port used for the filter")] String LocalPort[];
   [Write, Description("Specific Protocol for filter. Specified by name, number, or range")] String Protocol;
   [Write, Description("Documentation for the Rule")] String Description;
-  [Write, Description("Path and file name of the program for which the rule is applied")] String ApplicationPath;
+  [Write, Description("Path and file name of the program for which the rule is applied")] String Program;
   [Write, Description("Specifies the short name of a Windows service to which the firewall rule applies")] String Service;
 };

--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -416,7 +416,8 @@ function Test-RuleProperties
                 if (-not ($networkProfileinRule -contains $networkProfile))
                 {
                     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-                        $($LocalizedData.PropertyNoMatchMessage) -f 'Profile',$networkProfileinRule,$Profile
+                        $($LocalizedData.PropertyNoMatchMessage) `
+                            -f 'Profile',($networkProfileinRule -join ','),($Profile -join ',')
                         ) -join '')
                     $desiredConfigurationMatch = $false
                     break
@@ -426,7 +427,8 @@ function Test-RuleProperties
         else
         {
             Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-                $($LocalizedData.PropertyNoMatchMessage) -f 'Profile',$networkProfileinRule,$Profile
+                $($LocalizedData.PropertyNoMatchMessage) `
+                    -f 'Profile',($networkProfileinRule -join ','),($Profile -join ',')
                 ) -join '')
             $desiredConfigurationMatch = $false
         }
@@ -435,7 +437,8 @@ function Test-RuleProperties
     if ($Direction -and ($FirewallRule.Direction -ne $Direction))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.PropertyNoMatchMessage) -f 'Direction',$FirewallRule.Direction,$Direction
+            $($LocalizedData.PropertyNoMatchMessage) `
+                -f 'Direction',$FirewallRule.Direction,$Direction
             ) -join '')
         $desiredConfigurationMatch = $false
     }
@@ -451,7 +454,8 @@ function Test-RuleProperties
                 if (-not ($remotePortInRule -contains($port)))
                 {
                     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-                        $($LocalizedData.PropertyNoMatchMessage) -f 'RemotePort',$remotePortInRule,$RemotePort
+                        $($LocalizedData.PropertyNoMatchMessage) `
+                            -f 'RemotePort',($remotePortInRule -join ','),($RemotePort -join ',')
                         ) -join '')
                     $desiredConfigurationMatch = $false
                 }
@@ -460,7 +464,8 @@ function Test-RuleProperties
         else
         {
             Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-                $($LocalizedData.PropertyNoMatchMessage) -f 'RemotePort',$remotePortInRule,$RemotePort
+                $($LocalizedData.PropertyNoMatchMessage) `
+                    -f 'RemotePort',($remotePortInRule -join ','),($RemotePort -join ',')
                 ) -join '')
             $desiredConfigurationMatch = $false
         }
@@ -477,7 +482,8 @@ function Test-RuleProperties
                 if (-not ($localPortInRule -contains($port)))
                 {
                     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-                        $($LocalizedData.PropertyNoMatchMessage) -f 'LocalPort',$localPortInRule,$LocalPort
+                        $($LocalizedData.PropertyNoMatchMessage) `
+                            -f 'LocalPort',($localPortInRule -join ','),($LocalPort -join ',')
                         ) -join '')
                     $desiredConfigurationMatch = $false
                 }
@@ -486,7 +492,8 @@ function Test-RuleProperties
         else
         {
             Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-                $($LocalizedData.PropertyNoMatchMessage) -f 'LocalPort',$localPortInRule,$LocalPort
+                $($LocalizedData.PropertyNoMatchMessage) `
+                    -f 'LocalPort',($localPortInRule -join ','),($LocalPort -join ',')
                 ) -join '')
             $desiredConfigurationMatch = $false
         }
@@ -495,7 +502,8 @@ function Test-RuleProperties
     if ($Protocol -and ($properties.PortFilters.Protocol -ne $Protocol))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.PropertyNoMatchMessage) -f 'Protocol',$properties.PortFilters.Protocol,$Protocol
+            $($LocalizedData.PropertyNoMatchMessage) `
+                -f 'Protocol',$properties.PortFilters.Protocol,$Protocol
             ) -join '')
         $desiredConfigurationMatch = $false
     }
@@ -503,7 +511,8 @@ function Test-RuleProperties
     if ($Description -and ($FirewallRule.Description -ne $Description))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.PropertyNoMatchMessage) -f 'Description',$FirewallRule.Description,$Description
+            $($LocalizedData.PropertyNoMatchMessage) `
+                -f 'Description',$FirewallRule.Description,$Description
             ) -join '')
         $desiredConfigurationMatch = $false
     }
@@ -511,7 +520,8 @@ function Test-RuleProperties
     if ($ApplicationPath -and ($properties.ApplicationFilters.Program -ne $ApplicationPath))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.PropertyNoMatchMessage) -f 'ApplicationPath',$properties.ApplicationFilters.Program,$ApplicationPath
+            $($LocalizedData.PropertyNoMatchMessage) `
+                -f 'ApplicationPath',$properties.ApplicationFilters.Program,$ApplicationPath
             ) -join '')
         $desiredConfigurationMatch = $false
     }
@@ -519,7 +529,8 @@ function Test-RuleProperties
     if ($Service -and ($properties.ServiceFilters.Service -ne $Service))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.PropertyNoMatchMessage) -f 'Service',$properties.ServiceFilters.Service,$Service
+            $($LocalizedData.PropertyNoMatchMessage) `
+                -f 'Service',$properties.ServiceFilters.Service,$Service
             ) -join '')
         $desiredConfigurationMatch = $false
     }

--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -81,7 +81,7 @@ function Get-TargetResource
         RemotePort      = @($properties.PortFilters.RemotePort)
         LocalPort       = @($properties.PortFilters.LocalPort)
         Protocol        = $properties.PortFilters.Protocol
-        ApplicationPath = $properties.ApplicationFilters.Program
+        Program         = $properties.ApplicationFilters.Program
         Service         = $properties.ServiceFilters.Service
     }
 }
@@ -141,7 +141,7 @@ function Set-TargetResource
 
         # Path and file name of the program for which the rule is applied
         [ValidateNotNullOrEmpty()]
-        [String] $ApplicationPath,
+        [String] $Program,
 
         # Specifies the short name of a Windows service to which the firewall rule applies
         [ValidateNotNullOrEmpty()]
@@ -326,7 +326,7 @@ function Test-TargetResource
 
         # Path and file name of the program for which the rule is applied
         [ValidateNotNullOrEmpty()]
-        [String] $ApplicationPath,
+        [String] $Program,
 
         # Specifies the short name of a Windows service to which the firewall rule applies
         [ValidateNotNullOrEmpty()]
@@ -404,7 +404,7 @@ function Test-RuleProperties
         [String[]] $LocalPort,
         [String] $Protocol,
         [String] $Description,
-        [String] $ApplicationPath,
+        [String] $Program,
         [String] $Service
     )
 
@@ -548,11 +548,11 @@ function Test-RuleProperties
         $desiredConfigurationMatch = $false
     }
 
-    if ($ApplicationPath -and ($properties.ApplicationFilters.Program -ne $ApplicationPath))
+    if ($Program -and ($properties.ApplicationFilters.Program -ne $Program))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
             $($LocalizedData.PropertyNoMatchMessage) `
-                -f 'ApplicationPath',$properties.ApplicationFilters.Program,$ApplicationPath
+                -f 'Program',$properties.ApplicationFilters.Program,$Program
             ) -join '')
         $desiredConfigurationMatch = $false
     }
@@ -606,7 +606,8 @@ function Get-FirewallRule
         $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
 
-    return $firewallRule
+    # The array will only contain a single rule so only return the first one (not the array)
+    return $firewallRule[0]
 }
 
 ######################################################################################

--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -188,6 +188,15 @@ function Set-TargetResource
                     $($LocalizedData.UpdatingExistingFirewallMessage) -f $Name
                     ) -join '')
 
+                # If the DisplayName is provided then need to remove it
+                # And change it to NewDisplayName if it is different
+                if ($PSBoundParameters.ContainsKey('DisplayName')) {
+                    $null = $PSBoundParameters.Remove('DisplayName')
+                    if ($DisplayName -ne $FirewallRule.DisplayName) {
+                        $null = $PSBoundParameters.Add('NewDisplayName',$Name)
+                    }
+                }
+
                 # Set the existing Firewall rule based on specified parameters
                 Set-NetFirewallRule @PSBoundParameters
             }

--- a/README.md
+++ b/README.md
@@ -54,8 +54,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ## Known Invalid Configurations
 
 ### xFirewall
-* The exception 'One of the port keywords is invalid' will be thrown if a rule is created with the LocalPort set to PlayToDiscovery and the Protocol is not set to UDP. This is not an unexpected error, but because the New-NetFirewallRule documentation is ambiguous.
-* The exception 'The DisplayGroup of an existing Firewall Rule can not be changed' will be thrown if a configuration tries to change DisplayGroup property of an existing rule. This is because the Set-NetFirewallRule cmdlet does not support this function. Delete and re-create this rule instead. 
+* The exception 'One of the port keywords is invalid' will be thrown if a rule is created with the LocalPort set to PlayToDiscovery and the Protocol is not set to UDP. This is not an unexpected error, but because the New-NetFirewallRule documentation is incorrect.
+This issue has been reported on [Microsoft Connect](https://connect.microsoft.com/PowerShell/feedbackdetail/view/1974268/new-set-netfirewallrule-cmdlet-localport-parameter-documentation-is-incorrect-for-playtodiscovery)
+
+* The exception 'The DisplayGroup of an existing Firewall Rule can not be changed' will be thrown if a configuration tries to change DisplayGroup property of an existing rule. This is because the Set-NetFirewallRule cmdlet does not support this function. Delete and re-create this rule instead.
+This issue has been reported on [Microsoft Connect](https://connect.microsoft.com/PowerShell/feedbackdetail/view/1970765/add-ability-to-change-firewall-displaygroup-in-set-netfirewallrule-cmdlet) 
 
 ## Versions
 

--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **LocalPort**: Local port used for the filter.
 * **Protocol**: Specific protocol for filter. Specified by name, number, or range.
 * **Description**: Documentation for the rule.
-* **ApplicationPath**: Path and filename of the program for which the rule is applied.
+* **Program**: Path and filename of the program for which the rule is applied.
 * **Service**: Specifies the short name of a Windows service to which the firewall rule applies.
 
 ## Known Invalid Configurations
@@ -58,6 +58,9 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * The exception 'The DisplayGroup of an existing Firewall Rule can not be changed' will be thrown if a configuration tries to change DisplayGroup property of an existing rule. This is because the Set-NetFirewallRule cmdlet does not support this function. Delete and re-create this rule instead. 
 
 ## Versions
+
+### Unreleaed
+* MSFT_xFirewall: ApplicationPath Parameter renamed to Program for consistency with Cmdlets.
 
 ### 2.4.0.0
 * Added following resources:

--- a/README.md
+++ b/README.md
@@ -51,6 +51,12 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **ApplicationPath**: Path and filename of the program for which the rule is applied.
 * **Service**: Specifies the short name of a Windows service to which the firewall rule applies.
 
+## Known Invalid Configurations
+
+### xFirewall
+* The exception 'One of the port keywords is invalid' will be thrown if a rule is created with the LocalPort set to PlayToDiscovery and the Protocol is not set to UDP. This is not an unexpected error, but because the New-NetFirewallRule documentation is ambiguous.
+* The exception 'The DisplayGroup of an existing Firewall Rule can not be changed' will be thrown if a configuration tries to change DisplayGroup property of an existing rule. This is because the Set-NetFirewallRule cmdlet does not support this function. Delete and re-create this rule instead. 
+
 ## Versions
 
 ### 2.4.0.0

--- a/README.md
+++ b/README.md
@@ -61,6 +61,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 ### Unreleaed
 * MSFT_xFirewall: ApplicationPath Parameter renamed to Program for consistency with Cmdlets.
+* MSFT_xFirewall: Fix to prevent error when DisplayName parameter is set on an existing rule.
 
 ### 2.4.0.0
 * Added following resources:

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -191,11 +191,53 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Get-FirewallRule -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but is different' {
+        Context 'Ensure is Present and the Firewall Does Exist but has different DisplayName' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
-                $result = Set-TargetResource -Name $rule.Name -Ensure 'Present'
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -DisplayName 'Different' `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different DisplayGroup' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -DisplayGroup 'Different' `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different Enabled' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -Enabled 'False' `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different Action' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -Action 'Allow' `
+                    -Ensure 'Present'
 
                 Assert-MockCalled Set-NetFirewallRule -Exactly 1
                 Assert-MockCalled Test-RuleProperties -Exactly 1

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -101,8 +101,8 @@ InModuleScope $DSCResourceName {
                 $result.Protocol | Should Be $ruleProperties.PortFilters.Protocol
             }
 
-            It 'Should have the correct ApplicationPath and type' {
-                $result.ApplicationPath | Should Be $ruleProperties.ApplicationFilters.Program
+            It 'Should have the correct Program and type' {
+                $result.Program | Should Be $ruleProperties.ApplicationFilters.Program
             }
 
             It 'Should have the correct Service and type' {
@@ -205,7 +205,7 @@ InModuleScope $DSCResourceName {
             }
         }
         Context 'Ensure is Present and the Firewall Does Exist but has different DisplayGroup' {
-            It "should call expected mocks on firewall rule $($rule.Name)" {
+            It "should throw a CantChangeDisplayGroupError exception on rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
 
@@ -252,6 +252,115 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
+        Context 'Ensure is Present and the Firewall Does Exist but has different Profile' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                if ($rule.Profile -ccontains 'Domain') {$NewProfile = @('Public','Private')} else {$NewProfile = @('Domain','Public')}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -Profile $NewProfile `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different Direction' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                if ($rule.Direction -eq 'Inbound') {$NewDirection = 'Outbound'} else {$NewDirection = 'Inbound'}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -Direction $NewDirection `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different RemotePort' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -RemotePort 9999 `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different LocalPort' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -LocalPort 9999 `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different Protocol' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                if ($rule.Protocol -eq 'TCP') {$NewProtocol = 'UDP'} else {$NewProtocol = 'TCP'}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -Protocol $NewProtocol `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different Description' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -Description 'Different' `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different Program' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -Program 'Different' `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+        Context 'Ensure is Present and the Firewall Does Exist but has different Service' {
+            It "should call expected mocks on firewall rule $($rule.Name)" {
+                Mock Set-NetFirewallRule
+                Mock Test-RuleProperties {return $false}
+                $result = Set-TargetResource `
+                    -Name $rule.Name `
+                    -Service 'Different' `
+                    -Ensure 'Present'
+
+                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Test-RuleProperties -Exactly 1
+            }
+        }
+
+
         Context 'Ensure is Present and the Firewall Does Exist and is the same' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
@@ -285,7 +394,7 @@ InModuleScope $DSCResourceName {
             LocalPort = $Properties.PortFilters.LocalPort
             Protocol = $Properties.PortFilters.Protocol
             Description = $FirewallRule.Description
-            ApplicationPath = $Properties.ApplicationFilters.Program
+            Program = $Properties.ApplicationFilters.Program
             Service = $Properties.ServiceFilters.Service
         }
 
@@ -374,7 +483,7 @@ InModuleScope $DSCResourceName {
         }
         Context 'testing with a rule with a different application path' {
             $CompareRule = $Splat.Clone()
-            $CompareRule.ApplicationPath = 'Different'
+            $CompareRule.Program = 'Different'
             It 'should return False' {
                 $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                 $Result | Should be $False

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -191,7 +191,7 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Get-FirewallRule -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different DisplayName' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different DisplayName' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
@@ -204,7 +204,7 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different DisplayGroup' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different DisplayGroup' {
             It "should throw a CantChangeDisplayGroupError exception on rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
@@ -226,37 +226,57 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different Enabled' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different Enabled' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
+                if( $rule.Enabled -eq 'True' ) {
+                    $NewEnabled = 'False'
+                }
+                else
+                {
+                    $NewEnabled = 'True'
+                }                
                 $result = Set-TargetResource `
                     -Name $rule.Name `
-                    -Enabled 'False' `
+                    -Enabled $NewEnabled `
                     -Ensure 'Present'
 
                 Assert-MockCalled Set-NetFirewallRule -Exactly 1
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different Action' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different Action' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
+                if ( $rule.Action -eq 'Allow') {
+                    $NewAction = 'Block'
+                }
+                else
+                {
+                    $NewAction = 'Allow'
+                }
                 $result = Set-TargetResource `
                     -Name $rule.Name `
-                    -Action 'Allow' `
+                    -Action $NewAction `
                     -Ensure 'Present'
 
                 Assert-MockCalled Set-NetFirewallRule -Exactly 1
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different Profile' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different Profile' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
-                if ($rule.Profile -ccontains 'Domain') {$NewProfile = @('Public','Private')} else {$NewProfile = @('Domain','Public')}
+                if ( $rule.Profile -ccontains 'Domain') {
+                    $NewProfile = @('Public','Private')
+                }
+                else
+                { 
+                    $NewProfile = @('Domain','Public')
+                }
                 $result = Set-TargetResource `
                     -Name $rule.Name `
                     -Profile $NewProfile `
@@ -266,11 +286,17 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different Direction' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different Direction' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
-                if ($rule.Direction -eq 'Inbound') {$NewDirection = 'Outbound'} else {$NewDirection = 'Inbound'}
+                if ( $rule.Direction -eq 'Inbound') { 
+                    $NewDirection = 'Outbound'
+                }
+                    else
+                {
+                    $NewDirection = 'Inbound'
+                }
                 $result = Set-TargetResource `
                     -Name $rule.Name `
                     -Direction $NewDirection `
@@ -280,7 +306,7 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different RemotePort' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different RemotePort' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
@@ -293,7 +319,7 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different LocalPort' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different LocalPort' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
@@ -306,11 +332,17 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different Protocol' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different Protocol' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
-                if ($rule.Protocol -eq 'TCP') {$NewProtocol = 'UDP'} else {$NewProtocol = 'TCP'}
+                if ( $rule.Protocol -eq 'TCP') {
+                    $NewProtocol = 'UDP'
+                }
+                else
+                {
+                    $NewProtocol = 'TCP'
+                }
                 $result = Set-TargetResource `
                     -Name $rule.Name `
                     -Protocol $NewProtocol `
@@ -320,7 +352,7 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different Description' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different Description' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
@@ -333,7 +365,7 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different Program' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different Program' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
@@ -346,7 +378,7 @@ InModuleScope $DSCResourceName {
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }
-        Context 'Ensure is Present and the Firewall Does Exist but has different Service' {
+        Context 'Ensure is Present and the Firewall Does Exist but has a different Service' {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
@@ -419,7 +451,13 @@ InModuleScope $DSCResourceName {
         }
         Context 'testing with a rule with a different enabled' {
             $CompareRule = $Splat.Clone()
-            $CompareRule.Enabled = if( $CompareRule.Enabled -eq 'True' ) {'False'} Else {'True'}
+            if( $CompareRule.Enabled -eq 'True' ) {
+                $CompareRule.Enabled = 'False'
+            }
+            else
+            {
+                $CompareRule.Enabled = 'True'
+            }
             It 'should return False' {
                 $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                 $Result | Should be $False
@@ -427,7 +465,13 @@ InModuleScope $DSCResourceName {
         }
         Context 'testing with a rule with a different action' {
             $CompareRule = $Splat.Clone()
-            $CompareRule.Action = if ($CompareRule.Action -eq 'Allow') {'Block'} else {'Allow'}
+            if ($CompareRule.Action -eq 'Allow') {
+                $CompareRule.Action = 'Block'
+            }
+            else
+            {
+                $CompareRule.Action = 'Allow'
+            }
             It 'should return False' {
                 $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                 $Result | Should be $False
@@ -435,7 +479,13 @@ InModuleScope $DSCResourceName {
         }
         Context 'testing with a rule with a different profile' {
             $CompareRule = $Splat.Clone()
-            $CompareRule.Profile = 'Different'
+            if ( $CompareRule.Profile -ccontains 'Domain') {
+                $CompareRule.Profile = @('Public','Private')
+            }
+            else
+            { 
+                $CompareRule.Profile = @('Domain','Public')
+            }
             It 'should return False' {
                 $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                 $Result | Should be $False
@@ -443,7 +493,13 @@ InModuleScope $DSCResourceName {
         }
         Context 'testing with a rule with a different direction' {
             $CompareRule = $Splat.Clone()
-            $CompareRule.Direction = if ($CompareRule.Direction -eq 'Inbound') {'Outbound'} else {'Inbound'}
+            if ($CompareRule.Direction -eq 'Inbound') {
+                $CompareRule.Direction = 'Outbound'
+            }
+            else
+            {
+                $CompareRule.Direction = 'Inbound'
+            }
             It 'should return False' {
                 $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                 $Result | Should be $False
@@ -467,7 +523,13 @@ InModuleScope $DSCResourceName {
         }
         Context 'testing with a rule with a different protocol' {
             $CompareRule = $Splat.Clone()
-            $CompareRule.Protocol = 'Different'
+            if ( $CompareRule.Protocol -eq 'TCP') {
+                $CompareRule.Protocol = 'UDP'
+            }
+            else
+            {
+                $CompareRule.Protocol = 'TCP'
+            }
             It 'should return False' {
                 $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                 $Result | Should be $False

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -208,12 +208,21 @@ InModuleScope $DSCResourceName {
             It "should call expected mocks on firewall rule $($rule.Name)" {
                 Mock Set-NetFirewallRule
                 Mock Test-RuleProperties {return $false}
-                $result = Set-TargetResource `
+
+                $errorId = 'CantChangeDisplayGroupError'
+                $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
+                $errorMessage = $($LocalizedData.CantChangeDisplayGroupError) -f $Name
+                $exception = New-Object -TypeName System.InvalidOperationException `
+                    -ArgumentList $errorMessage
+                $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                    -ArgumentList $exception, $errorId, $errorCategory, $null
+
+                { $result = Set-TargetResource `
                     -Name $rule.Name `
                     -DisplayGroup 'Different' `
-                    -Ensure 'Present'
+                    -Ensure 'Present' } | Should Throw $errorRecord
 
-                Assert-MockCalled Set-NetFirewallRule -Exactly 1
+                Assert-MockCalled Set-NetFirewallRule -Exactly 0
                 Assert-MockCalled Test-RuleProperties -Exactly 1
             }
         }


### PR DESCRIPTION
This PR contains changes discussed in Issue #34. In adding the new pester tests to this resource, it also identified two minor issues (5 and 6) that I have resolved but may require further discussion.

The following things were changed:
1. Additional Pester tests added to check individual changes to the firewall rule properties.
2. Known Invalid Configurations section added to Readme.md.
3. Fix to Set-TargetResource so that if an existing rule is updated with a Known invalid configuration the correct error message will be displayed.
4. Fix to Set-TargetResource so that if DisplayName parameter is set when updating existing rule then error will not be thrown (actually same fix as 3).
5. Setting the ApplicationPath property would always cause an exception to be thrown, because no such parameter exists on the *-NetFirewallRule cmdlets. This parameter has been renamed to Program to match the cmdlets and to prevent the error. I felt that this was the best approach as this parameter could never have been used in the past anyway because it would **always** throw an exception - so I can't see any existing users of the resource are using this prop anyway.
6. Trying to change the DisplayGroup parameter (which actually changes the Group parameter) on an existing rule would throw an exception because it there is actually no way for the Set-NetFirewallRule cmdlet to change the group/display group property. This seems to me to be a limitation of the Cmdlet, so I've logged it on PowerShell connect. I've also noted this as a Known Invalid Config in the Readme.md. The issue is also detected and an appropriate exception is raised with advise to delete and re-create the rule instead. It would be possible to do this in the resource, but IMHO actually would cause more problems than it solves.
