### PR TITLE
Issue 39 - Added Validate Parameter to xDNSServerAddress resource

### DIFF
--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -54,6 +54,7 @@ function Get-TargetResource
             -AddressFamily $AddressFamily).ServerAddresses
         AddressFamily = $AddressFamily
         InterfaceAlias = $InterfaceAlias
+        Validate = $null
     }
 
     $returnValue
@@ -78,7 +79,9 @@ function Set-TargetResource
 
         [Parameter(Mandatory)]
         [ValidateSet('IPv4', 'IPv6')]
-        [String]$AddressFamily
+        [String]$AddressFamily,
+        
+        [Boolean]$Validate = $false
     )
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
@@ -87,6 +90,7 @@ function Set-TargetResource
 
     #Get the current DNS Server Addresses based on the parameters given.
     $PSBoundParameters.Remove('Address')
+    $PSBoundParameters.Remove('Validate')
     $currentAddress = (Get-DnsClientServerAddress @PSBoundParameters `
         -ErrorAction Stop).ServerAddresses
 
@@ -99,11 +103,14 @@ function Set-TargetResource
     if ($addressDifferent)
     {
         # Set the DNS settings as well
-        Set-DnsClientServerAddress `
-            -InterfaceAlias $InterfaceAlias `
-            -ServerAddresses $Address `
-            -Validate `
+        $Splat = @{
+            InterfaceAlias = $InterfaceAlias
+            Address = $Address
+            Validate = $Validate
+        }
+        Set-DnsClientServerAddress @Splat `
             -ErrorAction Stop
+
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
             $($LocalizedData.DNSServersHaveBeenSetCorrectlyMessage)
             ) -join '' )
@@ -136,7 +143,9 @@ function Test-TargetResource
 
         [Parameter(Mandatory)]
         [ValidateSet('IPv4', 'IPv6')]
-        [String]$AddressFamily
+        [String]$AddressFamily,
+        
+        [Boolean]$Validate = $false        
     )
     # Flag to signal whether settings are correct
     [Boolean] $desiredConfigurationMatch = $true

--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -54,7 +54,6 @@ function Get-TargetResource
             -AddressFamily $AddressFamily).ServerAddresses
         AddressFamily = $AddressFamily
         InterfaceAlias = $InterfaceAlias
-        Validate = $null
     }
 
     $returnValue

--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.schema.mof
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.schema.mof
@@ -4,4 +4,5 @@ class MSFT_xDNSServerAddress : OMI_BaseResource
   [Required] string Address[];
   [Key] string InterfaceAlias;
   [Key,Write,ValueMap{"IPv4", "IPv6"},Values{"IPv4", "IPv6"}] string AddressFamily;
+  [Write] boolean Validate;
 };

--- a/Examples/Sample_xDnsServerAddress.ps1
+++ b/Examples/Sample_xDnsServerAddress.ps1
@@ -11,7 +11,9 @@ configuration Sample_xDnsServerAddress
         [string]$InterfaceAlias,
 
         [ValidateSet("IPv4","IPv6")]
-        [string]$AddressFamily = 'IPv4'
+        [string]$AddressFamily = 'IPv4',
+        
+        [Boolean]$Validate
     )
 
     Import-DscResource -Module xNetworking
@@ -23,6 +25,7 @@ configuration Sample_xDnsServerAddress
             Address        = $DnsServerAddress
             InterfaceAlias = $InterfaceAlias
             AddressFamily  = $AddressFamily
+            Validate       = $Validate
         }
     }
 }

--- a/README.md
+++ b/README.md
@@ -27,6 +27,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Address**: The desired DNS Server address(es)
 * **InterfaceAlias**: Alias of the network interface for which the DNS server address is set.
 * **AddressFamily**: IP address family: { IPv4 | IPv6 }
+* **Validate**: Requires that the DNS Server addresses be validated if they are updated. It will cause the resouce to throw a 'A general error occurred that is not covered by a more specific error code.' error if set to True and specified DNS Servers are not accessible. Defaults to False.
 
 ### xDefaultGatewayAddress
 
