### PR TITLE
Fixes xRoute route removal failure - Fixes #134

### DIFF
--- a/DSCResources/MSFT_xRoute/MSFT_xRoute.psm1
+++ b/DSCResources/MSFT_xRoute/MSFT_xRoute.psm1
@@ -36,11 +36,11 @@ function Get-TargetResource
         [Parameter(Mandatory)]
         [ValidateSet('IPv4', 'IPv6')]
         [String] $AddressFamily,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $DestinationPrefix,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $NextHop
@@ -59,7 +59,7 @@ function Get-TargetResource
         InterfaceAlias    = $InterfaceAlias
         AddressFamily     = $AddressFamily
         DestinationPrefix = $DestinationPrefix
-        NextHop           = $NextHop 
+        NextHop           = $NextHop
     }
     if ($Route)
     {
@@ -89,7 +89,7 @@ function Get-TargetResource
         }
     }
 
-    $returnValue    
+    $returnValue
 } # Get-TargetResource
 
 function Set-TargetResource
@@ -104,11 +104,11 @@ function Set-TargetResource
         [Parameter(Mandatory)]
         [ValidateSet('IPv4', 'IPv6')]
         [String] $AddressFamily,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $DestinationPrefix,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $NextHop,
@@ -117,7 +117,7 @@ function Set-TargetResource
         [String] $Ensure = 'Present',
 
         [Uint16] $RouteMetric = 256,
-        
+
         [ValidateSet('No', 'Yes', 'Age')]
         [String] $Publish = 'No',
 
@@ -126,7 +126,7 @@ function Set-TargetResource
 
     # Remove any parameters that can't be splatted.
     $null = $PSBoundParameters.Remove('Ensure')
-    
+
     # Lookup the existing Route
     $Route = Get-Route @PSBoundParameters
 
@@ -144,7 +144,7 @@ function Set-TargetResource
             Set-NetRoute @PSBoundParameters `
                 -Confirm:$false `
                 -ErrorAction Stop
