### PR TITLE
Remove Group property from Get-TargetResource

### DIFF
--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -71,7 +71,6 @@ function Get-TargetResource
         Name            = $Name
         Ensure          = 'Present'
         DisplayName     = $firewallRule.DisplayName
-        Group           = $firewallRule.Group
         DisplayGroup    = $firewallRule.DisplayGroup
         Enabled         = $firewallRule.Enabled
         Action          = $firewallRule.Action

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -61,11 +61,6 @@ InModuleScope $DSCResourceName {
                 $result.DisplayName.GetType() | Should Be $rule.DisplayName.GetType()
             }
 
-            It 'Should have the correct Group and type' {
-                $result.Group | Should Be $rule.Group
-                $result.Group.GetType() | Should Be $rule.Group.GetType()
-            }
-
             It 'Should have the correct DisplayGroup and type' {
                 $result.DisplayGroup | Should Be $rule.DisplayGroup
                 $result.DisplayGroup.GetType() | Should Be $rule.DisplayGroup.GetType()


### PR DESCRIPTION
This removes the Group property from the Get-TargetResource function because it isn't defined in the schema and it is causing Get-DscConfiguration to fail.

This is in reference to issue [#41](https://github.com/PowerShell/xNetworking/issues/41).