### PR TITLE
Add Wildcard support for $InterfaceAlias

### DIFF
--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -199,7 +199,7 @@ function Test-ResourceProperty
         [String]$AddressFamily = 'IPv4'
     )
 
-    if ( -not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    if ( -not (Get-NetAdapter | Where-Object -Property Name -Like $InterfaceAlias )) # It doen't need to be unique. As it prove with Get-DnsClientServerAddress.
     {
         $errorId = 'InterfaceNotAvailable'
         $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError


### PR DESCRIPTION
Description
----

There used to be support Wildcard for InterfaceAlis, but degraded with commit https://github.com/PowerShell/xNetworking/commit/89a9d95b611782a1848f7c9a3a66d550ab0a4afa#diff-da1b602b4060c5ac9213c9b402ca75aaR178

This PR add Wildcard support for InterfaceAlias.

There are many cases that user couldn't know or promise interface alias. Something like it is  "Ethernet" or "Ethernet 2" or "Enternet ..." in Cloud Infrastructure. Thus Wildcard support is useful and should better to be supported.

Reproduce Procedure
----

```powershell
configuration Hoge
{
    Import-DSCResource -Module xNetworking
    xDNSServerAddress Test
    {
        Address = "10.0.0.10"
        InterfaceAlias = "Etthernet *"
        AddressFamily = "IPv4"
    }
}

Hoge
Start-DscConfiguration -Verbose -Wait -Path Hoge -Force
Test-DscConfiguration
Get-DscConfiguration
```

It will fail with previous psm1, and success in this PR.

```
Address        : {10.0.0.10}
AddressFamily  : IPv4
InterfaceAlias : Ehternet*
PSComputerName : 
```
