### PR TITLE
Fix for Issue #44 -xFirewall: Modify Set-TargetResource to support both Group/DisplayGroup 

### DIFF
--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.Schema.mof
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.Schema.mof
@@ -3,7 +3,8 @@ class MSFT_xFirewall : OMI_BaseResource
 {
   [Key, Description("Name of the Firewall Rule")] String Name;
   [Write, Description("Localized, user-facing name of the Firewall Rule being created")] String DisplayName;
-  [Write, Description("Name of the Firewall Group where we want to put the Firewall Rules")] string DisplayGroup;
+  [Write, Description("Name of the Firewall Group where we want to put the Firewall Rule")] string Group;
+  [Read, Description("The current value of the Display Group of the Firewall Rule")] string DisplayGroup;
   [Write, Description("Ensure the presence/absence of the resource"), ValueMap{"Present", "Absent"},Values{"Present", "Absent"}] String Ensure;
   [Write, Description("Enable or disable the supplied configuration"), ValueMap{"True", "False"},Values{"True", "False"}] string Enabled;
   [Write, Description("Permit or Block the supplied configuration"), ValueMap{"NotConfigured", "Allow", "Block"},Values{"NotConfigured", "Allow", "Block"}] String Action;

--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -183,7 +183,8 @@ function Set-TargetResource
 
                 # If the Group is being changed the the rule needs to be recreated
                 if ($PSBoundParameters.ContainsKey('Group') `
-                    -and ($Group -ne $FirewallRule.Group)) {
+                    -and ($Group -ne $FirewallRule.Group))
+                {
 
                     Remove-NetFirewallRule -Name $Name
 
@@ -192,17 +193,18 @@ function Set-TargetResource
 
                     # Loop through each possible property and if it is not passed as a parameter
                     # then set the PSBoundParameter property to the exiting rule value.
-                    'DisplayName','Group','Enabled','Action','Profile','Direction', `
-                    'RemotePort','LocalPort','Protocol','Description','Program','Service' `
-                        | Foreach-Object -Process {
-                            if (-not $PSBoundParameters.ContainsKey($_))
-                            {
-                                $PropertyValue = (Invoke-Expression -Command "`$FirewallRule.$_")
-                                if ($PropertyValue) {
-                                    $null = $PSBoundParameters.Add($_,$PropertyValue)
-                                }
+                    $PropList = @('DisplayName','Group','Enabled','Action','Profile','Direction', `
+                    'RemotePort','LocalPort','Protocol','Description','Program','Service')
+
+                    Foreach ($Prop in $PropsList) {
+                        if (-not $PSBoundParameters.ContainsKey($Prop))
+                        {
+                            $PropertyValue = (Invoke-Expression -Command "`$FirewallRule.$Prop")
+                            if ($PropertyValue) {
+                                $null = $PSBoundParameters.Add($Prop,$PropertyValue)
                             }
                         }
+                    }
 
                     New-NetFirewallRule @PSBoundParameters
                 }

--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -198,7 +198,9 @@ function Set-TargetResource
                             if (-not $PSBoundParameters.ContainsKey($_))
                             {
                                 $PropertyValue = (Invoke-Expression -Command "`$FirewallRule.$_")
-                                $null = $PSBoundParameters.Add($_,$PropertyValue)
+                                if ($PropertyValue) {
+                                    $null = $PSBoundParameters.Add($_,$PropertyValue)
+                                }
                             }
                         }
 

--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -25,7 +25,6 @@ TestFirewallRuleReturningMessage=Test Firewall rule with Name '{0}' returning {1
 FirewallRuleNotFoundMessage=No Firewall Rule found with Name '{0}'.
 GetAllPropertiesMessage=Get all the properties and add filter info to rule map.
 RuleNotUniqueError={0} Firewall Rules with the Name '{1}' were found. Only one expected.
-CantChangeDisplayGroupError=The DisplayGroup of an existing Firewall Rule can not be changed. Delete and recreate this rule instead.
 '@
 }
 
@@ -70,6 +69,7 @@ function Get-TargetResource
         Name            = $Name
         Ensure          = 'Present'
         DisplayName     = $firewallRule.DisplayName
