### PR TITLE
Fix typo for xNetBIOS resource name in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Publish**: Specifies the publish setting of an IP route. { No | Yes | Age }. Default: No.
 * **PreferredLifetime**: Specifies a preferred lifetime in seconds of an IP route.
 
-### NetBIOS
+### xNetBIOS
 
 * **InterfaceAlias**: Specifies the alias of a network interface. Mandatory.
 * **Setting**: xNetBIOS setting { Default | Enable | Disable }. Mandatory.


### PR DESCRIPTION
This fixes a typo for the xNetBIOS resource name in README.md. Since this is likely to confuse users, I thought it was worth making a pull request for.