### PR TITLE
Add Missing Integration Tests - Fixes #72

### DIFF
--- a/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -113,7 +113,8 @@ function Test-TargetResource
     [Boolean] $desiredConfigurationMatch = $true
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-        $($LocalizedData.CheckingDHCPClientMessage)
+        $($LocalizedData.CheckingDHCPClientMessage) `
+        -f $InterfaceAlias,$AddressFamily `
         ) -join '')
 
     Test-ResourceProperty @PSBoundParameters

--- a/README.md
+++ b/README.md
@@ -149,6 +149,13 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 
 ### Unreleased
 
+* MSFT_xDefaultGatewayAddress: Added Integration Tests.
+* MSFT_xDhcpClient: Added Integration Tests.
+* MSFT_xDnsConnectionSuffix: Added Integration Tests.
+* MSFT_xDnsServerAddress: Added Integration Tests.
+* MSFT_xIPAddress: Added Integration Tests.
+* MSFT_xDhcpClient: Fixed logged message in Test-TargetResource.
+
 ### 2.8.0.0
 
 * Templates folder removed. Use the test templates in the [Tests.Template folder in the DSCResources repository](https://github.com/PowerShell/DscResources/tree/master/Tests.Template) instead.

--- a/Tests/Integration/IntegrationHelper.ps1
+++ b/Tests/Integration/IntegrationHelper.ps1
@@ -45,7 +45,7 @@ function New-IntegrationLoopbackAdapter
             -Name $AdapterName `
             -ErrorAction Stop `
             @Splat
-    }
+    } # try
 } # function New-IntegrationLoopbackAdapter
 
 function Remove-IntegrationLoopbackAdapter

--- a/Tests/Integration/IntegrationHelper.ps1
+++ b/Tests/Integration/IntegrationHelper.ps1
@@ -1,0 +1,82 @@
+function New-IntegrationLoopbackAdapter
+{
+    [cmdletbinding()]
+    param (
+        [String]
+        $AdapterName
+    )
+    # Configure Loopback Adapter
+    if ($env:APPVEYOR) {
+        # Running in AppVeyor so force silent install of LoopbackAdapter
+        $Splat = @{ Force = $true }
+    }
+    else
+    {
+        $Splat = @{ Force = $false }
+    }
+
+    $LoopbackAdapterModuleName = 'LoopbackAdapter'
+    $LoopbackAdapterModulePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\$LoopbackAdapterModuleName"
+    $LoopbackAdapterModule = Install-ModuleFromPowerShellGallery `
+        -ModuleName $LoopbackAdapterModuleName `
+        -ModulePath $LoopbackAdapterModulePath `
+        @Splat
+
+    if ($LoopbackAdapterModule) {
+        # Import the module if it is available
+        $LoopbackAdapterModule | Import-Module -Force
+    }
+    else
+    {
+        # Module could not/would not be installed - so warn user that tests will fail.
+        Throw 'LoopbackAdapter Module could not be installed.'
+    }
+
+    try
+    {
+        # Does the loopback adapter already exist?
+        $null = Get-LoopbackAdapter `
+            -Name $AdapterName
+    }
+    catch
+    {
+        # The loopback Adapter does not exist so create it
+        $null = New-LoopbackAdapter `
+            -Name $AdapterName `
+            -ErrorAction Stop `
+            @Splat
+    }
+}
+
+function Remove-IntegrationLoopbackAdapter
+{
+    [cmdletbinding()]
+    param (
+        [String]
+        $AdapterName
+    )
+    if ($env:APPVEYOR) {
+        # Running in AppVeyor so force silent install of LoopbackAdapter
+        $Splat = @{ Force = $true }
+    }
+    else
+    {
+        $Splat = @{ Force = $false }
+    }
+
+    try
+    {
+        # Does the loopback adapter exist?
+        $null = Get-LoopbackAdapter `
+            -Name $AdapterName
+
+        # Remove Loopback Adapter
+        Remove-LoopbackAdapter `
+            -Name $AdapterName `
+            @Splat
+    }
+    catch
+    {
+        # Loopback Adapter does not exist - do nothing
+    }
+}

