### PR TITLE
Fixed xDnsConnectionSuffix Get-TargetResource returned hashtable.

### DIFF
--- a/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
+++ b/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
@@ -37,7 +37,7 @@ function Get-TargetResource
     $dnsClient = Get-DnsClient -InterfaceAlias $InterfaceAlias -ErrorAction SilentlyContinue;
     $targetResource = @{
         InterfaceAlias = $dnsClient.InterfaceAlias;
-        DnsSuffix = $dnsClient.ConnectionSpecificSuffix;
+        ConnectionSpecificSuffix = $dnsClient.ConnectionSpecificSuffix;
         RegisterThisConnectionsAddress = $dnsClient.RegisterThisConnectionsAddress;
         UseSuffixWhenRegistering = $dnsClient.UseSuffixWhenRegistering;
     }


### PR DESCRIPTION
The hashtable being returned didn't match schema.mof so Get-DscConfiguration cmdlet would fail.
Updated 'DnsSuffix' to 'ConnectionSpecificSuffix'.