### PR TITLE
Fix xFirewall Profile comparison -Fixes #102

### DIFF
--- a/README.md
+++ b/README.md
@@ -152,6 +152,7 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 * Templates folder removed. Use the test templates in the [Tests.Template folder in the DSCResources repository](https://github.com/PowerShell/DscResources/tree/master/Tests.Template) instead.
 * Added the following resources:
     * MSFT_xHostsFile resource to manage hosts file entries.
+* MSFT_xFirewall: Fix test of Profile parameter status.
 
 ### 2.7.0.0
 

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -621,7 +621,7 @@ try
                 DisplayGroup        = $FirewallRule.DisplayGroup
                 Group               = $FirewallRule.Group
                 Enabled             = $FirewallRule.Enabled
-                Profile             = $FirewallRule.Profile
+                Profile             = $FirewallRule.Profile -split ', '
                 Direction           = $FirewallRule.Direction
                 Action              = $FirewallRule.Action
                 RemotePort          = $Properties.PortFilters.RemotePort


### PR DESCRIPTION
Resolves issue #102.

Caused by xFirewall Profile code expecting Profile parameter returned by Get-NetFirewallRule to be an array. It is actually a comma+space delimited string.

Change causes Profile parameter to be "split" into an array before being compared with the desired profile state.