--- a/Tests/Integration/IntegrationHelper.ps1
+++ b/Tests/Integration/IntegrationHelper.ps1
@@ -13,7 +13,7 @@ function New-IntegrationLoopbackAdapter
     else
     {
         $Splat = @{ Force = $false }
-    }
+    } # if
 
     $LoopbackAdapterModuleName = 'LoopbackAdapter'
     $LoopbackAdapterModulePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\$LoopbackAdapterModuleName"
@@ -30,7 +30,7 @@ function New-IntegrationLoopbackAdapter
     {
         # Module could not/would not be installed - so warn user that tests will fail.
         Throw 'LoopbackAdapter Module could not be installed.'
-    }
+    } # if
 
     try
     {
@@ -46,7 +46,7 @@ function New-IntegrationLoopbackAdapter
             -ErrorAction Stop `
             @Splat
     }
-}
+} # function New-IntegrationLoopbackAdapter
 
 function Remove-IntegrationLoopbackAdapter
 {
@@ -69,14 +69,16 @@ function Remove-IntegrationLoopbackAdapter
         # Does the loopback adapter exist?
         $null = Get-LoopbackAdapter `
             -Name $AdapterName
-
-        # Remove Loopback Adapter
-        Remove-LoopbackAdapter `
-            -Name $AdapterName `
-            @Splat
     }
     catch
     {
         # Loopback Adapter does not exist - do nothing
+        return
     }
-}
+
+    # Remove Loopback Adapter
+    Remove-LoopbackAdapter `
+        -Name $AdapterName `
+        @Splat
+
+} # function Remove-IntegrationLoopbackAdapter

--- a/Tests/Integration/MSFT_xDNSConnectionSuffix.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSConnectionSuffix.Tests.ps1
@@ -1,5 +1,5 @@
 $Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xIPAddress'
+$Global:DSCResourceName    = 'MSFT_xDnsConnectionSuffix'
 
 #region HEADER
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
@@ -51,16 +51,8 @@ try
         }
 
         $null = New-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
+            -Name $TestDnsConnectionSuffix.InterfaceAlias `
             @PSBoundParameters
-
-        # The following two commands prevent an issue occuring in AppVeyor where the new
-        # Loopback adapter is created but not detected by WMI in the DSC resource.
-        $null = New-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Start-Sleep -Seconds 5
 
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
@@ -77,19 +69,15 @@ try
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
-            $current.InterfaceAlias             | Should Be $TestIPAddress.InterfaceAlias
-            $current.AddressFamily              | Should Be $TestIPAddress.AddressFamily
-            $current.IPAddress                  | Should Be $TestIPAddress.IPAddress
-            $current.SubnetMask                 | Should Be $TestIPAddress.SubnetMask
+            $current.InterfaceAlias                 | Should Be $TestDnsConnectionSuffix.InterfaceAlias
+            $current.ConnectionSpecificSuffix       | Should Be $TestDnsConnectionSuffix.ConnectionSpecificSuffix
+            $current.RegisterThisConnectionsAddress | Should Be $TestDnsConnectionSuffix.RegisterThisConnectionsAddress
+            $current.Ensure                         | Should Be $TestDnsConnectionSuffix.Ensure
         }
 
         # Remove Loopback Adapter
         Remove-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Remove-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
+            -Name $TestDnsConnectionSuffix.InterfaceAlias `
             @PSBoundParameters
     }
     #endregion

