### PR TITLE
Fix for Issue #32 - Changed xIPAddress so that DHCP status is not checked for IPv6

### DIFF
--- a/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -17,6 +17,7 @@ SubnetMaskDoesNotMatchMessage=Subnet mask does NOT match desired state. Expected
 SubnetMaskMatchMessage=Subnet mask is in desired state.
 DHCPIsNotDisabledMessage=DHCP is NOT disabled.
 DHCPIsAlreadyDisabledMessage=DHCP is already disabled.
+DHCPIsNotTestedMessage=DHCP status is ignored when Address Family is IPv6.
 InterfaceNotAvailableError=Interface "{0}" is not available. Please select a valid interface and try again.
 AddressFormatError=Address "{0}" is not in the correct format. Please correct the Address parameter in the configuration and try again.
 AddressIPv4MismatchError=Address "{0}" is in IPv4 format, which does not match server address family {1}. Please correct either of them in the configuration and try again.
@@ -251,6 +252,12 @@ function Test-TargetResource
                 $($LocalizedData.DHCPIsAlreadyDisabledMessage)
                 ) -join '' )
         }
+    }
+    else
+    {
+        Write-Warning -Message ( @( "$($MyInvocation.MyCommand): "
+            $($LocalizedData.DHCPIsNotTestedMessage)
+            ) -join '' )        
     }
     return $desiredConfigurationMatch
 } # Test-TargetResource

--- a/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -230,21 +230,27 @@ function Test-TargetResource
         }
     }
 
-    # Test if DHCP is already disabled
-    if (-not (Get-NetIPInterface `
-        -InterfaceAlias $InterfaceAlias `
-        -AddressFamily $AddressFamily).Dhcp.ToString().Equals('Disabled'))
+    # If DHCP is still enabled on IPv4 then IP address changes are definitely needed
+    # This test doesn't apply to IPv6 because the DHCP parameter returned on an IPv6
+    # does not mean DHCP is actually active.
+    if ($AddressFamily -eq 'IPv4')
     {
-        Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.DHCPIsNotDisabledMessage)
-            ) -join '' )
-        $desiredConfigurationMatch = $false
-    }
-    else
-    {
-        Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.DHCPIsAlreadyDisabledMessage)
-            ) -join '' )
+        # Test if DHCP is already disabled
+        if (-not (Get-NetIPInterface `
+            -InterfaceAlias $InterfaceAlias `
+            -AddressFamily $AddressFamily).Dhcp.ToString().Equals('Disabled'))
+        {
+            Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+                $($LocalizedData.DHCPIsNotDisabledMessage)
+                ) -join '' )
+            $desiredConfigurationMatch = $false
+        }
+        else
+        {
+            Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+                $($LocalizedData.DHCPIsAlreadyDisabledMessage)
+                ) -join '' )
+        }
     }
     return $desiredConfigurationMatch
 } # Test-TargetResource

--- a/Tests/Unit/MSFT_xIPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xIPAddress.Tests.ps1
@@ -245,7 +245,7 @@ try
                 }
                 It 'should call appropriate mocks' {
                     Assert-MockCalled -commandName Get-NetIPAddress -Exactly 1
-                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 0
                 }
             }
             
@@ -263,7 +263,7 @@ try
                 }
                 It 'should call appropriate mocks' {
                     Assert-MockCalled -commandName Get-NetIPAddress -Exactly 1
-                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 0
                 }
             }
         }


### PR DESCRIPTION
This is a fix for #32.

The change prevents the test for DHCP status to be performed on IPv6 addresses. If this test is allowed then Test-TargetResource will return $false even if the IPv6 address is correctly assigned and set to static. This causes the resource to continuously apply the IPv6 address every time it runs - which can cause intermittent network connectivity issues.

This change actually only wraps the DHCP test code in a check to see if it is IPv4.
