### PR TITLE
Add xNetAdapterBinding Resource - Fixes #116

### DIFF
--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -79,9 +79,12 @@ function Set-TargetResource
 
     $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
 
+    # Remove the EnsureEnabled so we can splat
+    $null = $PSBoundParameters.Remove('EnsureEnabled')
+
     if ($EnsureEnabled -eq 'Enabled')
     {
-        $CurrentNetAdapterBinding | Enable-NetAdapterBinding
+        Enable-NetAdapterBinding @PSBoundParameters
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
             $($LocalizedData.NetAdapterBindingEnabledMessage -f `
                 $InterfaceAlias,$ComponentId)
@@ -89,7 +92,7 @@ function Set-TargetResource
     }
     else
     {
-        $CurrentNetAdapterBinding | Disable-NetAdapterBinding
+        Disable-NetAdapterBinding @PSBoundParameters
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
             $($LocalizedData.NetAdapterBindingDisabledMessage -f `
                 $InterfaceAlias,$ComponentId)
@@ -114,9 +117,6 @@ function Test-TargetResource
         [String]$EnsureEnabled = 'Enabled'
     )
 
-    # Flag to signal whether settings are correct
-    [Boolean] $desiredConfigurationMatch = $true
-
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
         $($LocalizedData.CheckingNetAdapterBindingMessage -f `
             $InterfaceAlias,$ComponentId)
@@ -140,7 +140,7 @@ function Test-TargetResource
             $($LocalizedData.NetAdapterBindingDoesNotMatchMessage -f `
                 $InterfaceAlias,$ComponentId,$EnsureEnabled,$CurrentEnabled)
             ) -join '' )