--- a/Tests/Integration/MSFT_xDNSConnectionSuffix.config.ps1
+++ b/Tests/Integration/MSFT_xDNSConnectionSuffix.config.ps1
@@ -1,5 +1,5 @@
 $TestDnsConnectionSuffix = [PSObject]@{
-    InterfaceAlias                 = 'DnsConnectionSuffixLBA'
+    InterfaceAlias                 = 'xNetworkingLBA'
     ConnectionSpecificSuffix       = 'contoso.com'
     RegisterThisConnectionsAddress = $true
     UseSuffixWhenRegistering       = $false

--- a/Tests/Integration/MSFT_xDNSConnectionSuffix.config.ps1
+++ b/Tests/Integration/MSFT_xDNSConnectionSuffix.config.ps1
@@ -1,0 +1,20 @@
+$TestDnsConnectionSuffix = [PSObject]@{
+    InterfaceAlias                 = 'DnsConnectionSuffixLBA'
+    ConnectionSpecificSuffix       = 'contoso.com'
+    RegisterThisConnectionsAddress = $true
+    UseSuffixWhenRegistering       = $false
+    Ensure                         = 'Present'
+}
+
+configuration MSFT_xDnsConnectionSuffix_Config {
+    Import-DscResource -ModuleName xNetworking
+    node localhost {
+        xDnsConnectionSuffix Integration_Test {
+            InterfaceAlias                 = $TestDnsConnectionSuffix.InterfaceAlias
+            ConnectionSpecificSuffix       = $TestDnsConnectionSuffix.ConnectionSpecificSuffix
+            RegisterThisConnectionsAddress = $TestDnsConnectionSuffix.RegisterThisConnectionsAddress
+            UseSuffixWhenRegistering       = $TestDnsConnectionSuffix.UseSuffixWhenRegistering
+            Ensure                         = $TestDnsConnectionSuffix.Ensure
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
@@ -19,6 +19,10 @@ $TestEnvironment = Initialize-TestEnvironment `
     -TestType Integration 
 #endregion
 
+# Configure Loopback Adapter
+. (Join-Path -Path (Split-Path -Parent $Script:MyInvocation.MyCommand.Path) -ChildPath 'IntegrationHelper.ps1')
+New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
@@ -27,33 +31,6 @@ try
     . $ConfigFile -Verbose -ErrorAction Stop
 
     Describe "$($Global:DSCResourceName)_Integration" {
-        # Configure Loopback Adapter
-        if ($env:APPVEYOR) {
-            # Running in AppVeyor so force silent install of LoopbackAdapter
-            $PSBoundParameters.Force = $true
-        }
-
-        $LoopbackAdapterModuleName = 'LoopbackAdapter'
-        $LoopbackAdapterModulePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\$LoopbackAdapterModuleName"
-        $LoopbackAdapterModule = Install-ModuleFromPowerShellGallery `
-            -ModuleName $LoopbackAdapterModuleName `
-            -ModulePath $LoopbackAdapterModulePath `
-            @PSBoundParameters
-
-        if ($LoopbackAdapterModule) {
-            # Import the module if it is available
-            $LoopbackAdapterModule | Import-Module -Force
-        }
-        else
-        {
-            # Module could not/would not be installed - so warn user that tests will fail.
-            Throw 'LoopbackAdapter Module could not be installed.'
-        }
-
-        $null = New-LoopbackAdapter `
-            -Name $TestDNSServerAddress.InterfaceAlias `
-            @PSBoundParameters
-
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
@@ -73,16 +50,14 @@ try
             $current.AddressFamily              | Should Be $TestDNSServerAddress.AddressFamily
             $current.Address                    | Should Be $TestDNSServerAddress.Address
         }
-
-        # Remove Loopback Adapter
-        Remove-LoopbackAdapter `
-            -Name $TestDNSServerAddress.InterfaceAlias `
-            @PSBoundParameters
     }
     #endregion
 }
 finally
 {
+    # Remove Loopback Adapter
+    Remove-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
     #region FOOTER
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion

--- a/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
@@ -1,5 +1,5 @@
 $Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xIPAddress'
+$Global:DSCResourceName    = 'MSFT_xDNSServerAddress'
 
 #region HEADER
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
@@ -51,16 +51,8 @@ try
         }
 
         $null = New-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
+            -Name $TestDNSServerAddress.InterfaceAlias `
             @PSBoundParameters
-
-        # The following two commands prevent an issue occuring in AppVeyor where the new
-        # Loopback adapter is created but not detected by WMI in the DSC resource.
-        $null = New-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Start-Sleep -Seconds 5
 
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
@@ -77,19 +69,14 @@ try
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
-            $current.InterfaceAlias             | Should Be $TestIPAddress.InterfaceAlias
-            $current.AddressFamily              | Should Be $TestIPAddress.AddressFamily
-            $current.IPAddress                  | Should Be $TestIPAddress.IPAddress
-            $current.SubnetMask                 | Should Be $TestIPAddress.SubnetMask
+            $current.InterfaceAlias             | Should Be $TestDNSServerAddress.InterfaceAlias
+            $current.AddressFamily              | Should Be $TestDNSServerAddress.AddressFamily
+            $current.Address                    | Should Be $TestDNSServerAddress.Address
         }
 
         # Remove Loopback Adapter
         Remove-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Remove-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
+            -Name $TestDNSServerAddress.InterfaceAlias `
             @PSBoundParameters
     }
     #endregion

