### PR TITLE
Resolve Issue #68 - Added xDHCPClient Resource

### DIFF
--- a/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -1,0 +1,173 @@
+data LocalizedData
+{
+    # culture="en-US"
+    ConvertFrom-StringData -StringData @'
+GettingDHCPClientMessage=Getting the DHCP Client on {1} interface "{0}".
+ApplyingDHCPClientMessage=Applying the DHCP Client on {1} interface "{0}".
+DHCPClientSetStateMessage=DHCP Client was set to the desired state {2} on {1} interface "{0}".
+CheckingDHCPClientMessage=Checking the DHCP Client on {1} interface "{0}".
+DHCPClientDoesNotMatchMessage=DHCP Client is not in the desired state {2} on {1} interface "{0}".
+InterfaceNotAvailableError=Interface "{0}" is not available. Please select a valid interface and try again.
+'@
+}
+
+function Get-TargetResource
+{
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String] $InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('IPv4', 'IPv6')]
+        [String] $AddressFamily,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Enabled', 'Disabled')]
+        [String] $State
+    )
+
+    Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+        $($LocalizedData.GettingDHCPClientMessage) `
+        -f $InterfaceAlias,$AddressFamily `
+        ) -join '')
+
+    Test-ResourceProperty @PSBoundParameters
+    
+    $CurrentDHCPClient = Get-NetIPInterface `
+        -InterfaceAlias $InterfaceAlias `
+        -AddressFamily $AddressFamily
+
+    $returnValue = @{
+        State          = $CurrentDHCPClient.Dhcp
+        AddressFamily  = $AddressFamily
+        InterfaceAlias = $InterfaceAlias
+    }
+
+    $returnValue
+}
+
+function Set-TargetResource
+{
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String] $InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('IPv4', 'IPv6')]
+        [String] $AddressFamily,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Enabled', 'Disabled')]
+        [String] $State
+    )
+
+    Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+        $($LocalizedData.ApplyingDHCPClientMessage) `
+        -f $InterfaceAlias,$AddressFamily `
+        ) -join '')
+
+    Test-ResourceProperty @PSBoundParameters
+    
+    $CurrentDHCPClient = Get-NetIPInterface `
+        -InterfaceAlias $InterfaceAlias `
+        -AddressFamily $AddressFamily
+        
+    # The DHCP Client is in a different state - so change it.
+    if ($CurrentDHCPClient.DHCP -ne $State)
+    {
+        Set-NetIPInterface `
+            -InterfaceAlias $InterfaceAlias `
+            -AddressFamily $AddressFamily `
+            -Dhcp $State `
+            -ErrorAction Stop
+
+        Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+            $($LocalizedData.DHCPClientSetStateMessage) `
+            -f $InterfaceAlias,$AddressFamily,$State `
+            ) -join '' )
+    }
+} # Set-TargetResource
+
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String] $InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('IPv4', 'IPv6')]
+        [String] $AddressFamily,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Enabled', 'Disabled')]
+        [String] $State
+    )
+
+    # Flag to signal whether settings are correct
+    [Boolean] $desiredConfigurationMatch = $true
+
+    Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+        $($LocalizedData.CheckingDHCPClientMessage)
+        ) -join '')
+
+    Test-ResourceProperty @PSBoundParameters
+
+    $CurrentDHCPClient = Get-NetIPInterface `
+        -InterfaceAlias $InterfaceAlias `
+        -AddressFamily $AddressFamily
+        
+    # The DHCP Client is in a different state - so change it.
+    if ($CurrentDHCPClient.DHCP -ne $State)
+    {
+        Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+            $($LocalizedData.DHCPClientDoesNotMatchMessage) `
+            -f $InterfaceAlias,$AddressFamily,$State `
+            ) -join '' )
+        $desiredConfigurationMatch = $false
+    }
+
+    return $desiredConfigurationMatch
+} # Test-TargetResource
+
+function Test-ResourceProperty {
+    # Function will check the interface exists.
+    # If any problems are detected an exception will be thrown.
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String] $InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('IPv4', 'IPv6')]
+        [String] $AddressFamily,
+
+        [Parameter(Mandatory)]
+        [ValidateSet('Enabled', 'Disabled')]
+        [String] $State
+    )
+
+    if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    {
+        $errorId = 'InterfaceNotAvailable'
+        $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
+        $errorMessage = $($LocalizedData.InterfaceNotAvailableError) -f $InterfaceAlias
+        $exception = New-Object -TypeName System.InvalidOperationException `
+            -ArgumentList $errorMessage
+        $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+            -ArgumentList $exception, $errorId, $errorCategory, $null
+
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
+    }
+} # Test-ResourceProperty
+
+Export-ModuleMember -function *-TargetResource

--- a/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -88,6 +88,7 @@ function Set-TargetResource
         $($LocalizedData.DHCPClientSetStateMessage) `
         -f $InterfaceAlias,$AddressFamily,$State `
         ) -join '' )
+        
 } # Set-TargetResource
 
 function Test-TargetResource

--- a/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -78,19 +78,16 @@ function Set-TargetResource
         -AddressFamily $AddressFamily
         
     # The DHCP Client is in a different state - so change it.
-    if ($CurrentDHCPClient.DHCP -ne $State)
-    {
-        Set-NetIPInterface `
-            -InterfaceAlias $InterfaceAlias `
-            -AddressFamily $AddressFamily `
-            -Dhcp $State `
-            -ErrorAction Stop
+    Set-NetIPInterface `
+        -InterfaceAlias $InterfaceAlias `
+        -AddressFamily $AddressFamily `
+        -Dhcp $State `
+        -ErrorAction Stop
 
-        Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-            $($LocalizedData.DHCPClientSetStateMessage) `
-            -f $InterfaceAlias,$AddressFamily,$State `
-            ) -join '' )
-    }
+    Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+        $($LocalizedData.DHCPClientSetStateMessage) `
+        -f $InterfaceAlias,$AddressFamily,$State `
+        ) -join '' )
 } # Set-TargetResource
 
 function Test-TargetResource

--- a/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.schema.mof
+++ b/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.schema.mof
@@ -1,0 +1,7 @@
+[ClassVersion("1.0.0"), FriendlyName("xDHCPClient")]
+class MSFT_xDHCPClient: OMI_BaseResource
+{
+  [Required,ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled"}] string State;
+  [Key] string InterfaceAlias;
+  [Key,Write,ValueMap{"IPv4", "IPv6"},Values{"IPv4", "IPv6"}] string AddressFamily;
+};

--- a/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -230,35 +230,6 @@ function Test-TargetResource
                 ) -join '' )
         }
     }
-
-    # If DHCP is still enabled on IPv4 then IP address changes are definitely needed
-    # This test doesn't apply to IPv6 because the DHCP parameter returned on an IPv6
-    # does not mean DHCP is actually active.
-    if ($AddressFamily -eq 'IPv4')
-    {
-        # Test if DHCP is already disabled
-        if (-not (Get-NetIPInterface `
-            -InterfaceAlias $InterfaceAlias `
-            -AddressFamily $AddressFamily).Dhcp.ToString().Equals('Disabled'))
-        {
-            Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-                $($LocalizedData.DHCPIsNotDisabledMessage)
-                ) -join '' )
-            $desiredConfigurationMatch = $false
-        }
-        else
-        {
-            Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-                $($LocalizedData.DHCPIsAlreadyDisabledMessage)
-                ) -join '' )
-        }
-    }
-    else
-    {
-        Write-Warning -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.DHCPIsNotTestedMessage)
-            ) -join '' )        
-    }
     return $desiredConfigurationMatch
 } # Test-TargetResource
 

--- a/Examples/Sample_xDhcpClient_Enabled.ps1
+++ b/Examples/Sample_xDhcpClient_Enabled.ps1
@@ -1,0 +1,26 @@
+configuration Sample_xDhcpClient_Enabled
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost',
+
+        [Parameter(Mandatory)]
+        [string]$InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateSet("IPv4","IPv6")]
+        [string]$AddressFamily
+    )
+
+    Import-DscResource -Module xDhcpClient
+
+    Node $NodeName
+    {
+        xDhcpClient EnableDhcpClient
+        {
+            State          = 'Enabled'
+            InterfaceAlias = $InterfaceAlias
+            AddressFamily  = $AddressFamily
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -79,6 +79,12 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **IPv4Connectivity**: Specifies the IPv4 Connection Value { Disconnected | NoTraffic | Subnet | LocalNetwork | Internet }
 * **IPv6Connectivity**: Specifies the IPv6 Connection Value { Disconnected | NoTraffic | Subnet | LocalNetwork | Internet }
 
+### xDhcpClient
+
+* **State**: The desired state of the DHCP Client: { Enabled | Disabled }. Mandatory.
+* **InterfaceAlias**: Alias of the network interface for which the DNS server address is set. Mandatory.
+* **AddressFamily**: IP address family: { IPv4 | IPv6 }. Mandatory.
+
 
 ## Known Invalid Configurations
 
@@ -97,11 +103,14 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 ## Versions
 
 ### Unreleased Version
+* Added the following resources:
+    * MSFT_xDhcpClient resource to enable/disable DHCP on individual interfaces.
 * MSFT_*: Unit and Integration tests updated to use DSCResource.Tests\TestHelper.psm1 functions.
 * MSFT_*: Resource Name added to all unit test Desribes.
 * Templates update to use DSCResource.Tests\TestHelper.psm1 functions. 
 * MSFT_xNetConnectionProfile: Integration tests fixed when more than one connection profile present.
 * Changed AppVeyor.yml to use WMF 5 build environment.
+* MSFT_xIPAddress: Removed test for DHCP Status.
 
 ### 2.5.0.0
 * Added the following resources:
@@ -567,7 +576,7 @@ Start-DscConfiguration -Path Sample_xFirewall_AddFirewallRule_AllParameters -Wai
 
 ### Set the NetConnectionProfile to Public
 
-````powershell
+```powershell
 configuration MSFT_xNetConnectionProfile_Config {
     Import-DscResource -ModuleName xNetworking
     node localhost {
@@ -579,4 +588,36 @@ configuration MSFT_xNetConnectionProfile_Config {
         }
     }
 }
-````
+```
+
+### Set the DHCP Client state
+This example would set the DHCP Client State to enabled.
+
+```powershell
+configuration Sample_xDhcpClient_Enabled
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost',
+
+        [Parameter(Mandatory)]
+        [string]$InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateSet("IPv4","IPv6")]
+        [string]$AddressFamily
+    )
+
+    Import-DscResource -Module xDhcpClient
+
+    Node $NodeName
+    {
+        xDhcpClient EnableDhcpClient
+        {
+            State          = 'Enabled'
+            InterfaceAlias = $InterfaceAlias
+            AddressFamily  = $AddressFamily
+        }
+    }
+}
+```

--- a/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
+++ b/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
@@ -116,7 +116,7 @@ try
                     Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
                     Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
                     Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' } -Exactly 0
-                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' } -Exactly 0
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' } -Exactly 1
                 }
             }
 
@@ -129,7 +129,7 @@ try
                 It 'should call appropriate mocks' {
                     Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
                     Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
-                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' } -Exactly 0
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' } -Exactly 1
                     Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' } -Exactly 0
                 }
             }

--- a/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
+++ b/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
@@ -1,0 +1,225 @@
+﻿$Global:DSCModuleName      = 'xNetworking'
+$Global:DSCResourceName    = 'MSFT_xDhcpClient'
+
+#region HEADER
+if ( (-not (Test-Path -Path '.\DSCResource.Tests\')) -or `
+     (-not (Test-Path -Path '.\DSCResource.Tests\TestHelper.psm1')) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
+}
+else
+{
+    & git @('-C',(Join-Path -Path (Get-Location) -ChildPath '\DSCResource.Tests\'),'pull')
+}
+Import-Module .\DSCResource.Tests\TestHelper.psm1 -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit 
+#endregion
+
+# Begin Testing
+try
+{
+
+    #region Pester Tests
+
+    InModuleScope $Global:DSCResourceName {
+
+        # Create the Mock Objects that will be used for running tests
+        $MockNetAdapter = [PSCustomObject] @{
+            Name                    = 'Ethernet'
+        }
+
+        $TestNetIPInterfaceEnabled = [PSObject]@{
+            State                   = 'Enabled'
+            InterfaceAlias          = $MockNetAdapter.Name
+            AddressFamily           = 'IPv4'
+        }
+
+        $TestNetIPInterfaceDisabled = [PSObject]@{
+            State                   = 'Disabled'
+            InterfaceAlias          = $MockNetAdapter.Name
+            AddressFamily           = 'IPv4'
+        }
+
+        $MockNetIPInterfaceEnabled = [PSObject]@{
+            Dhcp                    = $TestNetIPInterfaceEnabled.State
+            InterfaceAlias          = $TestNetIPInterfaceEnabled.Name
+            AddressFamily           = $TestNetIPInterfaceEnabled.AddressFamily
+        }
+
+        $MockNetIPInterfaceDisabled = [PSObject]@{
+            Dhcp                    = $TestNetIPInterfaceDisabled.State
+            InterfaceAlias          = $TestNetIPInterfaceDisabled.Name
+            AddressFamily           = $TestNetIPInterfaceDisabled.AddressFamily
+        }
+
+        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+    
+            Mock Get-NetAdapter -MockWith { $MockNetAdapter }
+            Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceEnabled }
+    
+            Context 'invoking with when DHCP is enabled' {
+                It 'should return DHCP state of enabled' {
+                    $Result = Get-TargetResource @TestNetIPInterfaceEnabled
+                    $Result.State          | Should Be $TestNetIPInterfaceEnabled.State
+                    $Result.InterfaceAlias | Should Be $TestNetIPInterfaceEnabled.InterfaceAlias
+                    $Result.AddressFamily  | Should Be $TestNetIPInterfaceEnabled.AddressFamily
+                }
+                It 'should call all the mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                }                
+            }
+    
+            Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceDisabled }
+    
+            Context 'invoking with when DHCP is disabled' {
+                It 'should return DHCP state of disabled' {
+                    $Result = Get-TargetResource @TestNetIPInterfaceDisabled
+                    $Result.State          | Should Be $TestNetIPInterfaceDisabled.State
+                    $Result.InterfaceAlias | Should Be $TestNetIPInterfaceDisabled.InterfaceAlias
+                    $Result.AddressFamily  | Should Be $TestNetIPInterfaceDisabled.AddressFamily
+                }
+                It 'should call all the mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                }                
+            }
+        }
+    
+        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+    
+            Mock Get-NetAdapter -MockWith { $MockNetAdapter }
+            Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceDisabled }
+            Mock Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' }
+            Mock Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' }
+    
+            Context 'invoking with state enabled but DHCP is currently disabled' {
+                It 'should not throw an exception' {
+                    { Set-TargetResource @TestNetIPInterfaceEnabled } | Should Not Throw
+                }
+                It 'should call appropriate mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' } -Exactly 1
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' } -Exactly 0
+                }
+            }
+
+            Context 'invoking with state disabled and DHCP is currently disabled' {
+                It 'should not throw an exception' {
+                    { Set-TargetResource @TestNetIPInterfaceDisabled } | Should Not Throw
+                }
+                It 'should call appropriate mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' } -Exactly 0
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' } -Exactly 0
+                }
+            }
+
+            Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceEnabled }
+
+            Context 'invoking with state enabled and DHCP is currently enabled' {
+                It 'should not throw an exception' {
+                    { Set-TargetResource @TestNetIPInterfaceEnabled } | Should Not Throw
+                }
+                It 'should call appropriate mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' } -Exactly 0
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' } -Exactly 0
+                }
+            }
+
+            Context 'invoking with state disabled but DHCP is currently enabled' {
+                It 'should not throw an exception' {
+                    { Set-TargetResource @TestNetIPInterfaceDisabled } | Should Not Throw
+                }
+                It 'should call appropriate mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' } -Exactly 0
+                    Assert-MockCalled -commandName Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' } -Exactly 1
+                }
+            }
+        }
+    
+        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+    
+            Mock Get-NetAdapter -MockWith { $MockNetAdapter }
+            Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceDisabled }
+    
+            Context 'invoking with state enabled but DHCP is currently disabled' {
+                It 'should return false' {
+                    Test-TargetResource @TestNetIPInterfaceEnabled | Should Be $False
+                }
+                It 'should call all mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                }
+            }    
+
+            Context 'invoking with state disabled and DHCP is currently disabled' {
+                It 'should return true' {
+                    Test-TargetResource @TestNetIPInterfaceDisabled | Should Be $True
+                }
+                It 'should call all mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                }
+            }    
+
+            Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceEnabled }
+
+            Context 'invoking with state enabled and DHCP is currently enabled' {
+                It 'should return true' {
+                    Test-TargetResource @TestNetIPInterfaceEnabled | Should Be $True
+                }
+                It 'should call all mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                }
+            }    
+
+            Context 'invoking with state disabled but DHCP is currently enabled' {
+                It 'should return false' {
+                    Test-TargetResource @TestNetIPInterfaceDisabled | Should Be $False
+                }
+                It 'should call all mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
+                }
+            }    
+        }
+    
+        Describe "$($Global:DSCResourceName)\Test-ResourceProperty" {
+    
+            Mock Get-NetAdapter
+    
+            Context 'invoking with bad interface alias' {
+    
+                It 'should throw an InterfaceNotAvailable error' {
+                    $errorId = 'InterfaceNotAvailable'
+                    $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
+                    $errorMessage = $($LocalizedData.InterfaceNotAvailableError) -f $TestNetIPInterfaceEnabled.InterfaceAlias
+                    $exception = New-Object -TypeName System.InvalidOperationException `
+                        -ArgumentList $errorMessage
+                    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                        -ArgumentList $exception, $errorId, $errorCategory, $null
+    
+                    { Test-ResourceProperty @TestNetIPInterfaceEnabled } | Should Throw $ErrorRecord
+                }
+            }
+        }
+    } #end InModuleScope $DSCResourceName
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Unit/MSFT_xIPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xIPAddress.Tests.ps1
@@ -135,15 +135,6 @@ try
                     AddressFamily = 'IPv4'
                 }
             }
-    
-            Mock Get-NetIPInterface {
-                [PSCustomObject]@{
-                    InterfaceAlias = 'Ethernet'
-                    InterfaceIndex = 1
-                    AddressFamily = 'IPv4'
-                    Dhcp = 'Disabled'
-                }
-            }
             #endregion
     
             Context 'invoking with invalid IPv4 Address' {
@@ -179,7 +170,6 @@ try
                 }
                 It 'should call appropriate mocks' {
                     Assert-MockCalled -commandName Get-NetIPAddress -Exactly 1
-                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
                 }
             }
             
@@ -196,7 +186,6 @@ try
                 }
                 It 'should call appropriate mocks' {
                     Assert-MockCalled -commandName Get-NetIPAddress -Exactly 1
-                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
                 }
             }
     
@@ -245,7 +234,6 @@ try
                 }
                 It 'should call appropriate mocks' {
                     Assert-MockCalled -commandName Get-NetIPAddress -Exactly 1
-                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 0
                 }
             }
             
@@ -263,7 +251,6 @@ try
                 }
                 It 'should call appropriate mocks' {
                     Assert-MockCalled -commandName Get-NetIPAddress -Exactly 1
-                    Assert-MockCalled -commandName Get-NetIPInterface -Exactly 0
                 }
             }
         }

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@
 os: Unstable
 version: 2.5.{build}.0
 install:
-  - cinst -y pester
+  - cinst -y pester --version 3.3.13
   - git clone https://github.com/PowerShell/DscResource.Tests
   - ps: Push-Location
   - cd DscResource.Tests


### PR DESCRIPTION
This PR adds the xDHCPClient resource that enables DHCP to be enabled/disabled on a per Adapter/AddressFamily basis.

It also removes the test for DHCP status in the xIPAddress resource.

Unit tests are included, but Integration tests aren't because I haven't figured out a way to implement the integration test without disrupting network connectivity.

This should address Issue #32 and Issue #17.