-        $desiredConfigurationMatch = $false
+        return $false
     }
     else
     {
@@ -148,8 +148,8 @@ function Test-TargetResource
             $($LocalizedData.NetAdapterBindingMatchMessage -f `
                 $InterfaceAlias,$ComponentId)
             ) -join '' )
+        return $true
     } # if
-    return $desiredConfigurationMatch
 } # Test-TargetResource
 
 function Get-Binding {
@@ -190,6 +190,6 @@ function Get-Binding {
         -ErrorAction Stop
 
     return $Binding
-} # Test-ResourceProperty
+} # Get-Binding
 
 Export-ModuleMember -function *-TargetResource

--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -1,0 +1,195 @@
+data LocalizedData
+{
+    # culture="en-US"
+    ConvertFrom-StringData -StringData @'
+GettingNetAdapterBindingMessage=Getting the '{0}' Inerface '{1}' Binding.
+ApplyingNetAdapterBindingMessage=Applying the '{0}' Inerface '{1}' Binding.
+NetAdapterBindingEnabledMessage='{0}' Inerface '{1}' Binding was Enabled.
+NetAdapterBindingDisabledMessage='{0}' Inerface '{1}' Binding was Disabled.
+CheckingNetAdapterBindingMessage=Checking the '{0}' Inerface '{1}' Binding.
+NetAdapterBindingDoesNotMatchMessage='{0}' Inerface '{1}' Binding does NOT match desired state. Expected {2}, actual {3}.
+NetAdapterBindingMatchMessage='{0}' Inerface '{1}' Binding is in desired state.
+InterfaceNotAvailableError=Interface '{0}' is not available. Please select a valid interface and try again.
+ComponentIdNotAvailableError=Inerface '{0}' does not have '{1}' bound to it. Please select a bound component Id and try again.
+'@
+}
+
+function Get-TargetResource
+{
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]$InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]$ComponentId,
+
+        [ValidateSet('Enabled', 'Disabled')]
+        [String]$EnsureEnabled = 'Enabled'
+    )
+
+    Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+        $($LocalizedData.GettingNetAdapterBindingMessage -f `
+            $InterfaceAlias,$ComponentId)
+        ) -join '')
+
+    $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
+
+    if ($CurrentNetAdapterBinding.Enabled)
+    {
+        $EnsureEnabled = 'Enabled'
+    }
+    else
+    {
+        $EnsureEnabled = 'Disabled'
+    } # if
+
+    $returnValue = @{
+        InterfaceAlias = $InterfaceAlias
+        ComponentId    = $ComponentId
+        EnsureEnabled  = $EnsureEnabled
+    }
+
+    $returnValue
+} # Get-TargetResource
+
+function Set-TargetResource
+{
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]$InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]$ComponentId,
+
+        [ValidateSet('Enabled', 'Disabled')]
+        [String]$EnsureEnabled = 'Enabled'
+    )
+
+    Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+        $($LocalizedData.ApplyingNetAdapterBindingMessage -f `
+            $InterfaceAlias,$ComponentId)
+        ) -join '')
+
+    $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
+
+    if ($EnsureEnabled -eq 'Enabled')
+    {
+        $CurrentNetAdapterBinding | Enable-NetAdapterBinding
+        Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+            $($LocalizedData.NetAdapterBindingEnabledMessage -f `
+                $InterfaceAlias,$ComponentId)
+            ) -join '' )
+    }
+    else
+    {
+        $CurrentNetAdapterBinding | Disable-NetAdapterBinding
+        Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+            $($LocalizedData.NetAdapterBindingDisabledMessage -f `
+                $InterfaceAlias,$ComponentId)
+            ) -join '' )
+    } # if
+} # Set-TargetResource
+
+function Test-TargetResource
+{
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]$InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]$ComponentId,
+
+        [ValidateSet('Enabled', 'Disabled')]
+        [String]$EnsureEnabled = 'Enabled'
+    )
+
+    # Flag to signal whether settings are correct
+    [Boolean] $desiredConfigurationMatch = $true
+
+    Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+        $($LocalizedData.CheckingNetAdapterBindingMessage -f `
+            $InterfaceAlias,$ComponentId)
+        ) -join '')
+
+    $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
+
+    if ($CurrentNetAdapterBinding.Enabled)
+    {
+        $CurrentEnabled = 'Enabled'
+    }
+    else
+    {
+        $CurrentEnabled = 'Disabled'
+    } # if
+
+    # Test if the binding is in the correct state
+    if ($CurrentEnabled -ne $EnsureEnabled)
+    {
+        Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+            $($LocalizedData.NetAdapterBindingDoesNotMatchMessage -f `
+                $InterfaceAlias,$ComponentId,$EnsureEnabled,$CurrentEnabled)
+            ) -join '' )
+        $desiredConfigurationMatch = $false
+    }
+    else
+    {
+        Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+            $($LocalizedData.NetAdapterBindingMatchMessage -f `
+                $InterfaceAlias,$ComponentId)
+            ) -join '' )
+    } # if
+    return $desiredConfigurationMatch
+} # Test-TargetResource
+
+function Get-Binding {
+    # Function ensures the interface and component Id exists and
+    # returns the Net Adapter binding object.
+    [CmdletBinding()]
+    [OutputType([Microsoft.Management.Infrastructure.CimInstance])]
+    param
+    (
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]$InterfaceAlias,
+
+        [Parameter(Mandatory)]
+        [ValidateNotNullOrEmpty()]
+        [String]$ComponentId,
+
+        [ValidateSet('Enabled', 'Disabled')]
+        [String]$EnsureEnabled = 'Enabled'
+    )
+
+    if (-not (Get-NetAdapter -Name $InterfaceAlias -ErrorAction SilentlyContinue))
+    {
+        $errorId = 'InterfaceNotAvailable'
+        $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
+        $errorMessage = $($LocalizedData.InterfaceNotAvailableError) -f $InterfaceAlias
+        $exception = New-Object -TypeName System.InvalidOperationException `
+            -ArgumentList $errorMessage
+        $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+            -ArgumentList $exception, $errorId, $errorCategory, $null
+
+        $PSCmdlet.ThrowTerminatingError($errorRecord)
+    } # if
+
+    $Binding = Get-NetAdapterBinding `
+        -InterfaceAlias $InterfaceAlias `
+        -ComponentId $ComponentId `
+        -ErrorAction Stop
+
+    return $Binding
+} # Test-ResourceProperty
+
+Export-ModuleMember -function *-TargetResource

