### PR TITLE
Fix $env:PSModule getting set to null

### DIFF
--- a/Templates/unit_template.ps1
+++ b/Templates/unit_template.ps1
@@ -128,7 +128,10 @@ finally
 {
     #region FOOTER
     # Set PSModulePath back to previous settings
-    $env:PSModulePath = $script:tempPath;
+    if ($script:tempPath)
+    {
+        $env:PSModulePath = $script:tempPath
+    }
 
     # Restore the Execution Policy
     if ($rollbackExecution)


### PR DESCRIPTION
In the affected code $env:PSModulePath was being set to null when $script:tempPath did not contain a value.

/cc: @PlagueHO