+        Group           = $firewallRule.Group
         DisplayGroup    = $firewallRule.DisplayGroup
         Enabled         = $firewallRule.Enabled
         Action          = $firewallRule.Action
@@ -102,7 +102,7 @@ function Set-TargetResource
 
         # Name of the Firewall Group where we want to put the Firewall Rules
         [ValidateNotNullOrEmpty()]
-        [String] $DisplayGroup,
+        [String] $Group,
 
         # Ensure the presence/absence of the resource
         [ValidateSet('Present', 'Absent')]
@@ -152,7 +152,6 @@ function Set-TargetResource
 
     # Remove any parameters not used in Splats
     $null = $PSBoundParameters.Remove('Ensure')
-    $null = $PSBoundParameters.Remove('DisplayGroup')
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
         $($LocalizedData.FindFirewallRuleMessage) -f $Name
@@ -178,34 +177,23 @@ function Set-TargetResource
 
             if (-not (Test-RuleProperties -FirewallRule $firewallRule @PSBoundParameters))
             {
-                # Effectively renaming DisplayGroup to Group
-                if ($DisplayGroup) {
-                    $null = $PSBoundParameters.Add('Group', $DisplayGroup)
-                }
-
                 Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
                     $($LocalizedData.UpdatingExistingFirewallMessage) -f $Name
                     ) -join '')
 
-                # If the DisplayGroup is being changed then the rule
-                # Has to be removed and recreated because that is the
-                # Only way the DisplayGroup can be changed unfortunately.
-                # A change to the set-netfirewallrule has been requested:
-                # https://connect.microsoft.com/PowerShell/feedbackdetail/view/1970765/add-ability-to-change-firewall-displaygroup-in-set-netfirewallrule-cmdlet
+                # If the Group is being changed the the rule needs to be recreated
                 if ($PSBoundParameters.ContainsKey('Group') `
                     -and ($Group -ne $FirewallRule.Group)) {
-                    # Although it is possible to automatically remove and recreate
-                    # this rule, it introduces more problems than it solves.
-                    # So for now this will throw an error with the suggested solution.
-                    $errorId = 'CantChangeDisplayGroupError'
-                    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-                    $errorMessage = $($LocalizedData.CantChangeDisplayGroupError) -f $Name
-                    $exception = New-Object -TypeName System.InvalidOperationException `
-                        -ArgumentList $errorMessage
-                    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                        -ArgumentList $exception, $errorId, $errorCategory, $null
+                    # The group is changed so the rule must be deleted and
+                    # recreated
+                    Remove-NetFirewallRule -Name $Name
 
-                    $PSCmdlet.ThrowTerminatingError($errorRecord)
+                    # Merge the existing rule values into the PSBoundParameters
+                    # so that it can be splatted.
+
+                    # TODO
+
+                    New-NetFirewallRule @PSBoundParameters
                 }
                 else
                 {
@@ -290,7 +278,7 @@ function Test-TargetResource
 
         # Name of the Firewall Group where we want to put the Firewall Rules
         [ValidateNotNullOrEmpty()]
-        [String] $DisplayGroup,
+        [String] $Group,
 
         # Ensure the presence/absence of the resource
         [ValidateSet('Present', 'Absent')]
@@ -395,7 +383,7 @@ function Test-RuleProperties
         [Parameter(Mandatory)]
         $FirewallRule,
         [String] $Name,
-        [String] $DisplayName = $Name,
+        [String] $DisplayName,
         [string] $Group,
         [String] $DisplayGroup,
         [String] $Enabled = 'True',
@@ -418,6 +406,22 @@ function Test-RuleProperties
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
             $($LocalizedData.PropertyNoMatchMessage) -f 'Name',$FirewallRule.Name,$Name
+            ) -join '')
+        $desiredConfigurationMatch = $false
+    }
+
+    if ($DisplayName -and ($FirewallRule.DisplayName -ne $DisplayName))
+    {
+        Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+            $($LocalizedData.PropertyNoMatchMessage) -f 'DisplayName',$FirewallRule.DisplayName,$DisplayName
+            ) -join '')
+        $desiredConfigurationMatch = $false
+    }
+
+    if ($Group -and ($FirewallRule.Group -ne $Group))
+    {
+        Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+            $($LocalizedData.PropertyNoMatchMessage) -f 'Group',$FirewallRule.Group,$Group
             ) -join '')
         $desiredConfigurationMatch = $false
     }