--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -28,7 +28,7 @@ function Get-TargetResource
         [String]$ComponentId,
 
         [ValidateSet('Enabled', 'Disabled')]
-        [String]$EnsureEnabled = 'Enabled'
+        [String]$State = 'Enabled'
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -40,17 +40,17 @@ function Get-TargetResource
 
     if ($CurrentNetAdapterBinding.Enabled)
     {
-        $EnsureEnabled = 'Enabled'
+        $State = 'Enabled'
     }
     else
     {
-        $EnsureEnabled = 'Disabled'
+        $State = 'Disabled'
     } # if
 
     $returnValue = @{
         InterfaceAlias = $InterfaceAlias
         ComponentId    = $ComponentId
-        EnsureEnabled  = $EnsureEnabled
+        State          = $State
     }
 
     $returnValue
@@ -69,7 +69,7 @@ function Set-TargetResource
         [String]$ComponentId,
 
         [ValidateSet('Enabled', 'Disabled')]
-        [String]$EnsureEnabled = 'Enabled'
+        [String]$State = 'Enabled'
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -79,10 +79,10 @@ function Set-TargetResource
 
     $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
 
-    # Remove the EnsureEnabled so we can splat
-    $null = $PSBoundParameters.Remove('EnsureEnabled')
+    # Remove the State so we can splat
+    $null = $PSBoundParameters.Remove('State')
 
-    if ($EnsureEnabled -eq 'Enabled')
+    if ($State -eq 'Enabled')
     {
         Enable-NetAdapterBinding @PSBoundParameters
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
@@ -114,7 +114,7 @@ function Test-TargetResource
         [String]$ComponentId,
 
         [ValidateSet('Enabled', 'Disabled')]
-        [String]$EnsureEnabled = 'Enabled'
+        [String]$State = 'Enabled'
     )
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
@@ -134,11 +134,11 @@ function Test-TargetResource
     } # if
 
     # Test if the binding is in the correct state
