### PR TITLE
Added xDnsClientGlobalSetting Resource - Fixes #111

### DIFF
--- a/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
+++ b/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
@@ -1,0 +1,203 @@
+#region localizeddata
+if (Test-Path "${PSScriptRoot}\${PSUICulture}")
+{
+    Import-LocalizedData `
+        -BindingVariable LocalizedData `
+        -Filename MSFT_xDnsClientGlobalSetting.psd1 `
+        -BaseDirectory "${PSScriptRoot}\${PSUICulture}"
+}
+else
+{
+    #fallback to en-US
+    Import-LocalizedData `
+        -BindingVariable LocalizedData `
+        -Filename MSFT_xDnsClientGlobalSetting.psd1 `
+        -BaseDirectory "${PSScriptRoot}\en-US"
+}
+#endregion
+
+<#
+    This is an array of all the parameters used by this resource.
+#>
+data ParameterList
+{
+    @(
+        @{ Name = 'SuffixSearchList'; Type = 'String'  },
+        @{ Name = 'UseDevolution';    Type = 'Boolean' },
+        @{ Name = 'DevolutionLevel';  Type = 'Uint32'  }
+    )
+}
+
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([Hashtable])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance
+    )
+
+    Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($LocalizedData.GettingDnsClientGlobalSettingsMessage)
+        ) -join '' )
+
+    # Get the current Dns Client Global Settings
+    $DnsClientGlobalSetting = Get-DnsClientGlobalSetting `
+        -ErrorAction Stop
+
+    # Generate the return object.
+    $ReturnValue = @{
+        IsSingleInstance = 'Yes'
+    }
+    foreach ($parameter in $ParameterList)
+    {
+        $ReturnValue += @{ $parameter.Name = $DnsClientGlobalSetting.$($parameter.name) }
+    } # foreach
+
+    return $ReturnValue
+} # Get-TargetResource
+
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance,
+
+        [String[]]
+        $SuffixSearchList,
+
+        [Boolean]
+        $UseDevolution,
+
+        [Uint32]
+        $DevolutionList
+    )
+
+    Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($LocalizedData.SettingDnsClientGlobalSettingMessage)
+        ) -join '' )
+
+    # Get the current Dns Client Global Settings
+    $DnsClientGlobalSetting = Get-DnsClientGlobalSetting `
+        -ErrorAction Stop
+
+    # Generate a list of parameters that will need to be changed.
+    $ChangeParameters = @{}
+    foreach ($parameter in $ParameterList)
+    {
+        $ParameterSource = $DnsClientGlobalSetting.$($parameter.name)
+        $ParameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
+        if ($PSBoundParameters.ContainsKey($parameter.Name) `
+            -and ($ParameterSource -ne $ParameterNew))
+        {
+            $ChangeParameters += @{
+                $($parameter.name) = $ParameterNew
+            }
+            Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($LocalizedData.DnsClientGlobalSettingUpdateParameterMessage) `
+                    -f $parameter.Name,$ParameterNew
+                ) -join '' )
+        } # if
+    } # foreach
+    if ($ChangeParameters.Count -gt 0)
+    {
+        # Update any parameters that were identified as different
+        $null = Set-DnsClientGlobalSetting `
+            @ChangeParameters `
+            -ErrorAction Stop
+
+        Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($LocalizedData.DnsClientGlobalSettingUpdatedMessage)
+            ) -join '' )
+    } # if
+} # Set-TargetResource
+
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [String]
+        $IsSingleInstance,
+
+        [String[]]
+        $SuffixSearchList,
+
+        [Boolean]
+        $UseDevolution,
+
+        [Uint32]
+        $DevolutionList
+    )
+
+    Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($LocalizedData.TestingDnsClientGlobalSettingMessage)
+        ) -join '' )
+
+    # Flag to signal whether settings are correct
+    [Boolean] $DesiredConfigurationMatch = $true
+
+    # Get the current Dns Client Global Settings
+    $DnsClientGlobalSetting = Get-DnsClientGlobalSetting `
+        -ErrorAction Stop
+
+    # Check each parameter
+    foreach ($parameter in $ParameterList)
+    {
+        $ParameterSource = $DnsClientGlobalSetting.$($parameter.name)
+        $ParameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
+        if ($PSBoundParameters.ContainsKey($parameter.Name) `
+            -and ($ParameterSource -ne $ParameterNew)) {
+            Write-Verbose -Message ( @(
+                "$($MyInvocation.MyCommand): "
+                $($LocalizedData.DnsClientGlobalSettingParameterNeedsUpdateMessage) `
+                    -f $parameter.Name,$ParameterSource,$ParameterNew
+                ) -join '' )
+            $desiredConfigurationMatch = $false
+        } # if
+    } # foreach
+
+    return $DesiredConfigurationMatch
+} # Test-TargetResource
+
+# Helper Functions
+function New-TerminatingError
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory)]
+        [String] $ErrorId,
+
+        [Parameter(Mandatory)]
+        [String] $ErrorMessage,
+
+        [Parameter(Mandatory)]
+        [System.Management.Automation.ErrorCategory] $ErrorCategory
+    )
+
+    $exception = New-Object `
+        -TypeName System.InvalidOperationException `
+        -ArgumentList $errorMessage
+    $errorRecord = New-Object `
+        -TypeName System.Management.Automation.ErrorRecord `
+        -ArgumentList $exception, $errorId, $errorCategory, $null
+    $PSCmdlet.ThrowTerminatingError($errorRecord)
+}
+
+Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
+++ b/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
@@ -78,7 +78,7 @@ function Set-TargetResource
         $UseDevolution,
 
         [Uint32]
-        $DevolutionList
+        $DevolutionLevel
     )
 
     Write-Verbose -Message ( @(
@@ -141,7 +141,7 @@ function Test-TargetResource
         $UseDevolution,
 
         [Uint32]
-        $DevolutionList
+        $DevolutionLevel
     )
 
     Write-Verbose -Message ( @(

--- a/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.schema.mof
+++ b/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.schema.mof
@@ -1,0 +1,8 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xDnsClientGlobalSetting")]
+class MSFT_xDnsClientGlobalSetting : OMI_BaseResource
+{
+    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'"), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
+    [Write, Description("Specifies a list of global suffixes that can be used in the specified order by the DNS client for resolving the IP address of the computer name.")] String SuffixSearchList[];
+    [Write, Description("Specifies that devolution is activated.")] Boolean UseDevolution;
+    [Write, Description("Specifies the number of labels up to which devolution should occur.")] Uint32 DevolutionLevel;
+};

--- a/DSCResources/MSFT_xDnsClientGlobalSetting/en-US/MSFT_xDnsClientGlobalSetting.psd1
+++ b/DSCResources/MSFT_xDnsClientGlobalSetting/en-US/MSFT_xDnsClientGlobalSetting.psd1
@@ -1,0 +1,8 @@
+ConvertFrom-StringData @'
+GettingDnsClientGlobalSettingMessage=Getting DNS Client Global Settings.
+SettingDnsClientGlobalSettingMessage=Setting DNS Client Global Settings.
+DnsClientGlobalSettingUpdateParameterMessage=Setting DNS Client Global Settings parameter {0} to "{1}".
+DnsClientGlobalSettingUpdatedMessage=Setting DNS Client Global Settings updated.
+TestingDnsClientGlobalSettingMessage=Testing DNS Client Global Settings.
+DnsClientGlobalSettingParameterNeedsUpdateMessage=DNS Client Global Setting "{0}" is "{1}" but should be "{2}". Change required.
+'@

--- a/Examples/Sample_xDnsClientGlobalSetting_SuffixSearchList.ps1
+++ b/Examples/Sample_xDnsClientGlobalSetting_SuffixSearchList.ps1
@@ -1,0 +1,32 @@
+configuration Sample_xDnsClientGlobalSetting_SuffixSearchList
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost',
+
+        [Parameter(Mandatory)]
+        [string[]]$SuffixSearchList,
+
+        [Parameter(Mandatory)]
+        [boolean]$UseDevolution = $true,
+
+        [Parameter(Mandatory)]
+        [uint32]$DevolutionLevel = 0
+    )
+
+    Import-DscResource -Module xDnsClientGlobalSetting
+
+    Node $NodeName
+    {
+        xDhcpClient EnableDhcpClient
+        {
+            IsSingleInstance = 'Yes'
+            SuffixSearchList = $SuffixSearchList
+            UseDevolution    = $UseDevolution
+            DevolutionLevel  = $DevolutionLevel
+        }
+    }
+}
+
+Sample_xDnsClientGlobalSetting_SuffixSearchList -SuffixSearchList 'contoso.com'
+Start-DscConfiguration -Path Sample_xDnsClientGlobalSetting_SuffixSearchList -Wait -Verbose -Force

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ The **xNetworking** module contains the following resources:
 * **xNetworkTeam**
 * **xHostsFile**
 * **xNetAdapterBinding**
+* **xDnsClientGlobalSetting**
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/) or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any additional questions or comments.
@@ -140,6 +141,12 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **ComponentId**: Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip. Mandatory.
 * **State**: Specifies if the component ID for the Interface should be Enabled or Disabled. Optional. Defaults to Enabled. { Enabled | Disabled }.
 
+### xDnsClientGlobalSetting
+* **IsSingleInstance**: Specifies the resource is a single instance, the value must be 'Yes'.
+* **SuffixSearchList**: Specifies a list of global suffixes that can be used in the specified order by the DNS client for resolving the IP address of the computer name.
+* **UseDevolution**: Specifies that devolution is activated.
+* **DevolutionLevel**: Specifies the number of labels up to which devolution should occur.
+
 ## Functions
 
 ### Get-xNetworkAdapterName
@@ -184,6 +191,9 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 ## Versions
 
 ### Unreleased
+
+* Added the following resources:
+    * MSFT_xDnsClientGlobalSetting resource to configure the DNS Suffix Search List and Devolution.
 
 ### 2.10.0.0
 
@@ -921,4 +931,42 @@ Configuration SetDns
         }
     }
 }
+```
+
+### Set the DNS Client Global Setting Suffix Search List
+This example will set the DNS Global Suffix Search list to 'contoso.com'.
+
+```PowerShell
+configuration Sample_xDnsClientGlobalSetting_SuffixSearchList
+{
+    param
+    (
+        [string[]]$NodeName = 'localhost',
+
+        [Parameter(Mandatory)]
+        [string[]]$SuffixSearchList,
+
+        [Parameter(Mandatory)]
+        [boolean]$UseDevolution = $true,
+
+        [Parameter(Mandatory)]
+        [uint32]$DevolutionLevel = 0
+    )
+
+    Import-DscResource -Module xDnsClientGlobalSetting
+
+    Node $NodeName
+    {
+        xDhcpClient EnableDhcpClient
+        {
+            IsSingleInstance = 'Yes'
+            SuffixSearchList = $SuffixSearchList
+            UseDevolution    = $UseDevolution
+            DevolutionLevel  = $DevolutionLevel
+        }
+    }
+}
+
+Sample_xDnsClientGlobalSetting_SuffixSearchList -SuffixSearchList 'contoso.com'
+Start-DscConfiguration -Path Sample_xDnsClientGlobalSetting_SuffixSearchList -Wait -Verbose -Force
 ```

--- a/README.md
+++ b/README.md
@@ -191,9 +191,10 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 ## Versions
 
 ### Unreleased
-
 * Added the following resources:
     * MSFT_xDnsClientGlobalSetting resource to configure the DNS Suffix Search List and Devolution.
+* Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey.
+* Changed AppVeyor.yml to use default image
 
 ### 2.10.0.0
 

--- a/README.md
+++ b/README.md
@@ -194,7 +194,8 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 * Added the following resources:
     * MSFT_xDnsClientGlobalSetting resource to configure the DNS Suffix Search List and Devolution.
 * Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey.
-* Changed AppVeyor.yml to use default image
+* Changed AppVeyor.yml to use default image.
+* Fix xNetBios unit tests to work on default appveyor image.
 
 ### 2.10.0.0
 

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
@@ -19,6 +19,10 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 # Backup the existing settings
 $CurrentDnsClientGlobalSetting = Get-DnsClientGlobalSetting
+Set-DnsClientGlobalSetting `
+    -SuffixSearchList 'fabrikam.com' `
+    -UseDevolution $False `
+    -DevolutionLevel 4
 
 # Using try/finally to always cleanup even if something awful happens.
 try

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
@@ -1,0 +1,65 @@
+$Global:DSCModuleName   = 'xNetworking'
+$Global:DSCResourceName = 'MSFT_xDnsClientGlobalSetting'
+
+#region HEADER
+# Integration Test Template Version: 1.1.0
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Integration
+#endregion
+
+# Backup the existing settings
+$CurrentDnsClientGlobalSetting = Get-DnsClientGlobalSetting
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    #region Integration Tests
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    . $ConfigFile
+
+    Describe "$($Global:DSCResourceName)_Integration" {
+        #region DEFAULT TESTS
+        It 'Should compile without throwing' {
+            {
+                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+
+        It 'Should have set the resource and all the parameters should match' {
+            # Get the Rule details
+            $DnsClientGlobalSettingNew = Get-DnsClientGlobalSetting
+            $DnsClientGlobalSettingNew.SuffixSearchList | Should Be $DnsClientGlobalSetting.SuffixSearchList
+            $DnsClientGlobalSettingNew.UseDevolution    | Should Be $DnsClientGlobalSetting.UseDevolution
+            $DnsClientGlobalSettingNew.DevolutionLevel  | Should Be $DnsClientGlobalSetting.DevolutionLevel
+        }
+    }
+    #endregion
+}
+finally
+{
+    # Clean up
+    Set-DnsClientGlobalSetting `
+        -SuffixSearchList $CurrentDnsClientGlobalSetting.SuffixSearchList `
+        -UseDevolution $CurrentDnsClientGlobalSetting.UseDevolution `
+        -DevolutionLevel $CurrentDnsClientGlobalSetting.DevolutionLevel
+
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
@@ -19,14 +19,16 @@ $TestEnvironment = Initialize-TestEnvironment `
 
 # Backup the existing settings
 $CurrentDnsClientGlobalSetting = Get-DnsClientGlobalSetting
-Set-DnsClientGlobalSetting `
-    -SuffixSearchList 'fabrikam.com' `
-    -UseDevolution $False `
-    -DevolutionLevel 4
 
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
+    # Set the DNS Client Global settings to known values
+    Set-DnsClientGlobalSetting `
+        -SuffixSearchList 'fabrikam.com' `
+        -UseDevolution $False `
+        -DevolutionLevel 4
+
     #region Integration Tests
     $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
     . $ConfigFile

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.config.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.config.ps1
@@ -1,0 +1,17 @@
+$DnsClientGlobalSetting = @{
+    SuffixSearchList             = 'contoso.com'
+    UseDevolution                = $True
+    DevolutionLevel              = 1
+}
+
+Configuration MSFT_xDnsClientGlobalSetting_Config {
+    Import-DscResource -ModuleName xDFS
+    node localhost {
+        xDnsClientGlobalSetting Integration_Test {
+            IsSingleInstance     = 'Yes'
+            SuffixSearchList     = $DnsClientGlobalSetting.SuffixSearchList
+            UseDevolution        = $DnsClientGlobalSetting.UseDevolution
+            DevolutionLevel      = $DnsClientGlobalSetting.DevolutionLevel
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.config.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.config.ps1
@@ -1,11 +1,11 @@
 $DnsClientGlobalSetting = @{
     SuffixSearchList             = 'contoso.com'
     UseDevolution                = $True
-    DevolutionLevel              = 1
+    DevolutionLevel              = 2
 }
 
 Configuration MSFT_xDnsClientGlobalSetting_Config {
-    Import-DscResource -ModuleName xDFS
+    Import-DscResource -ModuleName xNetworking
     node localhost {
         xDnsClientGlobalSetting Integration_Test {
             IsSingleInstance     = 'Yes'

--- a/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
@@ -1,5 +1,5 @@
 $Global:DSCModuleName   = 'xNetworking'
-$Global:DSCResourceName = 'MSFT_xDnsClientGlobalSettings'
+$Global:DSCResourceName = 'MSFT_xDnsClientGlobalSetting'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0
@@ -24,141 +24,141 @@ try
     InModuleScope $Global:DSCResourceName {
 
         # Create the Mock Objects that will be used for running tests
-        $NamespaceServerConfiguration = [PSObject]@{
-            LdapTimeoutSec               = 45
-            SyncIntervalSec              = 5000
-            UseFQDN                      = $True
+        $DnsClientGlobalSettings = [PSObject]@{
+            SuffixSearchList             = 'contoso.com'
+            DevolutionLevel              = 1
+            UseDevolution                = $True
         }
-        $NamespaceServerConfigurationSplat = [PSObject]@{
+        $DnsClientGlobalSettingsSplat = [PSObject]@{
             IsSingleInstance             = 'Yes'
-            LdapTimeoutSec               = $NamespaceServerConfiguration.LdapTimeoutSec
-            SyncIntervalSec              = $NamespaceServerConfiguration.SyncIntervalSec
-            UseFQDN                      = $NamespaceServerConfiguration.UseFQDN
+            SuffixSearchList             = $DnsClientGlobalSettings.SuffixSearchList
+            DevolutionLevel              = $DnsClientGlobalSettings.DevolutionLevel
+            UseDevolution                = $DnsClientGlobalSettings.UseDevolution
         }
 
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
 
-            Context 'Namespace Server Configuration Exists' {
+            Context 'DNS Client Global Settings Exists' {
 
-                Mock Get-DFSNServerConfiguration -MockWith { $NamespaceServerConfiguration }
+                Mock Get-DnsClientGlobalSetting -MockWith { $DnsClientGlobalSettings }
 
-                It 'should return correct namespace server configuration values' {
+                It 'should return correct DNS Client Global Settings values' {
                     $Result = Get-TargetResource -IsSingleInstance 'Yes'
-                    $Result.LdapTimeoutSec            | Should Be $NamespaceServerConfiguration.LdapTimeoutSec
-                    $Result.SyncIntervalSec           | Should Be $NamespaceServerConfiguration.SyncIntervalSec
-                    $Result.UseFQDN                   | Should Be $NamespaceServerConfiguration.UseFQDN
+                    $Result.SuffixSearchList          | Should Be $DnsClientGlobalSettings.SuffixSearchList
+                    $Result.DevolutionLevel           | Should Be $DnsClientGlobalSettings.DevolutionLevel
+                    $Result.UseDevolution             | Should Be $DnsClientGlobalSettings.UseDevolution
                 }
                 It 'should call the expected mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -CommandName Get-DnsClientGlobalSetting -Exactly 1
                 }
             }
         }
 
         Describe "$($Global:DSCResourceName)\Set-TargetResource" {
 
-            Mock Get-DFSNServerConfiguration -MockWith { $NamespaceServerConfiguration }
-            Mock Set-DFSNServerConfiguration
+            Mock Get-DnsClientGlobalSetting -MockWith { $DnsClientGlobalSettings }
+            Mock Set-DnsClientGlobalSetting
 
-            Context 'Namespace Server Configuration all parameters are the same' {
+            Context 'DNS Client Global Settings all parameters are the same' {
                 It 'should not throw error' {
                     {
-                        $Splat = $NamespaceServerConfigurationSplat.Clone()
+                        $Splat = $DnsClientGlobalSettingsSplat.Clone()
                         Set-TargetResource @Splat
                     } | Should Not Throw
                 }
                 It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
-                    Assert-MockCalled -commandName Set-DFSNServerConfiguration -Exactly 0
+                    Assert-MockCalled -commandName Get-DnsClientGlobalSetting -Exactly 1
+                    Assert-MockCalled -commandName Set-DnsClientGlobalSetting -Exactly 0
                 }
             }
 
-            Context 'Namespace Server Configuration LdapTimeoutSec is different' {
+            Context 'DNS Client Global Settings SuffixSearchList is different' {
                 It 'should not throw error' {
                     {
-                        $Splat = $NamespaceServerConfigurationSplat.Clone()
-                        $Splat.LdapTimeoutSec = $Splat.LdapTimeoutSec + 1
+                        $Splat = $DnsClientGlobalSettingsSplat.Clone()
+                        $Splat.SuffixSearchList = 'fabrikam.com'
                         Set-TargetResource @Splat
                     } | Should Not Throw
                 }
                 It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
-                    Assert-MockCalled -commandName Set-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Get-DnsClientGlobalSetting -Exactly 1
+                    Assert-MockCalled -commandName Set-DnsClientGlobalSetting -Exactly 1
                 }
             }
 
-            Context 'Namespace Server Configuration SyncIntervalSec is different' {
+            Context 'DNS Client Global Settings DevolutionLevel is different' {
                 It 'should not throw error' {
                     {
-                        $Splat = $NamespaceServerConfigurationSplat.Clone()
-                        $Splat.SyncIntervalSec = $Splat.SyncIntervalSec + 1
+                        $Splat = $DnsClientGlobalSettingsSplat.Clone()
+                        $Splat.DevolutionLevel = $Splat.DevolutionLevel + 1
                         Set-TargetResource @Splat
                     } | Should Not Throw
                 }
                 It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
-                    Assert-MockCalled -commandName Set-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Get-DnsClientGlobalSetting -Exactly 1
+                    Assert-MockCalled -commandName Set-DnsClientGlobalSetting -Exactly 1
                 }
             }
 
-            Context 'Namespace Server Configuration UseFQDN is different' {
+            Context 'DNS Client Global Settings UseDevolution is different' {
                 It 'should not throw error' {
                     {
-                        $Splat = $NamespaceServerConfigurationSplat.Clone()
-                        $Splat.UseFQDN = -not $Splat.UseFQDN
+                        $Splat = $DnsClientGlobalSettingsSplat.Clone()
+                        $Splat.UseDevolution = -not $Splat.UseDevolution
                         Set-TargetResource @Splat
                     } | Should Not Throw
                 }
                 It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
-                    Assert-MockCalled -commandName Set-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Get-DnsClientGlobalSetting -Exactly 1
+                    Assert-MockCalled -commandName Set-DnsClientGlobalSetting -Exactly 1
                 }
             }
         }
 
         Describe "$($Global:DSCResourceName)\Test-TargetResource" {
 
-            Mock Get-DFSNServerConfiguration -MockWith { $NamespaceServerConfiguration }
+            Mock Get-DnsClientGlobalSetting -MockWith { $DnsClientGlobalSettings }
 
-            Context 'Namespace Server Configuration all parameters are the same' {
+            Context 'DNS Client Global Settings all parameters are the same' {
                 It 'should return true' {
-                    $Splat = $NamespaceServerConfigurationSplat.Clone()
+                    $Splat = $DnsClientGlobalSettingsSplat.Clone()
                     Test-TargetResource @Splat | Should Be $True
                 }
                 It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Get-DnsClientGlobalSetting -Exactly 1
                 }
             }
 
-            Context 'Namespace Server Configuration LdapTimeoutSec is different' {
+            Context 'DNS Client Global Settings SuffixSearchList is different' {
                 It 'should return false' {
-                    $Splat = $NamespaceServerConfigurationSplat.Clone()
-                    $Splat.LdapTimeoutSec = $Splat.LdapTimeoutSec + 1
+                    $Splat = $DnsClientGlobalSettingsSplat.Clone()
+                    $Splat.SuffixSearchList = 'fabrikam.com'
                     Test-TargetResource @Splat | Should Be $False
                 }
                 It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Get-DnsClientGlobalSetting -Exactly 1
                 }
             }
 
-            Context 'Namespace Server Configuration SyncIntervalSec is different' {
+            Context 'DNS Client Global Settings DevolutionLevel is different' {
                 It 'should return false' {
-                    $Splat = $NamespaceServerConfigurationSplat.Clone()
-                    $Splat.SyncIntervalSec = $Splat.SyncIntervalSec + 1
+                    $Splat = $DnsClientGlobalSettingsSplat.Clone()
+                    $Splat.DevolutionLevel = $Splat.DevolutionLevel + 1
                     Test-TargetResource @Splat | Should Be $False
                 }
                 It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Get-DnsClientGlobalSetting -Exactly 1
                 }
             }
 
-            Context 'Namespace Server Configuration UseFQDN is different' {
+            Context 'DNS Client Global Settings UseDevolution is different' {
                 It 'should return false' {
-                    $Splat = $NamespaceServerConfigurationSplat.Clone()
-                    $Splat.UseFQDN = -not $Splat.UseFQDN
+                    $Splat = $DnsClientGlobalSettingsSplat.Clone()
+                    $Splat.UseDevolution = -not $Splat.UseDevolution
                     Test-TargetResource @Splat | Should Be $False
                 }
                 It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Get-DnsClientGlobalSetting -Exactly 1
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
@@ -1,0 +1,196 @@
+$Global:DSCModuleName   = 'xNetworking'
+$Global:DSCResourceName = 'MSFT_xDnsClientGlobalSettings'
+
+#region HEADER
+# Unit Test Template Version: 1.1.0
+[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
+if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $Global:DSCModuleName `
+    -DSCResourceName $Global:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Tests
+    InModuleScope $Global:DSCResourceName {
+
+        # Create the Mock Objects that will be used for running tests
+        $NamespaceServerConfiguration = [PSObject]@{
+            LdapTimeoutSec               = 45
+            SyncIntervalSec              = 5000
+            UseFQDN                      = $True
+        }
+        $NamespaceServerConfigurationSplat = [PSObject]@{
+            IsSingleInstance             = 'Yes'
+            LdapTimeoutSec               = $NamespaceServerConfiguration.LdapTimeoutSec
+            SyncIntervalSec              = $NamespaceServerConfiguration.SyncIntervalSec
+            UseFQDN                      = $NamespaceServerConfiguration.UseFQDN
+        }
+
+        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+
+            Context 'Namespace Server Configuration Exists' {
+
+                Mock Get-DFSNServerConfiguration -MockWith { $NamespaceServerConfiguration }
+
+                It 'should return correct namespace server configuration values' {
+                    $Result = Get-TargetResource -IsSingleInstance 'Yes'
+                    $Result.LdapTimeoutSec            | Should Be $NamespaceServerConfiguration.LdapTimeoutSec
+                    $Result.SyncIntervalSec           | Should Be $NamespaceServerConfiguration.SyncIntervalSec
+                    $Result.UseFQDN                   | Should Be $NamespaceServerConfiguration.UseFQDN
+                }
+                It 'should call the expected mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                }
+            }
+        }
+
+        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+
+            Mock Get-DFSNServerConfiguration -MockWith { $NamespaceServerConfiguration }
+            Mock Set-DFSNServerConfiguration
+
+            Context 'Namespace Server Configuration all parameters are the same' {
+                It 'should not throw error' {
+                    {
+                        $Splat = $NamespaceServerConfigurationSplat.Clone()
+                        Set-TargetResource @Splat
+                    } | Should Not Throw
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Set-DFSNServerConfiguration -Exactly 0
+                }
+            }
+
+            Context 'Namespace Server Configuration LdapTimeoutSec is different' {
+                It 'should not throw error' {
+                    {
+                        $Splat = $NamespaceServerConfigurationSplat.Clone()
+                        $Splat.LdapTimeoutSec = $Splat.LdapTimeoutSec + 1
+                        Set-TargetResource @Splat
+                    } | Should Not Throw
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Set-DFSNServerConfiguration -Exactly 1
+                }
+            }
+
+            Context 'Namespace Server Configuration SyncIntervalSec is different' {
+                It 'should not throw error' {
+                    {
+                        $Splat = $NamespaceServerConfigurationSplat.Clone()
+                        $Splat.SyncIntervalSec = $Splat.SyncIntervalSec + 1
+                        Set-TargetResource @Splat
+                    } | Should Not Throw
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Set-DFSNServerConfiguration -Exactly 1
+                }
+            }
+
+            Context 'Namespace Server Configuration UseFQDN is different' {
+                It 'should not throw error' {
+                    {
+                        $Splat = $NamespaceServerConfigurationSplat.Clone()
+                        $Splat.UseFQDN = -not $Splat.UseFQDN
+                        Set-TargetResource @Splat
+                    } | Should Not Throw
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                    Assert-MockCalled -commandName Set-DFSNServerConfiguration -Exactly 1
+                }
+            }
+        }
+
+        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+
+            Mock Get-DFSNServerConfiguration -MockWith { $NamespaceServerConfiguration }
+
+            Context 'Namespace Server Configuration all parameters are the same' {
+                It 'should return true' {
+                    $Splat = $NamespaceServerConfigurationSplat.Clone()
+                    Test-TargetResource @Splat | Should Be $True
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                }
+            }
+
+            Context 'Namespace Server Configuration LdapTimeoutSec is different' {
+                It 'should return false' {
+                    $Splat = $NamespaceServerConfigurationSplat.Clone()
+                    $Splat.LdapTimeoutSec = $Splat.LdapTimeoutSec + 1
+                    Test-TargetResource @Splat | Should Be $False
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                }
+            }
+
+            Context 'Namespace Server Configuration SyncIntervalSec is different' {
+                It 'should return false' {
+                    $Splat = $NamespaceServerConfigurationSplat.Clone()
+                    $Splat.SyncIntervalSec = $Splat.SyncIntervalSec + 1
+                    Test-TargetResource @Splat | Should Be $False
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                }
+            }
+
+            Context 'Namespace Server Configuration UseFQDN is different' {
+                It 'should return false' {
+                    $Splat = $NamespaceServerConfigurationSplat.Clone()
+                    $Splat.UseFQDN = -not $Splat.UseFQDN
+                    Test-TargetResource @Splat | Should Be $False
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-DFSNServerConfiguration -Exactly 1
+                }
+            }
+        }
+
+        Describe "$($Global:DSCResourceName)\New-TerminatingError" {
+
+            Context 'Create a TestError Exception' {
+
+                It 'should throw an TestError exception' {
+                    $errorId = 'TestError'
+                    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
+                    $errorMessage = 'Test Error Message'
+                    $exception = New-Object `
+                        -TypeName System.InvalidOperationException `
+                        -ArgumentList $errorMessage
+                    $errorRecord = New-Object `
+                        -TypeName System.Management.Automation.ErrorRecord `
+                        -ArgumentList $exception, $errorId, $errorCategory, $null
+
+                    { New-TerminatingError `
+                        -ErrorId $errorId `
+                        -ErrorMessage $errorMessage `
+                        -ErrorCategory $errorCategory } | Should Throw $errorRecord
+                }
+            }
+        }
+    }
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
@@ -16,7 +16,7 @@ Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHel
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 #endregion
 
 # Begin Testing
@@ -24,6 +24,8 @@ try
 {
     #region Pester Tests
     InModuleScope $Global:DSCResourceName {
+
+        $InterfaceAlias = (Get-NetAdapter -Physical | Select-Object -First 1).Name
 
         $MockNetadapterSettingsDefault = New-Object -TypeName CimInstance -ArgumentList 'Win32_NetworkAdapterConfiguration' | Add-Member -MemberType NoteProperty -Name TcpipNetbiosOptions -Value 0 -PassThru
         $MockNetadapterSettingsEnable = New-Object -TypeName CimInstance -ArgumentList 'Win32_NetworkAdapterConfiguration' | Add-Member -MemberType NoteProperty -Name TcpipNetbiosOptions -Value 1 -PassThru
@@ -35,17 +37,17 @@ try
             Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsDefault}
 
             It 'Returns a hashtable' {
-                $targetResource = Get-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Default'
+                $targetResource = Get-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Default'
                 $targetResource -is [System.Collections.Hashtable] | Should Be $true
             }
 
             It 'NetBIOS over TCP/IP numerical setting "0" should translate to "Default"' {
-                $Result = Get-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Default'
+                $Result = Get-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Default'
                 $Result.Setting | should be 'Default'
             }
 
             It 'NetBIOS over TCP/IP setting should return real value "Default", not parameter value "Enable"' {
-                $Result = Get-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Enable'
+                $Result = Get-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Enable'
                 $Result.Setting | should be 'Default'
             }
         }
@@ -59,10 +61,10 @@ try
                 Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsDefault}
 
                 It 'should return true when value "Default" is set' {
-                    Test-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Default' | Should Be $true
+                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Default' | Should Be $true
                 }
                 It 'should return false when value "Disable" is set' {
-                    Test-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Disable' | Should Be $false
+                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Disable' | Should Be $false
                 }
             }
 
@@ -71,10 +73,10 @@ try
                 Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsDisable}
 
                 It 'should return true when value "Disable" is set' {
-                    Test-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Disable' | Should Be $true
+                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Disable' | Should Be $true
                 }
                 It 'should return false when value "Enable" is set' {
-                    Test-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Enable' | Should Be $false
+                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Enable' | Should Be $false
                 }
             }
 
@@ -83,10 +85,10 @@ try
                 Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsEnable}
 
                 It 'should return true when value "Enable" is set' {
-                    Test-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Enable' | Should Be $true
+                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Enable' | Should Be $true
                 }
                 It 'should return false when value "Disable" is set' {
-                    Test-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Disable' | Should Be $false
+                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Disable' | Should Be $false
                 }
             }
 
@@ -111,7 +113,7 @@ try
                 Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsEnable}
 
                 It 'Should call "Set-ItemProperty" instead of "Invoke-CimMethod"' {
-                    $Null = Set-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Default'
+                    $Null = Set-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Default'
 
                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly -Times 1
                     Assert-MockCalled -CommandName Invoke-CimMethod -Exactly -Times 0
@@ -124,7 +126,7 @@ try
                     Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsEnable}
                     Mock Invoke-CimMethod
 
-                    $Null = Set-TargetResource -InterfaceAlias 'Ethernet' -Setting 'Disable'
+                    $Null = Set-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Disable'
 
                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly -Times 0
                     Assert-MockCalled -CommandName Invoke-CimMethod -Exactly -Times 1

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,16 +1,16 @@
 #---------------------------------#
 #      environment configuration  #
 #---------------------------------#
-os: WMF 5
 version: 2.10.{build}.0
 install:
-  - cinst -y pester
   - git clone https://github.com/PowerShell/DscResource.Tests
-  - ps: Push-Location
-  - cd DscResource.Tests
-  - ps: Import-Module .\TestHelper.psm1 -force
-  - ps: Pop-Location
-  - ps: Get-PackageProvider -name nuget -ForceBootStrap -Force
+  - ps: |
+        Push-Location
+        cd DscResource.Tests
+        Import-Module .\TestHelper.psm1 -force
+        Pop-Location
+        Install-PackageProvider -Name NuGet -MinimumVersion 2.8.5.201 -Force
+        Install-Module -Name Pester -Repository PSGallery -Force
 
 #---------------------------------#
 #      build configuration        #


### PR DESCRIPTION
This adds support for setting the DNS client global suffix search list (and devolution level) as per #111.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/129)
<!-- Reviewable:end -->