--- a/Tests/Integration/MSFT_xDNSServerAddress.config.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress.config.ps1
@@ -1,0 +1,18 @@
+$TestDNSServerAddress = [PSObject]@{
+    InterfaceAlias          = 'DNSServerAddressLBA'
+    AddressFamily           = 'IPv4'
+    Address                 = '10.139.17.99'
+    Validate                = $False
+}
+
+configuration MSFT_xDNSServerAddress_Config {
+    Import-DscResource -ModuleName xNetworking
+    node localhost {
+        xDNSServerAddress Integration_Test {
+            InterfaceAlias          = $TestDNSServerAddress.InterfaceAlias
+            AddressFamily           = $TestDNSServerAddress.AddressFamily
+            Address                 = $TestDNSServerAddress.Address
+            Validate                = $TestDNSServerAddress.Validate
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xDNSServerAddress.config.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress.config.ps1
@@ -1,5 +1,5 @@
 $TestDNSServerAddress = [PSObject]@{
-    InterfaceAlias          = 'DNSServerAddressLBA'
+    InterfaceAlias          = 'xNetworkingLBA'
     AddressFamily           = 'IPv4'
     Address                 = '10.139.17.99'
     Validate                = $False

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -19,6 +19,10 @@ $TestEnvironment = Initialize-TestEnvironment `
     -TestType Integration 
 #endregion
 
+# Configure Loopback Adapter
+. (Join-Path -Path (Split-Path -Parent $Script:MyInvocation.MyCommand.Path) -ChildPath 'IntegrationHelper.ps1')
+New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
@@ -27,33 +31,6 @@ try
     . $ConfigFile -Verbose -ErrorAction Stop
 
     Describe "$($Global:DSCResourceName)_Integration" {
-        # Configure Loopback Adapter
-        if ($env:APPVEYOR) {
-            # Running in AppVeyor so force silent install of LoopbackAdapter
-            $PSBoundParameters.Force = $true
-        }
-
-        $LoopbackAdapterModuleName = 'LoopbackAdapter'
-        $LoopbackAdapterModulePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\$LoopbackAdapterModuleName"
-        $LoopbackAdapterModule = Install-ModuleFromPowerShellGallery `
-            -ModuleName $LoopbackAdapterModuleName `
-            -ModulePath $LoopbackAdapterModulePath `
-            @PSBoundParameters
-
-        if ($LoopbackAdapterModule) {
-            # Import the module if it is available
-            $LoopbackAdapterModule | Import-Module -Force
-        }
-        else
-        {
-            # Module could not/would not be installed - so warn user that tests will fail.
-            Throw 'LoopbackAdapter Module could not be installed.'
-        }
-
-        $null = New-LoopbackAdapter `
-            -Name $TestDefaultGatewayAddress.InterfaceAlias `
-            @PSBoundParameters
-
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
@@ -73,16 +50,14 @@ try
             $current.AddressFamily            | Should Be $TestDefaultGatewayAddress.AddressFamily
             $current.Address                  | Should Be $TestDefaultGatewayAddress.Address
         }
-
-        # Remove Loopback Adapter
-        Remove-LoopbackAdapter `
-            -Name $TestDefaultGatewayAddress.InterfaceAlias `
-            @PSBoundParameters
     }
     #endregion
 }
 finally
 {
+    # Remove Loopback Adapter
+    Remove-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
     #region FOOTER
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -1,5 +1,5 @@
 $Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xIPAddress'
+$Global:DSCResourceName    = 'MSFT_xDefaultGatewayAddress'
 
 #region HEADER
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
@@ -51,16 +51,8 @@ try
         }
 
         $null = New-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
+            -Name $TestDefaultGatewayAddress.InterfaceAlias `
             @PSBoundParameters
-
-        # The following two commands prevent an issue occuring in AppVeyor where the new
-        # Loopback adapter is created but not detected by WMI in the DSC resource.
-        $null = New-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Start-Sleep -Seconds 5
 
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
@@ -77,19 +69,14 @@ try
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
-            $current.InterfaceAlias             | Should Be $TestIPAddress.InterfaceAlias
-            $current.AddressFamily              | Should Be $TestIPAddress.AddressFamily
-            $current.IPAddress                  | Should Be $TestIPAddress.IPAddress
-            $current.SubnetMask                 | Should Be $TestIPAddress.SubnetMask
+            $current.InterfaceAlias           | Should Be $TestDefaultGatewayAddress.InterfaceAlias
+            $current.AddressFamily            | Should Be $TestDefaultGatewayAddress.AddressFamily
+            $current.Address                  | Should Be $TestDefaultGatewayAddress.Address
         }
 
         # Remove Loopback Adapter
         Remove-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Remove-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
+            -Name $TestDefaultGatewayAddress.InterfaceAlias `
             @PSBoundParameters
     }
     #endregion

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.config.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.config.ps1
@@ -1,5 +1,5 @@
 $TestDefaultGatewayAddress = [PSObject]@{
-    InterfaceAlias          = 'DefaultGatewayAddressLBA'
+    InterfaceAlias          = 'xNetworkingLBA'
     AddressFamily           = 'IPv4'
     Address                 = '10.0.0.0'
 }

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.config.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.config.ps1
@@ -1,0 +1,16 @@
+$TestDefaultGatewayAddress = [PSObject]@{
+    InterfaceAlias          = 'DefaultGatewayAddressLBA'
+    AddressFamily           = 'IPv4'
+    Address                 = '10.0.0.0'
+}
+
+configuration MSFT_xDefaultGatewayAddress_Config {
+    Import-DscResource -ModuleName xNetworking
+    node localhost {
+        xDefaultGatewayAddress Integration_Test {
+            InterfaceAlias          = $TestDefaultGatewayAddress.InterfaceAlias
+            AddressFamily           = $TestDefaultGatewayAddress.AddressFamily
+            Address                 = $TestDefaultGatewayAddress.Address
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xDhcpClient.Tests.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.Tests.ps1
@@ -1,5 +1,5 @@
 $Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xIPAddress'
+$Global:DSCResourceName    = 'MSFT_xDhcpClient'
 
 #region HEADER
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
@@ -51,16 +51,8 @@ try
         }
 
         $null = New-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
+            -Name $TestDhcpClient.InterfaceAlias `
             @PSBoundParameters
-
-        # The following two commands prevent an issue occuring in AppVeyor where the new
-        # Loopback adapter is created but not detected by WMI in the DSC resource.
-        $null = New-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Start-Sleep -Seconds 5
 
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
@@ -77,19 +69,14 @@ try
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
-            $current.InterfaceAlias             | Should Be $TestIPAddress.InterfaceAlias
-            $current.AddressFamily              | Should Be $TestIPAddress.AddressFamily
-            $current.IPAddress                  | Should Be $TestIPAddress.IPAddress
-            $current.SubnetMask                 | Should Be $TestIPAddress.SubnetMask
+            $current.InterfaceAlias           | Should Be $TestDhcpClient.InterfaceAlias
+            $current.AddressFamily            | Should Be $TestDhcpClient.AddressFamily
+            $current.State                    | Should Be $TestDhcpClient.State
         }
 
         # Remove Loopback Adapter
         Remove-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Remove-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
+            -Name $TestDhcpClient.InterfaceAlias `
             @PSBoundParameters
     }
     #endregion

--- a/Tests/Integration/MSFT_xDhcpClient.Tests.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.Tests.ps1
@@ -19,6 +19,10 @@ $TestEnvironment = Initialize-TestEnvironment `
     -TestType Integration 
 #endregion
 
+# Configure Loopback Adapter
+. (Join-Path -Path (Split-Path -Parent $Script:MyInvocation.MyCommand.Path) -ChildPath 'IntegrationHelper.ps1')
+New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
@@ -27,33 +31,6 @@ try
     . $ConfigFile -Verbose -ErrorAction Stop
 
     Describe "$($Global:DSCResourceName)_Integration" {
-        # Configure Loopback Adapter
-        if ($env:APPVEYOR) {
-            # Running in AppVeyor so force silent install of LoopbackAdapter
-            $PSBoundParameters.Force = $true
-        }
-
-        $LoopbackAdapterModuleName = 'LoopbackAdapter'
-        $LoopbackAdapterModulePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\$LoopbackAdapterModuleName"
-        $LoopbackAdapterModule = Install-ModuleFromPowerShellGallery `
-            -ModuleName $LoopbackAdapterModuleName `
-            -ModulePath $LoopbackAdapterModulePath `
-            @PSBoundParameters
-
-        if ($LoopbackAdapterModule) {
-            # Import the module if it is available
-            $LoopbackAdapterModule | Import-Module -Force
-        }
-        else
-        {
-            # Module could not/would not be installed - so warn user that tests will fail.
-            Throw 'LoopbackAdapter Module could not be installed.'
-        }
-
-        $null = New-LoopbackAdapter `
-            -Name $TestDhcpClient.InterfaceAlias `
-            @PSBoundParameters
-
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
@@ -73,16 +50,14 @@ try
             $current.AddressFamily            | Should Be $TestDhcpClient.AddressFamily
             $current.State                    | Should Be $TestDhcpClient.State
         }
