### PR TITLE
Firewall unit test fix

### DIFF
--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -83,6 +83,7 @@ try
             Select-Object -first 1).Name
         $FirewallRule = Get-FirewallRule -Name $FirewallRuleName
         $Properties = Get-FirewallRuleProperty -FirewallRule $FirewallRule
+        # Pull two rules to use testing that error is thrown when this occurs
         $FirewallRules = (Get-NetFirewallRule | `
             Sort-Object Name | `
             Where-Object {$_.DisplayGroup -ne $null} | `

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -62,7 +62,7 @@ if (($env:PSModulePath).Split(';') -ccontains $pwd.Path)
 $executionPolicy = Get-ExecutionPolicy
 if ($executionPolicy -ne 'Unrestricted')
 {
-    #Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force
+    Set-ExecutionPolicy -ExecutionPolicy Unrestricted -Force
     $rollbackExecution = $true
 }
 #endregion


### PR DESCRIPTION
Fixes:
1. Corrects Test-TargetResource and Set-TargetResource tests to ensure that when a parameter is being tested with a different value the value is **actually** different.
2. Ensured that ALL tests now use the same Firewall rule to test with (rather than change halfway through the tests).
3. Added Resource name to the Describe cmdlet so that what is being tested is more easily identifiable (also, makes NUNIT output useful).
4. Added firewall rule name being tested to each 'It' command so that NUINT output is usable - also makes them consistent.