@@ -67,6 +68,7 @@ This issue has been reported on [Microsoft Connect](https://connect.microsoft.co
 * MSFT_xDNSServerAddress: Change to ensure resource terminates if DNS Server validation fails.
 * MSFT_xFirewall: ApplicationPath Parameter renamed to Program for consistency with Cmdlets.
 * MSFT_xFirewall: Fix to prevent error when DisplayName parameter is set on an existing rule.
+* MSFT_xDNSServerAddress: Added Validate parameter to enable DNS server validation when changing server addresses.
 
 ### 2.4.0.0
 * Added following resources:
@@ -197,7 +199,8 @@ Configuration Sample_xDnsServerAddress
         [Parameter(Mandatory)]
         [string]$InterfaceAlias,
         [ValidateSet("IPv4","IPv6")]
-        [string]$AddressFamily = 'IPv4'
+        [string]$AddressFamily = 'IPv4',
+        [Boolean]$Validate
     )
     Import-DscResource -Module xNetworking
     Node $NodeName
@@ -207,6 +210,7 @@ Configuration Sample_xDnsServerAddress
             Address        = $DnsServerAddress
             InterfaceAlias = $InterfaceAlias
             AddressFamily  = $AddressFamily
+            Validate       = $Validate
         }
     }
 }

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -110,7 +110,8 @@ InModuleScope MSFT_xDNSServerAddress {
                 AddressFamily = 'IPv4'
             }
         }
-        Mock Set-DnsClientServerAddress
+        Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
+        Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
         #endregion
 
         Context 'invoking with single IPv4 Server Address that is the same as current' {
@@ -125,7 +126,8 @@ InModuleScope MSFT_xDNSServerAddress {
             }
             It 'should call all the mocks' {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
-                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
             }
         }
         Context 'invoking with single IPv4 Server Address that is different to current' {
@@ -140,9 +142,27 @@ InModuleScope MSFT_xDNSServerAddress {
             }
             It 'should call all the mocks' {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
-                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
             }
         }
+        Context 'invoking with single IPv4 Server Address that is different to current and validate true' {
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv4'
+                    Validate = $True
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+            }
+        }        
         Context 'invoking with multiple IPv4 Server Addresses that are different to current' {
             It 'should not throw an exception' {
 
@@ -155,7 +175,8 @@ InModuleScope MSFT_xDNSServerAddress {
             }
             It 'should call all the mocks' {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
-                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
             }
         }
 
@@ -168,7 +189,6 @@ InModuleScope MSFT_xDNSServerAddress {
                 AddressFamily = 'IPv4'
             }
         }
-        Mock Set-DnsClientServerAddress
         #endregion
 
         Context 'invoking with multiple IPv4 Server Addresses When there are no address assiged' {
@@ -183,7 +203,8 @@ InModuleScope MSFT_xDNSServerAddress {
             }
             It 'should call all the mocks' {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
-                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
             }
         }
 
@@ -198,7 +219,8 @@ InModuleScope MSFT_xDNSServerAddress {
                 AddressFamily = 'IPv6'
             }
         }
-        Mock Set-DnsClientServerAddress
+        Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
+        Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
         #endregion
 
         Context 'invoking with single IPv6 Server Address that is the same as current' {
@@ -213,7 +235,8 @@ InModuleScope MSFT_xDNSServerAddress {
             }
             It 'should call all the mocks' {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
-                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
             }
         }
         Context 'invoking with single IPv6 Server Address that is different to current' {
@@ -228,7 +251,25 @@ InModuleScope MSFT_xDNSServerAddress {
             }
             It 'should call all the mocks' {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
-                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
+            }
+        }
+        Context 'invoking with single IPv6 Server Address that is different to current and validate true' {
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ethernet'
+                    AddressFamily = 'IPv6'
+                    Validate = $True
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
             }
         }
         Context 'invoking with multiple IPv6 Server Addresses that are different to current' {
@@ -243,7 +284,8 @@ InModuleScope MSFT_xDNSServerAddress {
             }
             It 'should call all the mocks' {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
-                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
             }
         }
 
@@ -256,7 +298,6 @@ InModuleScope MSFT_xDNSServerAddress {
                 AddressFamily = 'IPv6'
             }
         }
-        Mock Set-DnsClientServerAddress
         #endregion
 
         Context 'invoking with multiple IPv6 Server Addresses When there are no address assiged' {
@@ -271,10 +312,10 @@ InModuleScope MSFT_xDNSServerAddress {
             }
             It 'should call all the mocks' {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
-                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
             }
         }
-
     }
 
     #######################################################################################


### PR DESCRIPTION
Changes:
1. Added validate parameter to xDNSServerAddress resource. Defaults to $false.
2. Pester tests for Set-TargetResource updated mocks to detect if validate set or not.
3. Documentation and samples updated.