-                
+
 
             Write-Verbose -Message ( @(
                 "$($MyInvocation.MyCommand): "
@@ -176,10 +176,8 @@ function Set-TargetResource
         if ($Route)
         {
             # The Route exists - remove it
-            $null = $PSBoundParameters.Remove('InterfaceAlias')
-            $null = $PSBoundParameters.Remove('AddressFamily')
-            $null = $PSBoundParameters.Remove('DestinationPrefix')
-            $null = $PSBoundParameters.Remove('NextHop')
+            $null = $PSBoundParameters.Remove('Publish')
+            $null = $PSBoundParameters.Remove('PreferredLifetime')
 
             Remove-NetRoute @PSBoundParameters `
                 -Confirm:$false `
@@ -207,11 +205,11 @@ function Test-TargetResource
         [Parameter(Mandatory)]
         [ValidateSet('IPv4', 'IPv6')]
         [String] $AddressFamily,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $DestinationPrefix,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $NextHop,
@@ -220,7 +218,7 @@ function Test-TargetResource
         [String] $Ensure = 'Present',
 
         [Uint16] $RouteMetric = 256,
-        
+
         [ValidateSet('No', 'Yes', 'Age')]
         [String] $Publish = 'No',
 
@@ -241,7 +239,7 @@ function Test-TargetResource
 
     # Check the parameters
     Test-ResourceProperty @PSBoundParameters
-    
+
     # Lookup the existing Route
     $Route = Get-Route @PSBoundParameters
 
@@ -336,11 +334,11 @@ Function Get-Route {
         [Parameter(Mandatory)]
         [ValidateSet('IPv4', 'IPv6')]
         [String] $AddressFamily,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $DestinationPrefix,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $NextHop,
@@ -349,7 +347,7 @@ Function Get-Route {
         [String] $Ensure = 'Present',
 
         [Uint16] $RouteMetric = 256,
-        
+
         [ValidateSet('No', 'Yes', 'Age')]
         [String] $Publish = 'No',
 
@@ -391,11 +389,11 @@ Function Test-ResourceProperty {
         [Parameter(Mandatory)]
         [ValidateSet('IPv4', 'IPv6')]
         [String] $AddressFamily,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $DestinationPrefix,
-        
+
         [Parameter(Mandatory)]
         [ValidateNotNullOrEmpty()]
         [String] $NextHop,
@@ -404,13 +402,13 @@ Function Test-ResourceProperty {
         [String] $Ensure = 'Present',
 
         [Uint16] $RouteMetric = 256,
-        
+
         [ValidateSet('No', 'Yes', 'Age')]
         [String] $Publish = 'No',
 
         [Double] $PreferredLifetime
     )
-    
+
     # Validate the Adapter exists
     if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
     {
@@ -471,7 +469,7 @@ Function Test-ResourceProperty {
 
         $PSCmdlet.ThrowTerminatingError($errorRecord)
     }
-    
+
     # Validate the NextHop Parameter
     if (-not ([System.Net.Ipaddress]::TryParse($NextHop, [ref]0)))
     {
@@ -513,7 +511,7 @@ Function Test-ResourceProperty {
             -ArgumentList $exception, $errorId, $errorCategory, $null
 
         $PSCmdlet.ThrowTerminatingError($errorRecord)
-    }    
+    }
 }
 
 Export-ModuleMember -Function *-TargetResource

--- a/DSCResources/MSFT_xRoute/MSFT_xRoute.psm1
+++ b/DSCResources/MSFT_xRoute/MSFT_xRoute.psm1
@@ -175,7 +175,13 @@ function Set-TargetResource
 
         if ($Route)
         {
-            # The Route exists - remove it
+            <#
+            The Route exists - remove it
+            Use the parameters passed to Set-TargetResource to delete the appropriate route.
+            Clear the Publish and PreferredLifetime parameters so they aren't passed to the
+            Remove-NetRoute cmdlet.
+            #>
+
             $null = $PSBoundParameters.Remove('Publish')
             $null = $PSBoundParameters.Remove('PreferredLifetime')
 

--- a/README.md
+++ b/README.md
@@ -197,6 +197,8 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 * Changed AppVeyor.yml to use default image.
 * Fix xNetBios unit tests to work on default appveyor image.
 * Fix bug in xRoute when removing an existing route.
+* Updated xRoute integration tests to use v1.1.0 test header.
+* Extended xRoute integration tests to perform both add and remove route tests.
 
 ### 2.10.0.0
 

--- a/README.md
+++ b/README.md
@@ -196,6 +196,7 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 * Converted AppVeyor.yml to pull Pester from PSGallery instead of Chocolatey.
 * Changed AppVeyor.yml to use default image.
 * Fix xNetBios unit tests to work on default appveyor image.
+* Fix bug in xRoute when removing an existing route.
 
 ### 2.10.0.0
 

--- a/Tests/Integration/MSFT_xRoute.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xRoute.Integration.Tests.ps1
@@ -49,7 +49,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Ad_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Add_Config"}
             $current.InterfaceAlias    | Should Be $TestRoute.InterfaceAlias
             $current.AddressFamily     | Should Be $TestRoute.AddressFamily
             $current.DestinationPrefix | Should Be $TestRoute.DestinationPrefix
@@ -69,7 +69,7 @@ try
         NextHop                 = '11.0.1.0'
         RouteMetric             = 200
     }
-    New-NetRoute @DummyRoute
+    $null = New-NetRoute @DummyRoute
 
     $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName)_Remove.config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
@@ -89,14 +89,12 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Remove_Config"}
             $current.InterfaceAlias    | Should Be $TestRoute.InterfaceAlias
             $current.AddressFamily     | Should Be $TestRoute.AddressFamily
             $current.DestinationPrefix | Should Be $TestRoute.DestinationPrefix
             $current.NextHop           | Should Be $TestRoute.NextHop
             $current.Ensure            | Should Be 'Absent'
-            $current.RouteMetric       | Should Be $TestRoute.RouteMetric
-            $current.Publish           | Should Be $TestRoute.Publish
         }
 
         It 'Should not delete the dummy route' {
@@ -108,10 +106,10 @@ try
 finally
 {
     # Clean up any created routes just in case the integration tests fail
-    Remove-NetRoute @DummyRoute `
+    $null = Remove-NetRoute @DummyRoute `
         -Confirm:$false `
         -ErrorAction SilentlyContinue
-    Remove-NetRoute `
+    $null = Remove-NetRoute `
         -InterfaceAlias $TestRoute.InterfaceAlias `
         -AddressFamily $TestRoute.AddressFamily `
         -DestinationPrefix $TestRoute.DestinationPrefix `

--- a/Tests/Integration/MSFT_xRoute.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xRoute.Integration.Tests.ps1
@@ -1,36 +1,44 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xRoute'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xRoute'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $InterfaceAlias = (Get-NetAdapter -Physical | Select-Object -First 1).Name
+    $TestRoute = [PSObject]@{
+        InterfaceAlias          = $InterfaceAlias
+        AddressFamily           = 'IPv4'
+        DestinationPrefix       = '10.0.0.0/8'
+        NextHop                 = '10.0.1.0'
+        RouteMetric             = 200
+        Publish                 = 'No'
+    }
+
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName)_Add.config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Add_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Add_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -41,27 +49,76 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Ad_Config"}
             $current.InterfaceAlias    | Should Be $TestRoute.InterfaceAlias
             $current.AddressFamily     | Should Be $TestRoute.AddressFamily
             $current.DestinationPrefix | Should Be $TestRoute.DestinationPrefix
             $current.NextHop           | Should Be $TestRoute.NextHop
-            $current.Ensure            | Should Be $TestRoute.Ensure
+            $current.Ensure            | Should Be 'Present'
+            $current.RouteMetric       | Should Be $TestRoute.RouteMetric
+            $current.Publish           | Should Be $TestRoute.Publish
+        }
+    }
+
+    # This is a dummy route that will be added to ensure that only a specific route
+    # is deleted by the resource.
+    $DummyRoute = [PSObject]@{
+        InterfaceAlias          = $InterfaceAlias
+        AddressFamily           = 'IPv4'
+        DestinationPrefix       = '11.0.0.0/8'
+        NextHop                 = '11.0.1.0'
+        RouteMetric             = 200
+    }
+    New-NetRoute @DummyRoute
+
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName)_Remove.config.ps1"
+    . $ConfigFile -Verbose -ErrorAction Stop
+
+    Describe "$($script:DSCResourceName)_Remove_Integration" {
+        #region DEFAULT TESTS
+        It 'Should compile without throwing' {
+            {
+                & "$($script:DSCResourceName)_Remove_Config" -OutputPath $TestEnvironment.WorkingFolder
+                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+            } | Should not throw
+        }
+
+        It 'should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+
+        It 'Should have set the resource and all the parameters should match' {
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
+            $current.InterfaceAlias    | Should Be $TestRoute.InterfaceAlias
+            $current.AddressFamily     | Should Be $TestRoute.AddressFamily
+            $current.DestinationPrefix | Should Be $TestRoute.DestinationPrefix
+            $current.NextHop           | Should Be $TestRoute.NextHop
+            $current.Ensure            | Should Be 'Absent'
             $current.RouteMetric       | Should Be $TestRoute.RouteMetric
             $current.Publish           | Should Be $TestRoute.Publish
         }
 
-        Remove-NetRoute `
-            -InterfaceAlias $TestRoute.InterfaceAlias `
-            -AddressFamily $TestRoute.AddressFamily `
-            -DestinationPrefix $TestRoute.DestinationPrefix `
-            -NextHop $TestRoute.NextHop `
-            -Confirm:$false
+        It 'Should not delete the dummy route' {
+            Get-NetRoute @DummyRoute | Should Not BeNullOrEmpty
+        }
     }
     #endregion
 }
 finally
 {
+    # Clean up any created routes just in case the integration tests fail
+    Remove-NetRoute @DummyRoute `
+        -Confirm:$false `
+        -ErrorAction SilentlyContinue
+    Remove-NetRoute `
+        -InterfaceAlias $TestRoute.InterfaceAlias `
+        -AddressFamily $TestRoute.AddressFamily `
+        -DestinationPrefix $TestRoute.DestinationPrefix `
+        -NextHop $TestRoute.NextHop `
+        -Confirm:$false `
+        -ErrorAction SilentlyContinue
+
     #region FOOTER
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion

--- a/Tests/Integration/MSFT_xRoute_add.config.ps1
+++ b/Tests/Integration/MSFT_xRoute_add.config.ps1
@@ -1,16 +1,4 @@
-$TestRoute = [PSObject]@{
-    InterfaceAlias          = (Get-NetAdapter -Physical | Select-Object -First 1).Name
-    AddressFamily           = 'IPv4'
-    DestinationPrefix       = '10.0.0.0/8'
-    NextHop                 = '10.0.1.0'
-    Ensure                  = 'Present'
-    RouteMetric             = 200
-    Publish                 = 'No'
-}
-
-$route = Get-NetRoute | Select-Object -First 1
-
-configuration MSFT_xRoute_Config {
+configuration MSFT_xRoute_Add_Config {
     Import-DscResource -ModuleName xNetworking
     node localhost {
         xRoute Integration_Test {
@@ -18,7 +6,7 @@ configuration MSFT_xRoute_Config {
             AddressFamily           = $TestRoute.AddressFamily
             DestinationPrefix       = $TestRoute.DestinationPrefix
             NextHop                 = $TestRoute.NextHop
-            Ensure                  = $TestRoute.Ensure
+            Ensure                  = 'Present'
             RouteMetric             = $TestRoute.RouteMetric
             Publish                 = $TestRoute.Publish
         }

--- a/Tests/Integration/MSFT_xRoute_remove.config.ps1
+++ b/Tests/Integration/MSFT_xRoute_remove.config.ps1
@@ -1,0 +1,14 @@
+configuration MSFT_xRoute_Remove_Config {
+    Import-DscResource -ModuleName xNetworking
+    node localhost {
+        xRoute Integration_Test {
+            InterfaceAlias          = $TestRoute.InterfaceAlias
+            AddressFamily           = $TestRoute.AddressFamily
+            DestinationPrefix       = $TestRoute.DestinationPrefix
+            NextHop                 = $TestRoute.NextHop
+            Ensure                  = 'Absent'
+            RouteMetric             = $TestRoute.RouteMetric
+            Publish                 = $TestRoute.Publish
+        }
+    }
+}

--- a/Tests/Unit/MSFT_xRoute.Tests.ps1
+++ b/Tests/Unit/MSFT_xRoute.Tests.ps1
@@ -191,14 +191,14 @@ try
                 Mock Get-NetRoute -MockWith { $MockRoute }
                 Mock New-NetRoute
                 Mock Set-NetRoute
-                Mock Remove-NetRoute -ParameterFilter {
+                Mock Remove-NetRoute `
                     -ParameterFilter {
                         $InterfaceAlias = $TestRoute.InterfaceAlias;
                         $AddressFamily = $TestRoute.AddressFamily;
                         $DestinationPrefix = $TestRoute.DestinationPrefix;
                         $NextHop = $TestRoute.NextHop;
                         $RouteMetric = $TestRoute.RouteMetric;
-                    } `
+                    }
                 }
 
                 It 'should not throw error' {

--- a/Tests/Unit/MSFT_xRoute.Tests.ps1
+++ b/Tests/Unit/MSFT_xRoute.Tests.ps1
@@ -16,7 +16,7 @@ Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHel
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
+    -TestType Unit
 #endregion
 
 # Begin Testing
@@ -24,7 +24,7 @@ try
 {
     #region Pester Tests
     InModuleScope $Global:DSCResourceName {
-    
+
         # Create the Mock Objects that will be used for running tests
         $MockNetAdapter = [PSCustomObject] @{
             Name                    = 'Ethernet'
@@ -40,7 +40,7 @@ try
             Publish                 = 'Age'
             PreferredLifetime       = 50000
         }
-    
+
         $TestRouteKeys = [PSObject]@{
             InterfaceAlias          = $MockNetAdapter.Name
             AddressFamily           = $TestRoute.AddressFamily
@@ -58,13 +58,13 @@ try
             Publish                 = $TestRoute.Publish
             PreferredLifetime       = ([Timespan]::FromSeconds($TestRoute.PreferredLifetime))
         }
-    
+
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
-    
+
             Context 'Route does not exist' {
-                
+
                 Mock Get-NetRoute
-    
+
                 It 'should return absent Route' {
                     $Result = Get-TargetResource `
                         @TestRouteKeys
@@ -72,13 +72,13 @@ try
                 }
                 It 'should call the expected mocks' {
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
-                } 
+                }
             }