-    if ($CurrentEnabled -ne $EnsureEnabled)
+    if ($CurrentEnabled -ne $State)
     {
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
             $($LocalizedData.NetAdapterBindingDoesNotMatchMessage -f `
-                $InterfaceAlias,$ComponentId,$EnsureEnabled,$CurrentEnabled)
+                $InterfaceAlias,$ComponentId,$State,$CurrentEnabled)
             ) -join '' )
         return $false
     }
@@ -168,7 +168,7 @@ function Get-Binding {
         [String]$ComponentId,
 
         [ValidateSet('Enabled', 'Disabled')]
-        [String]$EnsureEnabled = 'Enabled'
+        [String]$State = 'Enabled'
     )
 
     if (-not (Get-NetAdapter -Name $InterfaceAlias -ErrorAction SilentlyContinue))

--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.schema.mof
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.schema.mof
@@ -3,5 +3,5 @@ class MSFT_xNetAdapterBinding : OMI_BaseResource
 {
   [Key,Description("Specifies the alias of a network interface.")] string InterfaceAlias;
   [Key,Description("Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip.")] string ComponentId;
-  [Write,Description("Specifies if the component ID for the Interface should be Enabled or Disabled."),ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled"}] string EnsureEnabled;
+  [Write,Description("Specifies if the component ID for the Interface should be Enabled or Disabled."),ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled"}] string State;
 };

--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.schema.mof
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.schema.mof
@@ -1,0 +1,7 @@
+[ClassVersion("1.0.0"), FriendlyName("xNetAdapterBinding")]
+class MSFT_xNetAdapterBinding : OMI_BaseResource
+{
+  [Key,Description("Specifies the alias of a network interface.")] string InterfaceAlias;
+  [Key,Description("Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip.")] string ComponentId;
+  [Write,Description("Specifies if the component ID for the Interface should be Enabled or Disabled."),ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled"}] string EnsureEnabled;
+};

--- a/Examples/Sample_xNetAdapterBinding_DisableIPv6.ps1
+++ b/Examples/Sample_xNetAdapterBinding_DisableIPv6.ps1
@@ -12,8 +12,8 @@ configuration Sample_xNetAdapterBinding_DisableIPv6
         xNetAdapterBinding DisableIPv6
         {
             InterfaceAlias = 'Ethernet'
-            ComponentId = 'ms_tcpip6'
-            EnsureEnabled = 'Disabled'
+            ComponentId    = 'ms_tcpip6'
+            State          = 'Disabled'
         }
     }
 }

--- a/Examples/Sample_xNetAdapterBinding_DisableIPv6.ps1
+++ b/Examples/Sample_xNetAdapterBinding_DisableIPv6.ps1
@@ -1,0 +1,22 @@
+configuration Sample_xNetAdapterBinding_DisableIPv6
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost'
+    )
+
+    Import-DSCResource -ModuleName xNetworking
+
+    Node $NodeName
+    {
+        xNetAdapterBinding DisableIPv6
+        {
+            InterfaceAlias = 'Ethernet'
+            ComponentId = 'ms_tcpip6'
+            EnsureEnabled = 'Disabled'
+        }
+    }
+}
+
+Sample_xNetAdapterBinding_DisableIPv6
+Start-DscConfiguration -Path Sample_xNetAdapterBinding_DisableIPv6 -Wait -Verbose -Force

--- a/README.md
+++ b/README.md
@@ -14,6 +14,7 @@ The **xNetworking** module contains the following resources:
 * **xNetBIOS**
 * **xNetworkTeam**
 * **xHostsFile**
+* **xNetAdapterBinding**
 
 ## Contributing
 Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
@@ -131,6 +132,11 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **IPAddress**: Specifies the IP Address that should be mapped to the host name.
 * **Ensure**: Specifies if the hosts file entry should be created or deleted. { Present | Absent }.
 
+### xNetAdapterBinding
+* **InterfaceAlias**: Specifies the alias of a network interface. Mandatory.
+* **ComponentId**: Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip. Mandatory.
+* **EnsureEnabled**: Specifies if the component ID for the Interface should be Enabled or Disabled. Optional. Defaults to Enabled. { Enabled | Disabled }.
+
 ## Functions
 
 ### Get-xNetworkAdapterName
@@ -175,6 +181,9 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 ## Versions
 
 ### Unreleased
+
+* Added the following resources:
+    * MSFT_xNetAdapterBinding resource to enable/disable network adapter bindings.
 
 ### 2.9.0.0
 
@@ -831,6 +840,34 @@ Sample_xHostsFile_AddEntry
 Start-DscConfiguration -Path Sample_xHostsFile_AddEntry -Wait -Verbose -Force
 ```
 
+### Disable IPv6 on a Network Adapter.
+This example will disable the IPv6 binding on the network adapter 'Ethernet'.
+
+```powershell
+configuration Sample_xNetAdapterBinding_DisableIPv6
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost'
+    )
+
+    Import-DSCResource -ModuleName xNetworking
+
+    Node $NodeName
+    {
+        xNetAdapterBinding DisableIPv6
+        {
+            InterfaceAlias = 'Ethernet'
+            ComponentId = 'ms_tcpip6'
+            EnsureEnabled = 'Disabled'
+        }
+    }
+}
+
+Sample_xNetAdapterBinding_DisableIPv6
+Start-DscConfiguration -Path Sample_xNetAdapterBinding_DisableIPv6 -Wait -Verbose -Force
+```
+
 ### Set a node to use itself as a DNS server
 
 **Note** this sample assumes you have already setup DNS on the machine for brevity.
@@ -874,7 +911,7 @@ Configuration SetDns
             Address        = '127.0.0.1'
             InterfaceAlias = 'Ethernet1'
             AddressFamily  = 'IPv4'
-	        DependsOn = @('[Script]NetAdapterName')
+            DependsOn = @('[Script]NetAdapterName')
         }        
     }    
 }