-
-        # Remove Loopback Adapter
-        Remove-LoopbackAdapter `
-            -Name $TestDhcpClient.InterfaceAlias `
-            @PSBoundParameters
     }
     #endregion
 }
 finally
 {
+    # Remove Loopback Adapter
+    Remove-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
     #region FOOTER
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion

--- a/Tests/Integration/MSFT_xDhcpClient.config.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.config.ps1
@@ -1,0 +1,16 @@
+$TestDhcpClient = [PSObject]@{
+    InterfaceAlias          = 'DhcpClientLBA'
+    AddressFamily           = 'IPv4'
+    State                   = 'Enabled'
+}
+
+configuration MSFT_xDhcpClient_Config {
+    Import-DscResource -ModuleName xNetworking
+    node localhost {
+        xDhcpClient Integration_Test {
+            InterfaceAlias          = $TestDhcpClient.InterfaceAlias
+            AddressFamily           = $TestDhcpClient.AddressFamily
+            State                   = $TestDhcpClient.State
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xDhcpClient.config.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.config.ps1
@@ -1,5 +1,5 @@
 $TestDhcpClient = [PSObject]@{
-    InterfaceAlias          = 'DhcpClientLBA'
+    InterfaceAlias          = 'xNetworkingLBA'
     AddressFamily           = 'IPv4'
     State                   = 'Enabled'
 }

--- a/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
@@ -1,0 +1,68 @@
+$Global:DSCModuleName      = 'xNetworking'
+$Global:DSCResourceName    = 'MSFT_xRoute'
+
+#region HEADER
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+else
+{
+    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
+}
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Integration 
+#endregion
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    #region Integration Tests
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    . $ConfigFile -Verbose -ErrorAction Stop
+
+    Describe "$($Global:DSCResourceName)_Integration" {
+        #region DEFAULT TESTS
+        It 'Should compile without throwing' {
+            {
+                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+
+        It 'Should have set the resource and all the parameters should match' {
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current.InterfaceAlias    | Should Be $TestRoute.InterfaceAlias
+            $current.AddressFamily     | Should Be $TestRoute.AddressFamily
+            $current.DestinationPrefix | Should Be $TestRoute.DestinationPrefix
+            $current.NextHop           | Should Be $TestRoute.NextHop
+            $current.Ensure            | Should Be $TestRoute.Ensure
+            $current.RouteMetric       | Should Be $TestRoute.RouteMetric
+            $current.Publish           | Should Be $TestRoute.Publish
+        }
+
+        Remove-NetRoute `
+            -InterfaceAlias $TestRoute.InterfaceAlias `
+            -AddressFamily $TestRoute.AddressFamily `
+            -DestinationPrefix $TestRoute.DestinationPrefix `
+            -NextHop $TestRoute.NextHop `
+            -Confirm:$false
+    }
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
@@ -50,17 +50,19 @@ try
             Throw 'LoopbackAdapter Module could not be installed.'
         }
 
-        $null = New-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
-            @PSBoundParameters
-
-        # The following two commands prevent an issue occuring in AppVeyor where the new
+        # The following command prevents an issue occuring in AppVeyor where the new
         # Loopback adapter is created but not detected by WMI in the DSC resource.
         $null = New-LoopbackAdapter `
             -Name 'Dummy' `
             @PSBoundParameters
 
-        Start-Sleep -Seconds 5
+        $null = New-LoopbackAdapter `
+            -Name $TestIPAddress.InterfaceAlias `
+            @PSBoundParameters
+
+        # The following command prevents an issue occuring in AppVeyor where the new
+        # Loopback adapter is created but not detected by WMI in the DSC resource.
+        Start-Sleep -Seconds 10
 
         #region DEFAULT TESTS
         It 'Should compile without throwing' {

--- a/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
@@ -23,10 +23,6 @@ $TestEnvironment = Initialize-TestEnvironment `
 . (Join-Path -Path (Split-Path -Parent $Script:MyInvocation.MyCommand.Path) -ChildPath 'IntegrationHelper.ps1')
 New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
 
-# The following command prevents an issue occuring in AppVeyor where the new
-# Loopback adapter is created but not detected by WMI in the DSC resource.
-# Start-Sleep -Seconds 10
-
 # Using try/finally to always cleanup even if something awful happens.
 try
 {

--- a/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
@@ -19,6 +19,14 @@ $TestEnvironment = Initialize-TestEnvironment `
     -TestType Integration 
 #endregion
 
+# Configure Loopback Adapter
+. (Join-Path -Path (Split-Path -Parent $Script:MyInvocation.MyCommand.Path) -ChildPath 'IntegrationHelper.ps1')
+New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
+# The following command prevents an issue occuring in AppVeyor where the new
+# Loopback adapter is created but not detected by WMI in the DSC resource.
+# Start-Sleep -Seconds 10
+
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
@@ -27,43 +35,6 @@ try
     . $ConfigFile -Verbose -ErrorAction Stop
 
     Describe "$($Global:DSCResourceName)_Integration" {
-        # Configure Loopback Adapter
-        if ($env:APPVEYOR) {
-            # Running in AppVeyor so force silent install of LoopbackAdapter
-            $PSBoundParameters.Force = $true
-        }
-
-        $LoopbackAdapterModuleName = 'LoopbackAdapter'
-        $LoopbackAdapterModulePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\$LoopbackAdapterModuleName"
-        $LoopbackAdapterModule = Install-ModuleFromPowerShellGallery `
-            -ModuleName $LoopbackAdapterModuleName `
-            -ModulePath $LoopbackAdapterModulePath `
-            @PSBoundParameters
-
-        if ($LoopbackAdapterModule) {
-            # Import the module if it is available
-            $LoopbackAdapterModule | Import-Module -Force
-        }
-        else
-        {
-            # Module could not/would not be installed - so warn user that tests will fail.
-            Throw 'LoopbackAdapter Module could not be installed.'
-        }
-
-        # The following command prevents an issue occuring in AppVeyor where the new
-        # Loopback adapter is created but not detected by WMI in the DSC resource.
-        $null = New-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        $null = New-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
-            @PSBoundParameters
-
-        # The following command prevents an issue occuring in AppVeyor where the new
-        # Loopback adapter is created but not detected by WMI in the DSC resource.
-        Start-Sleep -Seconds 10
-
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
@@ -84,20 +55,14 @@ try
             $current.IPAddress                  | Should Be $TestIPAddress.IPAddress
             $current.SubnetMask                 | Should Be $TestIPAddress.SubnetMask
         }
-
-        # Remove Loopback Adapter
-        Remove-LoopbackAdapter `
-            -Name 'Dummy' `
-            @PSBoundParameters
-
-        Remove-LoopbackAdapter `
-            -Name $TestIPAddress.InterfaceAlias `
-            @PSBoundParameters
     }
     #endregion
 }
 finally
 {
+    # Remove Loopback Adapter
+    Remove-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
     #region FOOTER
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion

--- a/Tests/Integration/MSFT_xIPAddress.config.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.config.ps1
@@ -1,0 +1,26 @@
+$TestRoute = [PSObject]@{
+    InterfaceAlias          = (Get-NetAdapter -Physical | Select-Object -First 1).Name
+    AddressFamily           = 'IPv4'
+    DestinationPrefix       = '10.0.0.0/8'
+    NextHop                 = '10.0.1.0'
+    Ensure                  = 'Present'
+    RouteMetric             = 200
+    Publish                 = 'No'
+}
+
+$route = Get-NetRoute | Select-Object -First 1
+
+configuration MSFT_xRoute_Config {
+    Import-DscResource -ModuleName xNetworking
+    node localhost {
+        xRoute Integration_Test {
+            InterfaceAlias          = $TestRoute.InterfaceAlias
+            AddressFamily           = $TestRoute.AddressFamily
+            DestinationPrefix       = $TestRoute.DestinationPrefix
+            NextHop                 = $TestRoute.NextHop
+            Ensure                  = $TestRoute.Ensure
+            RouteMetric             = $TestRoute.RouteMetric
+            Publish                 = $TestRoute.Publish
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xIPAddress.config.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.config.ps1
@@ -1,26 +1,18 @@
-$TestRoute = [PSObject]@{
-    InterfaceAlias          = (Get-NetAdapter -Physical | Select-Object -First 1).Name
+$TestIPAddress = [PSObject]@{
+    InterfaceAlias          = 'IPAddressLBA'
     AddressFamily           = 'IPv4'
-    DestinationPrefix       = '10.0.0.0/8'
-    NextHop                 = '10.0.1.0'
-    Ensure                  = 'Present'
-    RouteMetric             = 200
-    Publish                 = 'No'
+    IPAddress               = '10.11.12.13'
+    SubnetMask              = 16
 }
 
-$route = Get-NetRoute | Select-Object -First 1
-
-configuration MSFT_xRoute_Config {
+configuration MSFT_xIPAddress_Config {
     Import-DscResource -ModuleName xNetworking
     node localhost {
-        xRoute Integration_Test {
-            InterfaceAlias          = $TestRoute.InterfaceAlias
-            AddressFamily           = $TestRoute.AddressFamily
-            DestinationPrefix       = $TestRoute.DestinationPrefix
-            NextHop                 = $TestRoute.NextHop
-            Ensure                  = $TestRoute.Ensure
-            RouteMetric             = $TestRoute.RouteMetric
-            Publish                 = $TestRoute.Publish
+        xIPAddress Integration_Test {
+            InterfaceAlias          = $TestIPAddress.InterfaceAlias
+            AddressFamily           = $TestIPAddress.AddressFamily
+            IPAddress               = $TestIPAddress.IPAddress
+            SubnetMask              = $TestIPAddress.SubnetMask
         }
     }
 }

--- a/Tests/Integration/MSFT_xIPAddress.config.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.config.ps1
@@ -1,5 +1,5 @@
 $TestIPAddress = [PSObject]@{
-    InterfaceAlias          = 'IPAddressLBA'
+    InterfaceAlias          = 'xNetworkingLBA'
     AddressFamily           = 'IPv4'
     IPAddress               = '10.11.12.13'
     SubnetMask              = 16


### PR DESCRIPTION
- Fixes #72 
- Fixes #90 

Contains the following changes:

* MSFT_xDefaultGatewayAddress: Added Integration Tests.
* MSFT_xDhcpClient: Added Integration Tests.
* MSFT_xDnsConnectionSuffix: Added Integration Tests.
* MSFT_xDnsServerAddress: Added Integration Tests.
* MSFT_xIPAddress: Added Integration Tests.
* MSFT_xDhcpClient: Fixed logged message in Test-TargetResource.

These integration tests require the use of the ```LoopbackAdapter``` module from the PowerShell Gallery.
The Integration tests use the ```Install-ModuleFromPowerShellGallery``` function from the DSCResource.Test repo to install the ```LoopbackAdapter``` module.
The ```LoopbackAdapter``` module will download and install Chocolatey (if not installed) and Chocolatey will be used to download the [DevCon.Portable package](https://chocolatey.org/packages/devcon.portable) (DevCon is an Microsoft Application that allows command line installation of devices - it is available in the WDK).

- If the Integration tests are run on a non-AppVeyor machine then the user will be asked to confirm installation of any of these items, with failure of any of these items causing the tests to fail.
- If the Integration tests are run on an AppVeyor machine then the confirmations are suppressed and all required packages downloaded automatically.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/108)
<!-- Reviewable:end -->