-    
+
             Context 'Route does exist' {
-                
+
                 Mock Get-NetRoute -MockWith { $MockRoute }
-    
+
                 It 'should return correct Route' {
                     $Result = Get-TargetResource `
                         @TestRouteKeys
@@ -96,18 +96,18 @@ try
                 }
             }
         }
-    
+
         Describe "$($Global:DSCResourceName)\Set-TargetResource" {
-    
+
             Context 'Route does not exist but should' {
-                
+
                 Mock Get-NetRoute
                 Mock New-NetRoute
                 Mock Set-NetRoute
                 Mock Remove-NetRoute
-    
+
                 It 'should not throw error' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         Set-TargetResource @Splat
                     } | Should Not Throw
@@ -119,16 +119,16 @@ try
                     Assert-MockCalled -commandName Remove-NetRoute -Exactly 0
                 }
             }
-    
+
             Context 'Route exists and should but has a different RouteMetric' {
-                
+
                 Mock Get-NetRoute -MockWith { $MockRoute }
                 Mock New-NetRoute
                 Mock Set-NetRoute
                 Mock Remove-NetRoute
-    
+
                 It 'should not throw error' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.RouteMetric = $Splat.RouteMetric + 10
                         Set-TargetResource @Splat
@@ -143,14 +143,14 @@ try
             }
 
             Context 'Route exists and should but has a different Publish' {
-                
+
                 Mock Get-NetRoute -MockWith { $MockRoute }
                 Mock New-NetRoute
                 Mock Set-NetRoute
                 Mock Remove-NetRoute
-    
+
                 It 'should not throw error' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.Publish = 'No'
                         Set-TargetResource @Splat
@@ -163,22 +163,22 @@ try
                     Assert-MockCalled -commandName Remove-NetRoute -Exactly 0
                 }
             }
-       
+
             Context 'Route exists and should but has a different PreferredLifetime' {
-                
+
                 Mock Get-NetRoute -MockWith { $MockRoute }
                 Mock New-NetRoute
                 Mock Set-NetRoute
                 Mock Remove-NetRoute
-    
+
                 It 'should not throw error' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.PreferredLifetime = $TestRoute.PreferredLifetime + 1000
                         Set-TargetResource @Splat
                     } | Should Not Throw
                 }
-                It 'should call expected Mocks' {
+                It 'should call expected mocks' {
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                     Assert-MockCalled -commandName New-NetRoute -Exactly 0
                     Assert-MockCalled -commandName Set-NetRoute -Exactly 1
@@ -187,36 +187,52 @@ try
             }
 
             Context 'Route exists and but should not' {
-                
+
                 Mock Get-NetRoute -MockWith { $MockRoute }
                 Mock New-NetRoute
                 Mock Set-NetRoute
-                Mock Remove-NetRoute
-    
+                Mock Remove-NetRoute -ParameterFilter {
+                    -ParameterFilter {
+                        $InterfaceAlias = $TestRoute.InterfaceAlias;
+                        $AddressFamily = $TestRoute.AddressFamily;
+                        $DestinationPrefix = $TestRoute.DestinationPrefix;
+                        $NextHop = $TestRoute.NextHop;
+                        $RouteMetric = $TestRoute.RouteMetric;
+                    } `
+                }
+
                 It 'should not throw error' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.Ensure = 'Absent'
                         Set-TargetResource @Splat
                     } | Should Not Throw
                 }