--- a/README.md
+++ b/README.md
@@ -455,7 +455,7 @@ Configuration Sample_xDefaultGatewayAddress_Set
     {
         xDefaultGatewayAddress SetDefaultGateway
         {
-			Address        = $DefaultGateway
+            Address        = $DefaultGateway
             InterfaceAlias = $InterfaceAlias
             AddressFamily  = $AddressFamily
         }

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 ### xNetAdapterBinding
 * **InterfaceAlias**: Specifies the alias of a network interface. Mandatory.
 * **ComponentId**: Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip. Mandatory.
-* **EnsureEnabled**: Specifies if the component ID for the Interface should be Enabled or Disabled. Optional. Defaults to Enabled. { Enabled | Disabled }.
+* **State**: Specifies if the component ID for the Interface should be Enabled or Disabled. Optional. Defaults to Enabled. { Enabled | Disabled }.
 
 ## Functions
 
@@ -155,7 +155,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Name**: **Mandatory**, the name of the adapter you are trying to find, if an adapter by this name is found, no other parameters are used.
 * **Status**: Optional, with a default of `Up`. The status of the network adapter. { Up | Disconnected | Disabled }
 * **PhysicalMediaType**:   Optional, with no default. The physical media type of the network adapter. Examples: `802.3`
-* Returns `$true` if the named adapter exist, `$false` if it does not. 
+* Returns `$true` if the named adapter exist, `$false` if it does not.
 
 ### Set-xNetworkAdapterName
 * Sets the network adapter name of the adapter found by the parameters specified.  **This is investigational, names and parameters are subject to change**
@@ -859,7 +859,7 @@ configuration Sample_xNetAdapterBinding_DisableIPv6
         {
             InterfaceAlias = 'Ethernet'
             ComponentId = 'ms_tcpip6'
-            EnsureEnabled = 'Disabled'
+            State = 'Disabled'
         }
     }
 }
