### PR TITLE
Add wild card support for $InterfaceAlias.

### DIFF
--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -168,7 +168,7 @@ function Test-TargetResource
     # Get the current DNS Server Addresses based on the parameters given.
     # Interface Alias may return multiple when passed WildCard (*)
     $interfaceAliases = Get-NetAdapter -Name $InterfaceAlias
-    foreach ($alias in $interfaceAliases.InterfaceAlias)
+    foreach ($alias in $interfaceAliases.Name)
     {
         $currentAddress = (Get-DnsClientServerAddress `
             -InterfaceAlias $alias `

--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -212,7 +212,9 @@ function Test-ResourceProperty
         [String]$AddressFamily = 'IPv4'
     )
 
-    if ( -not (Get-NetAdapter | Where-Object -Property Name -Like $InterfaceAlias )) # -Like means support wildcard for InterfaceAlias. InterfaceAlias doesn't need to be exact name, as uniqueness is proved with Get-DnsClientServerAddress. 
+    # -Like means support wildcard for InterfaceAlias.
+    #InterfaceAlias doesn't need to be exact name, as uniqueness, singularity, is proved with Get-DnsClientServerAddress. 
+    if ( -not (Get-NetAdapter | Where-Object -Property Name -Like $InterfaceAlias))
     {
         $errorId = 'InterfaceNotAvailable'
         $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError

--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -55,8 +55,11 @@ Get the present list of DNS ServerAddress DSC Resource schema variables on the s
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
         $($LocalizedData.GettingDNSServerAddressesMessage)
         ) -join '')