-                It 'should call expected Mocks' {
+                It 'should call expected mocks and parameters' {
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                     Assert-MockCalled -commandName New-NetRoute -Exactly 0
                     Assert-MockCalled -commandName Set-NetRoute -Exactly 0
-                    Assert-MockCalled -commandName Remove-NetRoute -Exactly 1
+                    Assert-MockCalled -commandName Remove-NetRoute `
+                        -ParameterFilter {
+                            $InterfaceAlias = $TestRoute.InterfaceAlias;
+                            $AddressFamily = $TestRoute.AddressFamily;
+                            $DestinationPrefix = $TestRoute.DestinationPrefix;
+                            $NextHop = $TestRoute.NextHop;
+                            $RouteMetric = $TestRoute.RouteMetric;
+                        } `
+                        -Exactly 1
                 }
             }
-    
+
             Context 'Route does not exist and should not' {
-                
+
                 Mock Get-NetRoute
                 Mock New-NetRoute
                 Mock Set-NetRoute
                 Mock Remove-NetRoute
-    
+
                 It 'should not throw error' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.Ensure = 'Absent'
                         Set-TargetResource @Splat
@@ -230,31 +246,31 @@ try
                 }
             }
         }
-    
+
         Describe "$($Global:DSCResourceName)\Test-TargetResource" {
 
             Context 'Route does not exist but should' {
-                
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
                 Mock Get-NetRoute
-    
+
                 It 'should return false' {
                     $Splat = $TestRoute.Clone()
                     Test-TargetResource @Splat | Should Be $False
-                    
+
                 }
                 It 'should call expected Mocks' {
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                 }
             }
-    
+
             Context 'Route exists and should but has a different RouteMetric' {
-                
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
                 Mock Get-NetRoute -MockWith { $MockRoute }
-    
+
                 It 'should return false' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.RouteMetric = $Splat.RouteMetric + 5
                         Test-TargetResource @Splat | Should Be $False
@@ -264,14 +280,14 @@ try
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                 }
             }
