### PR TITLE
Fixed Get-TargetResource as it contains mof not defined invalid key in return. (Group)

### DIFF
--- a/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -68,18 +68,17 @@ function Get-TargetResource
     # Populate the properties for get target resource
     return @{
         Name            = $Name
-        Ensure          = 'Present'
         DisplayName     = $firewallRule.DisplayName
-        Group           = $firewallRule.Group
         DisplayGroup    = $firewallRule.DisplayGroup
+        Ensure          = 'Present'
         Enabled         = $firewallRule.Enabled
         Action          = $firewallRule.Action
         Profile         = $firewallRule.Profile.ToString() -replace(' ', '') -split(',')
         Direction       = $firewallRule.Direction
-        Description     = $firewallRule.Description
         RemotePort      = @($properties.PortFilters.RemotePort)
         LocalPort       = @($properties.PortFilters.LocalPort)
         Protocol        = $properties.PortFilters.Protocol
+        Description     = $firewallRule.Description
         ApplicationPath = $properties.ApplicationFilters.Program
         Service         = $properties.ServiceFilters.Service
     }


### PR DESCRIPTION
There are issue with Get-DSConfiguration when using current master ver.2.4.0.
This PR will fix it and return valid result with Get-DSCConfiguation.

Reproduce Procedure
----

You can reproduce issue with following.

```powershell
configuration Sample
{
    Import-DscResource -ModuleName xNetworking

    xFirewall Hoge
    {
        Name = "Test"
        DisplayName = "Test"
        Ensure = "Present"
        Action = "Allow"
        Enabled = $true
        Direction = "Inbound"
        LocalPort = "10101"
        Protocol = "TCP"
        Profile = "Any"
        RemotePort = "Any"
        Description = "hoge"
    }    
}

Sample 
Start-DscConfiguration -Path Sample -Wait -Verbose -Force -Debug
Get-DscConfiguration
Test-DscConfiguration
```

Reason of Error
----

This is due to invalid key ```Group``` included in Get-TargetResource.

PR
----

You have 2 option to fix it.
1. Remove Group from return result.
2. Add Group Key in the mof.

I have choose 1 as it is simple and can be avoid any side effect. Also this PR include "Change Get-TargetResource return Hashtable Order match to mof definition" for readability.

You may find reproduce code will return valid Get-DscConfiguration result after merge this fix.

```
Action          : Allow
ApplicationPath : Any
Description     : hoge
Direction       : Inbound
DisplayGroup    : 
DisplayName     : Test
Enabled         : True
Ensure          : Present
LocalPort       : {10101}
Name            : Test
Profile         : {Any}
Protocol        : TCP
RemotePort      : {Any}
Service         : Any
PSComputerName  : 
```