@@ -892,7 +892,7 @@ Configuration SetDns
         {
             GetScript = {
                 Import-module xNetworking
-                $getResult = Get-xNetworkAdapterName -Name 'Ethernet1' 
+                $getResult = Get-xNetworkAdapterName -Name 'Ethernet1'
                 return @{
                     result = $getResult
                 }
@@ -912,7 +912,7 @@ Configuration SetDns
             InterfaceAlias = 'Ethernet1'
             AddressFamily  = 'IPv4'
             DependsOn = @('[Script]NetAdapterName')
-        }        
-    }    
+        }
+    }
 }
 ```

--- a/Tests/Integration/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterBinding.Tests.ps1
@@ -1,0 +1,62 @@
+$Global:DSCModuleName      = 'xNetworking'
+$Global:DSCResourceName    = 'MSFT_xNetAdapterBinding'
+
+#region HEADER
+# Integration Test Template Version: 1.1.0
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Integration 
+#endregion
+
+# Configure Loopback Adapter
+. (Join-Path -Path (Split-Path -Parent $Script:MyInvocation.MyCommand.Path) -ChildPath 'IntegrationHelper.ps1')
+New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    #region Integration Tests
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    . $ConfigFile -Verbose -ErrorAction Stop
+
+    Describe "$($Global:DSCResourceName)_Integration" {
+        #region DEFAULT TESTS
+        It 'Should compile without throwing' {
+            {
+                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+
+        It 'Should have set the resource and all the parameters should match' {
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current.InterfaceAlias           | Should Be $TestDisableIPv4.InterfaceAlias
+            $current.ComponentId              | Should Be $TestDisableIPv4.ComponentId
+            $current.EnsureEnabled            | Should Be $TestDisableIPv4.EnsureEnabled
+        }
+    }
+    #endregion
+}
+finally
+{
+    # Remove Loopback Adapter
+    Remove-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
+
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterBinding.Tests.ps1
@@ -14,7 +14,7 @@ Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHel
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -TestType Integration
 #endregion
 
 # Configure Loopback Adapter
@@ -46,7 +46,7 @@ try
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
             $current.InterfaceAlias           | Should Be $TestDisableIPv4.InterfaceAlias
             $current.ComponentId              | Should Be $TestDisableIPv4.ComponentId
-            $current.EnsureEnabled            | Should Be $TestDisableIPv4.EnsureEnabled
+            $current.State                    | Should Be $TestDisableIPv4.State
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xNetAdapterBinding.config.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterBinding.config.ps1
@@ -1,7 +1,7 @@
 $TestDisableIPv4 = [PSObject]@{
     InterfaceAlias          = 'xNetworkingLBA'
     ComponentId             = 'ms_tcpip'
-    EnsureEnabled           = 'Disabled'
+    State                   = 'Disabled'
 }
 
 configuration MSFT_xNetAdapterBinding_Config {
@@ -10,7 +10,7 @@ configuration MSFT_xNetAdapterBinding_Config {
         xNetAdapterBinding Integration_Test {
             InterfaceAlias          = $TestDisableIPv4.InterfaceAlias
             ComponentId             = $TestDisableIPv4.ComponentId
-            EnsureEnabled           = $TestDisableIPv4.EnsureEnabled
+            State                   = $TestDisableIPv4.State
         }
     }
 }

--- a/Tests/Integration/MSFT_xNetAdapterBinding.config.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterBinding.config.ps1
@@ -1,0 +1,16 @@
+$TestDisableIPv4 = [PSObject]@{
+    InterfaceAlias          = 'xNetworkingLBA'
+    ComponentId             = 'ms_tcpip'
+    EnsureEnabled           = 'Disabled'
+}
+
+configuration MSFT_xNetAdapterBinding_Config {
+    Import-DscResource -ModuleName xNetworking
+    node localhost {
+        xNetAdapterBinding Integration_Test {
+            InterfaceAlias          = $TestDisableIPv4.InterfaceAlias
+            ComponentId             = $TestDisableIPv4.ComponentId
+            EnsureEnabled           = $TestDisableIPv4.EnsureEnabled
+        }
+    }
+}

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -14,7 +14,7 @@ Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHel
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 #endregion HEADER
 
 # Begin Testing
@@ -76,19 +76,6 @@ try
         }
 
         Describe "$($Global:DSCResourceName)\Set-TargetResource" {
-            function Enable-NetAdapterBinding {
-                param (
-                    [Parameter(ValueFromPipeline=$True)]
-                    $InputObject
-                )
-            }
-            function Disable-NetAdapterBinding {
-                param (
-                    [Parameter(ValueFromPipeline=$True)]
-                    $InputObject
-                )
-            }
-
             Context 'Adapter exists and set binding to Enabled' {
                 Mock Get-Binding -MockWith { $MockBindingDisabled }
                 Mock Enable-NetAdapterBinding

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -24,12 +24,12 @@ try
         $TestBindingEnabled = @{
             InterfaceAlias = 'Ethernet'
             ComponentId = 'ms_tcpip63'
-            EnsureEnabled = 'Enabled'
+            State = 'Enabled'
         }
         $TestBindingDisabled = @{
             InterfaceAlias = 'Ethernet'
             ComponentId = 'ms_tcpip63'
-            EnsureEnabled = 'Disabled'
+            State = 'Disabled'
         }
         $MockAdapter = @{
             InterfaceAlias = 'Ethernet'
@@ -53,7 +53,7 @@ try
                     $Result = Get-TargetResource @TestBindingDisabled
                     $Result.InterfaceAlias | Should Be $TestBindingDisabled.InterfaceAlias
                     $Result.ComponentId | Should Be $TestBindingDisabled.ComponentId
-                    $Result.EnsureEnabled | Should Be 'Enabled'
+                    $Result.State | Should Be 'Enabled'
                 }
                 It 'Should call all the mocks' {
                     Assert-MockCalled -commandName Get-Binding -Exactly 1
@@ -67,7 +67,7 @@ try
                     $Result = Get-TargetResource @TestBindingEnabled
                     $Result.InterfaceAlias | Should Be $TestBindingEnabled.InterfaceAlias
                     $Result.ComponentId | Should Be $TestBindingEnabled.ComponentId
-                    $Result.EnsureEnabled | Should Be 'Disabled'
+                    $Result.State | Should Be 'Disabled'
                 }
                 It 'Should call all the mocks' {
                     Assert-MockCalled -commandName Get-Binding -Exactly 1

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -1,0 +1,221 @@
+﻿$Global:DSCModuleName      = 'xNetworking'
+$Global:DSCResourceName    = 'MSFT_xNetAdapterBinding'
+
+#region HEADER
+# Unit Test Template Version: 1.1.0
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit 
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    InModuleScope $Global:DSCResourceName {
+        $TestBindingEnabled = @{
+            InterfaceAlias = 'Ethernet'
+            ComponentId = 'ms_tcpip63'
+            EnsureEnabled = 'Enabled'
+        }
+        $TestBindingDisabled = @{
+            InterfaceAlias = 'Ethernet'
+            ComponentId = 'ms_tcpip63'
+            EnsureEnabled = 'Disabled'
+        }
+        $MockAdapter = @{
+            InterfaceAlias = 'Ethernet'
+        }
+        $MockBindingEnabled = @{
+            InterfaceAlias = 'Ethernet'
+            ComponentId = 'ms_tcpip63'
+            Enabled = $True
+        }
+        $MockBindingDisabled = @{
+            InterfaceAlias = 'Ethernet'
+            ComponentId = 'ms_tcpip63'
+            Enabled = $False
+        }
+
+        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+            Context 'Adapter exists and binding Enabled' {
+                Mock Get-Binding -MockWith { $MockBindingEnabled }
+
+                It 'should return existing binding' {
+                    $Result = Get-TargetResource @TestBindingDisabled
+                    $Result.InterfaceAlias | Should Be $TestBindingDisabled.InterfaceAlias
+                    $Result.ComponentId | Should Be $TestBindingDisabled.ComponentId
+                    $Result.EnsureEnabled | Should Be 'Enabled'
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                }
+            }
+
+            Context 'Adapter exists and binding Disabled' {
+                Mock Get-Binding -MockWith { $MockBindingDisabled }
+
+                It 'should return existing binding' {
+                    $Result = Get-TargetResource @TestBindingEnabled
+                    $Result.InterfaceAlias | Should Be $TestBindingEnabled.InterfaceAlias
+                    $Result.ComponentId | Should Be $TestBindingEnabled.ComponentId
+                    $Result.EnsureEnabled | Should Be 'Disabled'
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                }
+            }
+        }
+
+        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+            function Enable-NetAdapterBinding {
+                param (
+                    [Parameter(ValueFromPipeline=$True)]
+                    $InputObject
+                )
+            }
+            function Disable-NetAdapterBinding {
+                param (
+                    [Parameter(ValueFromPipeline=$True)]
+                    $InputObject
+                )
+            }
+
+            Context 'Adapter exists and set binding to Enabled' {
+                Mock Get-Binding -MockWith { $MockBindingDisabled }
+                Mock Enable-NetAdapterBinding
+                Mock Disable-NetAdapterBinding
+                It 'Should not throw an exception' {
+                    { Set-TargetResource @TestBindingEnabled } | Should Not Throw
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                    Assert-MockCalled -commandName Enable-NetAdapterBinding -Exactly 1
+                    Assert-MockCalled -commandName Disable-NetAdapterBinding -Exactly 0
+                }
+            }
+
+            Context 'Adapter exists and set binding to Disabled' {
+                Mock Get-Binding -MockWith { $MockBindingEnabled }
+                Mock Enable-NetAdapterBinding
+                Mock Disable-NetAdapterBinding
+                It 'Should not throw an exception' {
+                    { Set-TargetResource @TestBindingDisabled } | Should Not Throw
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                    Assert-MockCalled -commandName Enable-NetAdapterBinding -Exactly 0
+                    Assert-MockCalled -commandName Disable-NetAdapterBinding -Exactly 1
+                }
+            }
+        }
+
+        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+            Context 'Adapter exists, current binding set to Enabled but want it Disabled' {
+                Mock Get-Binding -MockWith { $MockBindingEnabled }
+                It 'Should return false' {
+                    Test-TargetResource @TestBindingDisabled | Should Be $False
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                }
+            }
+
+            Context 'Adapter exists, current binding set to Disabled but want it Enabled' {
+                Mock Get-Binding -MockWith { $MockBindingDisabled }
+                It 'Should return false' {
+                    Test-TargetResource @TestBindingEnabled | Should Be $False
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                }
+            }
+
+            Context 'Adapter exists, current binding set to Enabled and want it Enabled' {
+                Mock Get-Binding -MockWith { $MockBindingEnabled }
+                It 'Should return true' {
+                    Test-TargetResource @TestBindingEnabled | Should Be $True
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                }
+            }
+
+            Context 'Adapter exists, current binding set to Disabled and want it Disabled' {
+                Mock Get-Binding -MockWith { $MockBindingDisabled }
+                It 'Should return true' {
+                    Test-TargetResource @TestBindingDisabled | Should Be $True
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                }
+            }
+        }
+
+        Describe "$($Global:DSCResourceName)\Get-Binding" {
+            Context 'Adapter does not exist' {
+                Mock Get-NetAdapter
+                It 'Should throw an InterfaceNotAvailable error' {
+                    $errorId = 'InterfaceNotAvailable'
+                    $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
+                    $errorMessage = $($LocalizedData.InterfaceNotAvailableError `
+                        -f $TestBindingEnabled.InterfaceAlias)
+                    $exception = New-Object -TypeName System.InvalidOperationException `
+                        -ArgumentList $errorMessage
+                    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
+                        -ArgumentList $exception, $errorId, $errorCategory, $null
+
+                    { Get-Binding @TestBindingEnabled } | Should Throw $errorRecord
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                }
+            }
+
+            Context 'Adapter exists and binding enabled' {
+                Mock Get-NetAdapter -MockWith { $MockAdapter }
+                Mock Get-NetAdapterBinding -MockWith { $MockBindingEnabled }
+                It 'Should return the adapter binding' {
+                    $Result = Get-Binding @TestBindingEnabled
+                    $Result.InterfaceAlias | Should Be $MockBindingEnabled.InterfaceAlias
+                    $Result.ComponentId    | Should Be $MockBindingEnabled.ComponentId
+                    $Result.Enabled        | Should Be $MockBindingEnabled.Enabled
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetAdapterBinding -Exactly 1
+                }
+            }
+
+            Context 'Adapter exists and binding disabled' {
+                Mock Get-NetAdapter -MockWith { $MockAdapter }
+                Mock Get-NetAdapterBinding -MockWith { $MockBindingDisabled }
+                It 'Should return the adapter binding' {
+                    $Result = Get-Binding @TestBindingDisabled
+                    $Result.InterfaceAlias | Should Be $MockBindingDisabled.InterfaceAlias
+                    $Result.ComponentId    | Should Be $MockBindingDisabled.ComponentId
+                    $Result.Enabled        | Should Be $MockBindingDisabled.Enabled
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
+                    Assert-MockCalled -commandName Get-NetAdapterBinding -Exactly 1
+                }
+            }
+        }
+    } #end InModuleScope $DSCResourceName
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}


### PR DESCRIPTION
Fixes #116 

Adds xNetAdapterBinding resource.

This resource is just used to enable or disable components (e.g. IPv4, IPv6) from a network adapter.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="35" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/120)
<!-- Reviewable:end -->