-    
+
             Context 'Route exists and should but has a different Publish' {
-                
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
                 Mock Get-NetRoute -MockWith { $MockRoute }
-    
+
                 It 'should return false' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.Publish = 'Yes'
                         Test-TargetResource @Splat | Should Be $False
@@ -283,12 +299,12 @@ try
             }
 
             Context 'Route exists and should but has a different PreferredLifetime' {
-                
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
                 Mock Get-NetRoute -MockWith { $MockRoute }
-    
+
                 It 'should return false' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.PreferredLifetime = $Splat.PreferredLifetime + 5000
                         Test-TargetResource @Splat | Should Be $False
@@ -300,12 +316,12 @@ try
             }
 
             Context 'Route exists and should and all parameters match' {
-                
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
                 Mock Get-NetRoute -MockWith { $MockRoute }
-    
+
                 It 'should return true' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         Test-TargetResource @Splat | Should Be $True
                     } | Should Not Throw
@@ -314,14 +330,14 @@ try
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                 }
             }
-    
+
             Context 'Route exists but should not' {
-                
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
                 Mock Get-NetRoute -MockWith { $MockRoute }
-    
+
                 It 'should return false' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.Ensure = 'Absent'
                     Test-TargetResource @Splat | Should Be $False
@@ -331,14 +347,14 @@ try
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                 }
             }