+    
+    # obtain all the interface addresses
+    $dnsClientServerAddresses = Get-NetAdapter -Name $InterfaceAlias `
+    | ForEach-Object { Get-DnsClientServerAddress -InterfaceAlias $_  -AddressFamily $AddressFamily }
 
-    $dnsClientServerAddresses = Get-NetAdapter -Name $InterfaceAlias | ForEach-Object { Get-DnsClientServerAddress -InterfaceAlias $_  -AddressFamily $AddressFamily }
     $returnValue = @{
         Address = $dnsClientServerAddresses.ServerAddresses
         AddressFamily = $AddressFamily

--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -212,7 +212,7 @@ function Test-ResourceProperty
         [String]$AddressFamily = 'IPv4'
     )
 
-    if ( -not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    if ( -not (Get-NetAdapter | Where-Object -Property Name -Like $InterfaceAlias )) # -Like means support wildcard for InterfaceAlias. InterfaceAlias doesn't need to be exact name, as uniqueness is proved with Get-DnsClientServerAddress. 
     {
         $errorId = 'InterfaceNotAvailable'
         $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError

--- a/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -79,7 +79,6 @@ Set Node configuration to desired state.
 .DESCRIPTION
 Set a new Server Address in the current node
 #>
-    [OutputType([Void])]
     [CmdletBinding()]
     param
     (    

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -93,6 +93,40 @@ InModuleScope MSFT_xDNSServerAddress {
             }
         }
 
+        # Test Wildcard IPv4 with multiple interfaces
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = '192.168.0.1'
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv4'
+            }
+        }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias and an IPv4 address, Multiple Interface card' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should return true' {
+
+                $Splat = @{
+                    Address = '192.168.0.1'
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                $Result = Get-TargetResource @Splat
+                $Result.IPAddress | Should Be $Splat.IPAddress
+            }
+        }
+
         # Test IPv6 
 
         #region Mocks
@@ -145,6 +179,39 @@ InModuleScope MSFT_xDNSServerAddress {
             }
         }
 
+        # Test Wildcard IPv6 with multiple interfaces
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = 'fe80:ab04:30F5:002b::1'
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv6'
+            }
+        }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias and an IPv6 address, Multiple Interface card' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should return true' {
+
+                $Splat = @{
+                    Address = 'fe80:ab04:30F5:002b::1'
+                    InterfaceAlias = 'Ethe*'
+                    AddressFamily = 'IPv6'
+                }
+                $Result = Get-TargetResource @Splat
+                $Result.IPAddress | Should Be $Splat.IPAddress
+            }
+        }
     }
 
     #######################################################################################
@@ -358,6 +425,168 @@ InModuleScope MSFT_xDNSServerAddress {
         #endregion
 
         Context 'invoking with Wildcard InterfaceAlias && multiple IPv4 Server Addresses When there are no address assiged' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2','192.168.0.3')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $false }
+            }
+        }
+
+        # Test Wildcard IPv4 with multiple interfaces
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @('192.168.0.1')
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv4'
+            }
+        }
+        Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
+        Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv4 Server Address that is the same as current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('192.168.0.1')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv4 Server Address that is different to current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $false }
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv4 Server Address that is different to current and validate true' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                    Validate = $True
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+            }
+        }        
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && multiple IPv4 Server Addresses that are different to current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2','192.168.0.3')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $false }
+            }
+        }
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @()
+                InterfaceAlias = 'Ethernet'
+                AddressFamily = 'IPv4'
+            }
+        }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && multiple IPv4 Server Addresses When there are no address assiged' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
             It 'should not throw an exception' {
 
                 $Splat = @{
@@ -597,6 +826,155 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $false }
             }
         }
+
+        # Test Wildcard IPv6 with multiple interfac
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @('fe80:ab04:30F5:002b::1')
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv6'
+            }
+        }
+        Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
+        Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv6 Server Address that is the same as current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv6 Server Address that is different to current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $false }
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv6 Server Address that is different to current and validate true' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                    Validate = $True
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && multiple IPv6 Server Addresses that are different to current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $false }
+            }
+        }
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @()
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv6'
+            }
+        }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && multiple IPv6 Server Addresses When there are no address assiged' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should not throw an exception' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::1')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                { Set-TargetResource @Splat } | Should Not Throw
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly $exactly -ParameterFilter { $Validate -eq $false }
+            }
+        }
     }
 
     #######################################################################################
@@ -775,6 +1153,121 @@ InModuleScope MSFT_xDNSServerAddress {
             }
         }
 
+        # Test Wildcard IPv4 with multiple interfaces
+
+        #region Mocks
+        Mock Get-NetAdapter -MockWith { [PSCustomObject]@{ Name = 'Ether*' } }
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @('192.168.0.1')
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv4'
+            }
+        }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv4 Server Address that is the same as current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should return true' {
+
+                $Splat = @{
+                    Address = @('192.168.0.1')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                Test-TargetResource @Splat | Should Be $True
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv4 Server Address that is different to current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && multiple IPv4 Server Addresses that are different to current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2','192.168.0.3')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+            }
+        }
+
+        #region Mocks
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @()
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv4'
+            }
+        }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && multiple IPv4 Server Addresses that are no addresses assigned' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('192.168.0.2','192.168.0.3')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+            }
+        }
+
         # Test IPv6 
 
         #region Mocks
@@ -873,7 +1366,7 @@ InModuleScope MSFT_xDNSServerAddress {
         }
         #endregion
 
-        Context 'invoking with single IPv6 Server Address that is the same as current' {
+        Context 'invoking with Wildcard InterfaceAlias && single IPv6 Server Address that is the same as current' {
             It 'should return true' {
 
                 $Splat = @{
@@ -888,7 +1381,7 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
             }
         }
-        Context 'invoking with single IPv6 Server Address that is different to current' {
+        Context 'invoking with Wildcard InterfaceAlias && single IPv6 Server Address that is different to current' {
             It 'should return false' {
 
                 $Splat = @{
@@ -903,7 +1396,7 @@ InModuleScope MSFT_xDNSServerAddress {
                 Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
             }
         }
-        Context 'invoking with multiple IPv6 Server Addresses that are different to current' {
+        Context 'invoking with Wildcard InterfaceAlias && multiple IPv6 Server Addresses that are different to current' {
             It 'should return false' {
 
                 $Splat = @{
@@ -931,7 +1424,123 @@ InModuleScope MSFT_xDNSServerAddress {
         }
         #endregion
 
-        Context 'invoking with multiple IPv6 Server Addresses that are no addresses assigned' {
+        Context 'invoking with Wildcard InterfaceAlias && multiple IPv6 Server Addresses that are no addresses assigned' {
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+            }
+        }
+
+        # Test Wildcard IPv6 with multiple interfaces
+
+        #region Mocks
+        Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ether*' } }
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @('fe80:ab04:30F5:002b::1')
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv6'
+            }
+        }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv6 Server Address that is the same as current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should return true' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                Test-TargetResource @Splat | Should Be $True
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && single IPv6 Server Address that is different to current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+            }
+        }
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && multiple IPv6 Server Addresses that are different to current' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+            It 'should return false' {
+
+                $Splat = @{
+                    Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                Test-TargetResource @Splat | Should Be $False
+            }
+            It 'should call all the mocks' {
+                $exactly = (Get-NetAdapter -Name 'Ether*' | Measure-Object).Count
+                Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly $exactly
+            }
+        }
+
+        #region Mocks
+        Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ether*' } }
+        Mock Get-DnsClientServerAddress -MockWith {
+
+            [PSCustomObject]@{
+                ServerAddresses = @()
+                InterfaceAlias = 'Ether*'
+                AddressFamily = 'IPv6'
+            }
+        }
+        #endregion
+
+        Context 'invoking with Wildcard InterfaceAlias && Multiple interface && multiple IPv6 Server Addresses that are no addresses assigned' {
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
             It 'should return false' {
 
                 $Splat = @{
@@ -1155,6 +1764,162 @@ InModuleScope MSFT_xDNSServerAddress {
         }
 
         Context 'invoking with valid IPv6 Addresses with Wildcard interface alias' {
+
+            It 'should not throw an error' {
+                $Splat = @{
+                    Address = 'fe80:ab04:30F5:002b::1'
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                { Test-ResourceProperty @Splat } | Should Not Throw
+            }
+        }
+
+        # Wildcard Interface Alias cases with multiple interfaces
+
+        Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ether*' } }
+
+        Context 'invoking with bad Wildcard interface alias && Multiple interface' {
+
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should throw an InterfaceNotAvailable error' {
+                $Splat = @{
+                    Address = '192.168.0.1'
+                    InterfaceAlias = 'NotReal*'
+                    AddressFamily = 'IPv4'
+                }
+                $errorId = 'InterfaceNotAvailable'
+                $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
+                $errorMessage = $($LocalizedData.InterfaceNotAvailableError) -f $Splat.InterfaceAlias
+                $exception = New-Object -TypeName System.InvalidOperationException `
+                    -ArgumentList $errorMessage
+                $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                    -ArgumentList $exception, $errorId, $errorCategory, $null
+
+                { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
+            }
+        }
+
+        Context 'invoking with invalid IP Address with Wildcard interface alias && Multiple interface' {
+
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should throw an AddressFormatError error' {
+                $Splat = @{
+                    Address = 'NotReal'
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                $errorId = 'AddressFormatError'
+                $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                $errorMessage = $($LocalizedData.AddressFormatError) -f $Splat.Address
+                $exception = New-Object -TypeName System.InvalidOperationException `
+                    -ArgumentList $errorMessage
+                $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                    -ArgumentList $exception, $errorId, $errorCategory, $null
+
+                { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
+            }
+        }
+
+        Context 'invoking with IPv4 Address and family mismatch with Wildcard interface alias && Multiple interface' {
+
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should throw an AddressMismatchError error' {
+                $Splat = @{
+                    Address = '192.168.0.1'
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv6'
+                }
+                $errorId = 'AddressMismatchError'
+                $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                $errorMessage = $($LocalizedData.AddressIPv4MismatchError) -f $Splat.Address,$Splat.AddressFamily
+                $exception = New-Object -TypeName System.InvalidOperationException `
+                    -ArgumentList $errorMessage
+                $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                    -ArgumentList $exception, $errorId, $errorCategory, $null
+
+                { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
+            }
+        }
+
+        Context 'invoking with IPv6 Address and family mismatch with Wildcard interface alias && Multiple interface' {
+
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should throw an AddressMismatchError error' {
+                $Splat = @{
+                    Address = 'fe80::'
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                $errorId = 'AddressMismatchError'
+                $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                $errorMessage = $($LocalizedData.AddressIPv6MismatchError) -f $Splat.Address,$Splat.AddressFamily
+                $exception = New-Object -TypeName System.InvalidOperationException `
+                    -ArgumentList $errorMessage
+                $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                    -ArgumentList $exception, $errorId, $errorCategory, $null
+
+                { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
+            }
+        }
+
+        Context 'invoking with valid IPv4 Addresses with Wildcard interface alias && Multiple interface' {
+
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
+
+            It 'should not throw an error' {
+                $Splat = @{
+                    Address = '192.168.0.1'
+                    InterfaceAlias = 'Ether*'
+                    AddressFamily = 'IPv4'
+                }
+                { Test-ResourceProperty @Splat } | Should Not Throw
+            }
+        }
+
+        Context 'invoking with valid IPv6 Addresses with Wildcard interface alias && Multiple interface' {
+
+            # Mock should capsul inside script block scope
+            Mock Get-NetAdapter {
+                return @(
+                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
+                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
+                )
+            }
 
             It 'should not throw an error' {
                 $Splat = @{

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -425,13 +425,6 @@ InModuleScope MSFT_xDNSServerAddress {
         #endregion
 
         Context 'invoking with Wildcard InterfaceAlias && multiple IPv4 Server Addresses When there are no address assiged' {
-            # Mock should capsul inside script block scope
-            Mock Get-NetAdapter {
-                return @(
-                    [PSCustomObject]@{ Name = 'Ethernet 1'; InterfaceAlias = 'Ethernet 1' },
-                    [PSCustomObject]@{ Name = 'Ethernet 2'; InterfaceAlias = 'Ethernet 2' }
-                )
-            }
 
             It 'should not throw an exception' {
 

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -325,7 +325,7 @@ InModuleScope MSFT_xDNSServerAddress {
         # Test IPv4 
 
         #region Mocks
-        Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+        Mock Get-NetAdapter -MockWith { [PSCustomObject]@{ Name = 'Ethernet' } }
         Mock Get-DnsClientServerAddress -MockWith {
 
             [PSCustomObject]@{


### PR DESCRIPTION
Description
----

This is re-create PR from https://github.com/PowerShell/xNetworking/pull/56 to be merged to dev branch.

There used to be support Wildcard for InterfaceAlis, but degraded with commit https://github.com/PowerShell/xNetworking/commit/89a9d95b611782a1848f7c9a3a66d550ab0a4afa#diff-da1b602b4060c5ac9213c9b402ca75aaR178

This PR add Wildcard support for InterfaceAlias.

There are many cases that user couldn't know or promise interface alias. Something like it is  "Ethernet" or "Ethernet 2" or "Enternet n..." in Cloud Infrastructure. Thus Wildcard support is useful and should be better supported.

Reproduce Procedure
----

```powershell
configuration Hoge
{
    Import-DSCResource -Module xNetworking
    xDNSServerAddress Test
    {
        Address = "10.0.0.10"
        InterfaceAlias = "Etthernet*"
        AddressFamily = "IPv4"
    }
}

Hoge
Start-DscConfiguration -Verbose -Wait -Path Hoge -Force
Test-DscConfiguration
Get-DscConfiguration
```

It will fail with previous psm1, but success in this PR as following.

```
Address        : {10.0.0.10}
AddressFamily  : IPv4
InterfaceAlias : Ehternet*
PSComputerName : 
```