--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -184,14 +184,23 @@ function Set-TargetResource
                 # If the Group is being changed the the rule needs to be recreated
                 if ($PSBoundParameters.ContainsKey('Group') `
                     -and ($Group -ne $FirewallRule.Group)) {
-                    # The group is changed so the rule must be deleted and
-                    # recreated
+
                     Remove-NetFirewallRule -Name $Name
 
                     # Merge the existing rule values into the PSBoundParameters
                     # so that it can be splatted.
 
-                    # TODO
+                    # Loop through each possible property and if it is not passed as a parameter
+                    # then set the PSBoundParameter property to the exiting rule value.
+                    'DisplayName','Group','Enabled','Action','Profile','Direction', `
+                    'RemotePort','LocalPort','Protocol','Description','Program','Service' `
+                        | Foreach-Object -Process {
+                            if (-not $PSBoundParameters.ContainsKey($_))
+                            {
+                                $PropertyValue = (Invoke-Expression -Command "`$FirewallRule.$_")
+                                $null = $PSBoundParameters.Add($_,$PropertyValue)
+                            }
+                        }
 
                     New-NetFirewallRule @PSBoundParameters
                 }

--- a/Examples/Sample_xFirewall_AddFirewallRule.ps1
+++ b/Examples/Sample_xFirewall_AddFirewallRule.ps1
@@ -15,7 +15,7 @@ configuration Sample_xFirewall_AddFirewallRule
         {
             Name                  = "NotePadFirewallRule"
             DisplayName           = "Firewall Rule for Notepad.exe"
-            DisplayGroup          = "NotePad Firewall Rule Group"
+            Group                 = "NotePad Firewall Rule Group"
             Ensure                = "Present"
             Enabled               = "True"
             Profile               = ("Domain", "Private")

--- a/Examples/Sample_xFirewall_AddFirewallRuleToExistingGroup.ps1
+++ b/Examples/Sample_xFirewall_AddFirewallRuleToExistingGroup.ps1
@@ -16,14 +16,14 @@ configuration Sample_xFirewall_AddFirewallRuleToExistingGroup
         {
             Name                  = "MyFirewallRule"
             DisplayName           = "My Firewall Rule"
-            DisplayGroup          = "My Firewall Rule Group"
+            Group                 = "My Firewall Rule Group"
         }
 
         xFirewall Firewall1
         {
             Name                  = "MyFirewallRule1"
             DisplayName           = "My Firewall Rule"
-            DisplayGroup          = "My Firewall Rule Group"
+            Group                 = "My Firewall Rule Group"
             Ensure                = "Present"
             Enabled               = "True"
             Profile               = ("Domain", "Private")

--- a/Examples/Sample_xFirewall_DisableAccessToApplication.ps1
+++ b/Examples/Sample_xFirewall_DisableAccessToApplication.ps1
@@ -16,7 +16,7 @@ configuration Sample_xFirewall_AddFirewallRuleToNewGroup
         {
             Name                  = "NotePadFirewallRule"
             DisplayName           = "Firewall Rule for Notepad.exe"
-            DisplayGroup          = "NotePad Firewall Rule Group"
+            Group                 = "NotePad Firewall Rule Group"
             Ensure                = "Present"
             Description           = "Firewall Rule for Notepad.exe"
             ApplicationPath       = "c:\windows\system32\notepad.exe"

--- a/README.md
+++ b/README.md
@@ -47,8 +47,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### xFirewall
 
 * **Name**: Name of the firewall rule
-* **DisplayName**: Localized, user-facing name of the firewall rule being created .
-* **DisplayGroup**: Name of the firewall group where we want to put the firewall rules.
+* **Group**: Name of the firewall group where we want to put the firewall rule.
 * **Ensure**: Ensure that the firewall rule is Present or Absent.
 * **Enabled**: Enable or Disable the supplied configuration.
 * **Action**: Permit or Block the supplied configuration
@@ -67,9 +66,6 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * The exception 'One of the port keywords is invalid' will be thrown if a rule is created with the LocalPort set to PlayToDiscovery and the Protocol is not set to UDP. This is not an unexpected error, but because the New-NetFirewallRule documentation is incorrect.
 This issue has been reported on [Microsoft Connect](https://connect.microsoft.com/PowerShell/feedbackdetail/view/1974268/new-set-netfirewallrule-cmdlet-localport-parameter-documentation-is-incorrect-for-playtodiscovery)
 
-* The exception 'The DisplayGroup of an existing Firewall Rule can not be changed' will be thrown if a configuration tries to change DisplayGroup property of an existing rule. This is because the Set-NetFirewallRule cmdlet does not support this function. Delete and re-create this rule instead.
-This issue has been reported on [Microsoft Connect](https://connect.microsoft.com/PowerShell/feedbackdetail/view/1970765/add-ability-to-change-firewall-displaygroup-in-set-netfirewallrule-cmdlet)
-
 ## Versions
 
 ### Unreleased Version
@@ -79,6 +75,9 @@ This issue has been reported on [Microsoft Connect](https://connect.microsoft.co
 * MSFT_xFirewall: ApplicationPath Parameter renamed to Program for consistency with Cmdlets.
 * MSFT_xFirewall: Fix to prevent error when DisplayName parameter is set on an existing rule.
 * Added xDnsConnectionSuffix resource to manage connection-specific DNS suffixes.
+* MSFT_xFirewall: Setting a different DisplayName parameter on an existing rule now correctly reports as needs change.
+* MSFT_xFirewall: Changed DisplayGroup parameter to Group for consistency with Cmdlets and reduce confusion.
+* MSFT_xFirewall: Changing the Group of an existing Firewall rule will recreate the Firewall rule rather than change it.
 
 ### 2.4.0.0
 * Added following resources:
@@ -356,14 +355,14 @@ Configuration Add_FirewallRuleToExistingGroup
         {
             Name                  = "MyFirewallRule"
             DisplayName           = "My Firewall Rule"
-            DisplayGroup          = "My Firewall Rule Group"
+            Group          = "My Firewall Rule Group"
         }
 
         xFirewall Firewall1
         {
             Name                  = "MyFirewallRule1"
             DisplayName           = "My Firewall Rule"
-            DisplayGroup          = "My Firewall Rule Group"
+            Group                 = "My Firewall Rule Group"
             Ensure                = "Present"
             Enabled               = "True"
             Profile               = ("Domain", "Private")
@@ -391,7 +390,7 @@ Configuration Disable_AccessToApplication
         {
             Name                  = "NotePadFirewallRule"
             DisplayName           = "Firewall Rule for Notepad.exe"
-            DisplayGroup          = "NotePad Firewall Rule Group"
+            Group                 = "NotePad Firewall Rule Group"
             Ensure                = "Present"
             Action                = 'Blocked'
             Description           = "Firewall Rule for Notepad.exe"
@@ -421,7 +420,7 @@ Configuration Sample_xFirewall
         {
             Name                  = "NotePadFirewallRule"
             DisplayName           = "Firewall Rule for Notepad.exe"
-            DisplayGroup          = "NotePad Firewall Rule Group"
+            Group                 = "NotePad Firewall Rule Group"
             Ensure                = "Present"
             Enabled               = "True"
             Action                = 'Allow'

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This issue has been reported on [Microsoft Connect](https://connect.microsoft.co
 
 ### 2.4.0.0
 * Added following resources:
-  * MSFT_xDefaultGatewayAddress
+    * MSFT_xDefaultGatewayAddress
 * MSFT_xFirewall: Removed code using DisplayGroup to lookup Firewall Rule because it was redundant.
 * MSFT_xFirewall: Set-TargetResource now updates firewall rules instead of recreating them.
 * MSFT_xFirewall: Added message localization support.

--- a/README.md
+++ b/README.md
@@ -356,7 +356,7 @@ Configuration Add_FirewallRuleToExistingGroup
         {
             Name                  = "MyFirewallRule"
             DisplayName           = "My Firewall Rule"
-            Group          = "My Firewall Rule Group"
+            Group                 = "My Firewall Rule Group"
         }
 
         xFirewall Firewall1

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### xFirewall
 
 * **Name**: Name of the firewall rule
+* **DisplayName**: Localized, user-facing name of the firewall rule being created.
 * **Group**: Name of the firewall group where we want to put the firewall rule.
 * **Ensure**: Ensure that the firewall rule is Present or Absent.
 * **Enabled**: Enable or Disable the supplied configuration.

--- a/README.md
+++ b/README.md
@@ -82,7 +82,7 @@ This issue has been reported on [Microsoft Connect](https://connect.microsoft.co
 
 ### 2.4.0.0
 * Added following resources:
-    * MSFT_xDefaultGatewayAddress
+   * MSFT_xDefaultGatewayAddress
 * MSFT_xFirewall: Removed code using DisplayGroup to lookup Firewall Rule because it was redundant.
 * MSFT_xFirewall: Set-TargetResource now updates firewall rules instead of recreating them.
 * MSFT_xFirewall: Added message localization support.

--- a/Tests/Integration/Firewall.ps1
+++ b/Tests/Integration/Firewall.ps1
@@ -5,7 +5,8 @@
 
 $rule = @{
     Name         = 'b8df0af9-d0cc-4080-885b-6ed263aaed67'
-    DisplayGroup = 'b8df0af9-d0cc-4080-885b-6ed263aaed67'
+    DisplayName  = 'b8df0af9-d0cc-4080-885b-6ed263aaed67'
+    Group        = 'b8df0af9-d0cc-4080-885b-6ed263aaed67'
     Ensure       = 'Present'
     Enabled      = 'False'
     Profile      = 'Domain, Private'
@@ -19,7 +20,8 @@ Configuration Firewall {
     node localhost {
        xFirewall Integration_Test {
             Name            = $rule.Name
-            DisplayGroup    = $rule.DisplayGroup
+            DisplayName     = $rule.DisplayName
+            Group           = $rule.Group
             Ensure          = 'Present'
             Enabled         = $rule.Enabled
             Profile         = ($rule.Profile).toString()

--- a/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
@@ -73,7 +73,7 @@ try {
 }
 finally {
     # Restore the Execution Policy
-    if ($rollbackExection)
+    if ($rollbackExecution)
     {
         Set-ExectuionPolicy $executionPolicy
     }

--- a/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
@@ -75,7 +75,7 @@ finally {
     # Restore the Execution Policy
     if ($rollbackExecution)
     {
-        Set-ExectuionPolicy $executionPolicy
+        Set-ExecutionPolicy -ExecutionPolicy $executionPolicy -Force
     }
     
     # Cleanup DSC Configuration

--- a/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
@@ -31,8 +31,12 @@ if (($env:PSModulePath).Split(';') -ccontains $pwd.Path)
 }
 
 # Preserve and set the execution policy so that the DSC MOF can be created
-$OldExecutionPolicy = Get-ExecutionPolicy
-Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force
+$executionPolicy = Get-ExecutionPolicy
+if ($executionPolicy -ne 'Unrestricted')
+{
+    Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force
+    $rollbackExecution = $true
+}
 
 try {
     # Load in the DSC Configuration
@@ -69,8 +73,11 @@ try {
 }
 finally {
     # Restore the Execution Policy
-    Set-ExecutionPolicy -ExecutionPolicy $OldExecutionPolicy -Force
-
+    if ($rollbackExection)
+    {
+        Set-ExectuionPolicy $executionPolicy
+    }
+    
     # Cleanup DSC Configuration
     Remove-NetFirewallRule -Name 'b8df0af9-d0cc-4080-885b-6ed263aaed67'
     Remove-Item -Path $env:Temp\Firewall -Recurse -Force


### PR DESCRIPTION
This resolves issue #44.

It contains changes as per discussion in the Issue:
1. DisplayGroup renamed to Group and all code/documentation/samples/tests referencing it updated.
2. New DisplayGroup parameter added as a READ parameter so that it can be reported via Get-TargetResource.
3. If the Group value is set to a different value for an existing rule the rule will be deleted and recreated.
4. Integration Test code updated to automatically set execution policy (and restore it) so it will run on machines with a more restrictive policy.
5. Fix to ensure that if a resource should only update the DisplayName for an existing rule it will correctly detect that changes are required.

Hopefully this issue has been :hammer: 