-    
+
             Context 'Route does not exist and should not' {
-                
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
                 Mock Get-NetRoute
-    
+
                 It 'should return true' {
-                    { 
+                    {
                         $Splat = $TestRoute.Clone()
                         $Splat.Ensure = 'Absent'
                         Test-TargetResource @Splat | Should Be $True
@@ -351,9 +367,9 @@ try
         }
 
         Describe "$($Global:DSCResourceName)\Test-ResourceProperty" {
-      
+
             Context 'invoking with bad interface alias' {
-    
+
                 Mock Get-NetAdapter
 
                 It 'should throw an InterfaceNotAvailable error' {
@@ -364,21 +380,21 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @TestRoute } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'invoking with bad IPv4 DestinationPrefix address' {
-    
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
 
                 It 'should throw an AddressFormatError error' {
                     $Splat = $TestRoute.Clone()
                     $Splat.DestinationPrefix = '10.0.300.0/24'
                     $Splat.NextHop = '10.0.1.0'
-                    $Splat.AddressFamily = 'IPv4'                    
-                    
+                    $Splat.AddressFamily = 'IPv4'
+
                     $errorId = 'AddressFormatError'
                     $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
                     $errorMessage = $($LocalizedData.AddressFormatError) -f '10.0.300.0'
@@ -386,13 +402,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-               
+
             Context 'invoking with bad IPv6 DestinationPrefix address' {
-    
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
 
                 It 'should throw an AddressFormatError error' {
@@ -408,13 +424,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'invoking with IPv4 DestinationPrefix mismatch' {
-    
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
 
                 It 'should throw an AddressIPv6MismatchError error' {
@@ -422,7 +438,7 @@ try
                     $Splat.DestinationPrefix = 'fe80::/64'
                     $Splat.NextHop = '10.0.1.0'
                     $Splat.AddressFamily = 'IPv4'
-                    
+
                     $errorId = 'AddressIPv6MismatchError'
                     $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
                     $errorMessage = $($LocalizedData.AddressIPv6MismatchError) -f 'fe80::','IPv4'
@@ -430,13 +446,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'invoking with IPv6 DestinationPrefix mismatch' {
-    
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
 
                 It 'should throw an AddressIPv4MismatchError error' {
@@ -444,7 +460,7 @@ try
                     $Splat.DestinationPrefix = '10.0.0.0/24'
                     $Splat.NextHop = 'fe81::'
                     $Splat.AddressFamily = 'IPv6'
-                    
+
                     $errorId = 'AddressIPv4MismatchError'
                     $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
                     $errorMessage = $($LocalizedData.AddressIPv4MismatchError) -f '10.0.0.0','IPv6'
@@ -452,13 +468,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'invoking with bad IPv4 NextHop address' {
-    
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
 
                 It 'should throw an AddressFormatError error' {
@@ -474,13 +490,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-               
+
             Context 'invoking with bad IPv6 NextHop address' {
-    
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
 
                 It 'should throw an AddressFormatError error' {
@@ -496,13 +512,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'invoking with IPv4 NextHop mismatch' {
-    
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
 
                 It 'should throw an AddressIPv6MismatchError error' {
@@ -510,7 +526,7 @@ try
                     $Splat.DestinationPrefix = '10.0.0.0/24'
                     $Splat.NextHop = 'fe90::'
                     $Splat.AddressFamily = 'IPv4'
-                                        
+
                     $errorId = 'AddressIPv6MismatchError'
                     $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
                     $errorMessage = $($LocalizedData.AddressIPv6MismatchError) -f 'fe90::','IPv4'
@@ -518,13 +534,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'invoking with IPv6 NextHop mismatch' {
-    
+
                 Mock Get-NetAdapter -MockWith { $MockNetAdapter }
 
                 It 'should throw an AddressIPv4MismatchError error' {
@@ -532,7 +548,7 @@ try
                     $Splat.DestinationPrefix = 'fe80::/64'
                     $Splat.NextHop = '10.0.1.0'
                     $Splat.AddressFamily = 'IPv6'
-                    
+
                     $errorId = 'AddressIPv4MismatchError'
                     $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
                     $errorMessage = $($LocalizedData.AddressIPv4MismatchError) -f '10.0.1.0','IPv6'
@@ -540,7 +556,7 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }

--- a/Tests/Unit/MSFT_xRoute.Tests.ps1
+++ b/Tests/Unit/MSFT_xRoute.Tests.ps1
@@ -193,11 +193,11 @@ try
                 Mock Set-NetRoute
                 Mock Remove-NetRoute `
                     -ParameterFilter {
-                        $InterfaceAlias = $TestRoute.InterfaceAlias;
-                        $AddressFamily = $TestRoute.AddressFamily;
-                        $DestinationPrefix = $TestRoute.DestinationPrefix;
-                        $NextHop = $TestRoute.NextHop;
-                        $RouteMetric = $TestRoute.RouteMetric;
+                        InterfaceAlias = $TestRoute.InterfaceAlias -and `
+                        AddressFamily = $TestRoute.AddressFamily -and `
+                        DestinationPrefix = $TestRoute.DestinationPrefix -and `
+                        NextHop = $TestRoute.NextHop -and `
+                        RouteMetric = $TestRoute.RouteMetric
                     }
                 }
 
@@ -214,11 +214,11 @@ try
                     Assert-MockCalled -commandName Set-NetRoute -Exactly 0
                     Assert-MockCalled -commandName Remove-NetRoute `
                         -ParameterFilter {
-                            $InterfaceAlias = $TestRoute.InterfaceAlias;
-                            $AddressFamily = $TestRoute.AddressFamily;
-                            $DestinationPrefix = $TestRoute.DestinationPrefix;
-                            $NextHop = $TestRoute.NextHop;
-                            $RouteMetric = $TestRoute.RouteMetric;
+                            InterfaceAlias = $TestRoute.InterfaceAlias -and `
+                            AddressFamily = $TestRoute.AddressFamily -and `
+                            DestinationPrefix = $TestRoute.DestinationPrefix -and `
+                            NextHop = $TestRoute.NextHop -and `
+                            RouteMetric = $TestRoute.RouteMetric
                         } `
                         -Exactly 1
                 }

--- a/Tests/Unit/MSFT_xRoute.Tests.ps1
+++ b/Tests/Unit/MSFT_xRoute.Tests.ps1
@@ -193,11 +193,11 @@ try
                 Mock Set-NetRoute
                 Mock Remove-NetRoute `
                     -ParameterFilter {
-                        (InterfaceAlias -eq $TestRoute.InterfaceAlias) -and `
-                        (AddressFamily -eq $TestRoute.AddressFamily) -and `
-                        (DestinationPrefix -eq $TestRoute.DestinationPrefix) -and `
-                        (NextHop -eq $TestRoute.NextHop) -and `
-                        (RouteMetric -eq $TestRoute.RouteMetric)
+                        ($InterfaceAlias -eq $TestRoute.InterfaceAlias) -and `
+                        ($AddressFamily -eq $TestRoute.AddressFamily) -and `
+                        ($DestinationPrefix -eq $TestRoute.DestinationPrefix) -and `
+                        ($NextHop -eq $TestRoute.NextHop) -and `
+                        ($RouteMetric -eq $TestRoute.RouteMetric)
                     }
 
                 It 'should not throw error' {
@@ -213,11 +213,11 @@ try
                     Assert-MockCalled -commandName Set-NetRoute -Exactly 0
                     Assert-MockCalled -commandName Remove-NetRoute `
                         -ParameterFilter {
-                            (InterfaceAlias -eq $TestRoute.InterfaceAlias) -and `
-                            (AddressFamily -eq $TestRoute.AddressFamily) -and `
-                            (DestinationPrefix -eq $TestRoute.DestinationPrefix) -and `
-                            (NextHop -eq $TestRoute.NextHop) -and `
-                            (RouteMetric -eq $TestRoute.RouteMetric)
+                            ($InterfaceAlias -eq $TestRoute.InterfaceAlias) -and `
+                            ($AddressFamily -eq $TestRoute.AddressFamily) -and `
+                            ($DestinationPrefix -eq $TestRoute.DestinationPrefix) -and `
+                            ($NextHop -eq $TestRoute.NextHop) -and `
+                            ($RouteMetric -eq $TestRoute.RouteMetric)
                         } `
                         -Exactly 1
                 }

--- a/Tests/Unit/MSFT_xRoute.Tests.ps1
+++ b/Tests/Unit/MSFT_xRoute.Tests.ps1
@@ -193,13 +193,12 @@ try
                 Mock Set-NetRoute
                 Mock Remove-NetRoute `
                     -ParameterFilter {
-                        InterfaceAlias = $TestRoute.InterfaceAlias -and `
-                        AddressFamily = $TestRoute.AddressFamily -and `
-                        DestinationPrefix = $TestRoute.DestinationPrefix -and `
-                        NextHop = $TestRoute.NextHop -and `
-                        RouteMetric = $TestRoute.RouteMetric
+                        (InterfaceAlias -eq $TestRoute.InterfaceAlias) -and `
+                        (AddressFamily -eq $TestRoute.AddressFamily) -and `
+                        (DestinationPrefix -eq $TestRoute.DestinationPrefix) -and `
+                        (NextHop -eq $TestRoute.NextHop) -and `
+                        (RouteMetric -eq $TestRoute.RouteMetric)
                     }
-                }
 
                 It 'should not throw error' {
                     {
@@ -214,11 +213,11 @@ try
                     Assert-MockCalled -commandName Set-NetRoute -Exactly 0
                     Assert-MockCalled -commandName Remove-NetRoute `
                         -ParameterFilter {
-                            InterfaceAlias = $TestRoute.InterfaceAlias -and `
-                            AddressFamily = $TestRoute.AddressFamily -and `
-                            DestinationPrefix = $TestRoute.DestinationPrefix -and `
-                            NextHop = $TestRoute.NextHop -and `
-                            RouteMetric = $TestRoute.RouteMetric
+                            (InterfaceAlias -eq $TestRoute.InterfaceAlias) -and `
+                            (AddressFamily -eq $TestRoute.AddressFamily) -and `
+                            (DestinationPrefix -eq $TestRoute.DestinationPrefix) -and `
+                            (NextHop -eq $TestRoute.NextHop) -and `
+                            (RouteMetric -eq $TestRoute.RouteMetric)
                         } `
                         -Exactly 1
                 }


### PR DESCRIPTION
This PR fixes the Route Removal failure in xRoute as reported in #134.

I have included better unit tests for this to prevent regression.

Sorry about all the removal of end of line spaces - I have VS Code set to trim lines.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/137)
<!-- Reviewable:end -->
