### PR TITLE
Update Unit & Integration Tests to use v1.1.0 Template - FIxes #141

### DIFF
--- a/README.md
+++ b/README.md
@@ -198,8 +198,9 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
     * MSFT_xNetAdapterBinding.Integration.Tests.ps1
 * Updated all integration tests to use v1.1.0 header and script variable context.
 * Updated all unit tests to use v1.1.0 header and script variable context.
-* Removed unneccessary global variable from MSFT_xNetworkTeam.integration.tests.ps1
+* Removed uneccessary global variable from MSFT_xNetworkTeam.integration.tests.ps1
 * Converted Invoke-Expression in all integration tests to &.
+* Fixed unit test description in xNetworkAdapter.Tests.ps1
 
 ### 2.11.0.0
 * Added the following resources:

--- a/README.md
+++ b/README.md
@@ -191,6 +191,15 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 ## Versions
 
 ### Unreleased
+* Corrected integration test filenames:
+    * MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
+    * MSFT_xDhcpClient.Integration.Tests.ps1
+    * MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
+    * MSFT_xNetAdapterBinding.Integration.Tests.ps1
+* Updated all integration tests to use v1.1.0 header and script variable context.
+* Updated all unit tests to use v1.1.0 header and script variable context.
+* Removed unneccessary global variable from MSFT_xNetworkTeam.integration.tests.ps1
+* Converted Invoke-Expression in all integration tests to &.
 
 ### 2.11.0.0
 * Added the following resources:

--- a/Tests/Integration/MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
@@ -1,22 +1,20 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xDnsConnectionSuffix'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xDnsConnectionSuffix'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Configure Loopback Adapter
@@ -27,14 +25,14 @@ New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -45,7 +43,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $current.InterfaceAlias                 | Should Be $TestDnsConnectionSuffix.InterfaceAlias
             $current.ConnectionSpecificSuffix       | Should Be $TestDnsConnectionSuffix.ConnectionSpecificSuffix
             $current.RegisterThisConnectionsAddress | Should Be $TestDnsConnectionSuffix.RegisterThisConnectionsAddress

--- a/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
@@ -1,22 +1,20 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xDNSServerAddress'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xDNSServerAddress'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Configure Loopback Adapter
@@ -27,14 +25,14 @@ New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -45,7 +43,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $current.InterfaceAlias             | Should Be $TestDNSServerAddress.InterfaceAlias
             $current.AddressFamily              | Should Be $TestDNSServerAddress.AddressFamily
             $current.Address                    | Should Be $TestDNSServerAddress.Address

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
@@ -1,22 +1,20 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xDefaultGatewayAddress'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xDefaultGatewayAddress'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Configure Loopback Adapter
@@ -27,14 +25,14 @@ New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -45,7 +43,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $current.InterfaceAlias           | Should Be $TestDefaultGatewayAddress.InterfaceAlias
             $current.AddressFamily            | Should Be $TestDefaultGatewayAddress.AddressFamily
             $current.Address                  | Should Be $TestDefaultGatewayAddress.Address

--- a/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
@@ -1,22 +1,20 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xDhcpClient'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xDhcpClient'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Configure Loopback Adapter
@@ -27,14 +25,14 @@ New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -45,7 +43,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $current.InterfaceAlias           | Should Be $TestDhcpClient.InterfaceAlias
             $current.AddressFamily            | Should Be $TestDhcpClient.AddressFamily
             $current.State                    | Should Be $TestDhcpClient.State

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
@@ -1,19 +1,19 @@
-$Global:DSCModuleName   = 'xNetworking'
-$Global:DSCResourceName = 'MSFT_xDnsClientGlobalSetting'
+$script:DSCModuleName   = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xDnsClientGlobalSetting'
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Integration
 #endregion
 
@@ -30,14 +30,14 @@ try
         -DevolutionLevel 4
 
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }

--- a/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
@@ -1,36 +1,34 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xFirewall'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xFirewall'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -60,7 +58,7 @@ try
                 $ParameterSource = (Invoke-Expression -Command "`$($($parameters.source))")
                 $ParameterNew = (Invoke-Expression -Command "`$rule.$($parameters.name)")
                 $ParameterSource | Should Be $ParameterNew
-            }           
+            }
         }
 
         # Cleanup the Rule

--- a/Tests/Integration/MSFT_xHostsFile.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostsFile.Integration.Tests.ps1
@@ -1,37 +1,36 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xHostsFile'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xHostsFile'
 
 Copy-Item "${env:SystemRoot}\System32\Drivers\Etc\Hosts" "${env:Temp}\Hosts" -Force
 
 #region HEADER
-if ( (-not (Test-Path -Path '.\DSCResource.Tests\')) -or `
-     (-not (Test-Path -Path '.\DSCResource.Tests\TestHelper.psm1')) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path (Get-Location) -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module .\DSCResource.Tests\TestHelper.psm1 -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -43,7 +42,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $result = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $result = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $result.Ensure                 | Should Be $HostEntry.Ensure
             $result.HostName               | Should Be $HostEntry.HostName
             $result.IPAddress              | Should Be $HostEntry.IPAddress

--- a/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
@@ -1,22 +1,20 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xIPAddress'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xIPAddress'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Configure Loopback Adapter
@@ -27,14 +25,14 @@ New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -45,7 +43,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $current.InterfaceAlias             | Should Be $TestIPAddress.InterfaceAlias
             $current.AddressFamily              | Should Be $TestIPAddress.AddressFamily
             $current.IPAddress                  | Should Be $TestIPAddress.IPAddress

--- a/Tests/Integration/MSFT_xNetAdapterBinding.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterBinding.Integration.Tests.ps1
@@ -1,19 +1,19 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xNetAdapterBinding'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xNetAdapterBinding'
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Integration
 #endregion
 
@@ -25,14 +25,14 @@ New-IntegrationLoopbackAdapter -AdapterName 'xNetworkingLBA'
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -43,7 +43,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $current.InterfaceAlias           | Should Be $TestDisableIPv4.InterfaceAlias
             $current.ComponentId              | Should Be $TestDisableIPv4.ComponentId
             $current.State                    | Should Be $TestDisableIPv4.State

--- a/Tests/Integration/MSFT_xNetBIOS.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetBIOS.Integration.Tests.ps1
@@ -1,36 +1,34 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xNetBIOS'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xNetBIOS'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -41,7 +39,7 @@ try
         #endregion
 
         It 'Should have set the resource and all setting should match current state' {
-            $Live = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $Live = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $Live.Setting | should be $Current #Current is defined in MSFT_NetBIOS.config.ps1
         }
     }

--- a/Tests/Integration/MSFT_xNetConnectionProfile.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetConnectionProfile.Integration.Tests.ps1
@@ -1,36 +1,34 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xNetConnectionProfile'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xNetConnectionProfile'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -41,7 +39,7 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $rule.InterfaceAlias   | Should Be $current.InterfaceAlias
             $rule.NetworkCategory  | Should Be $current.NetworkCategory
             $rule.IPv4Connectivity | Should Be $current.IPv4Connectivity

--- a/Tests/Integration/MSFT_xNetworkTeam.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeam.Integration.Tests.ps1
@@ -1,39 +1,39 @@
 #Remove this following line before using this integration test script
 return
 
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xNetworkTeam'
-$Global:teamMembers        = (Get-NetAdapter -Physical).Name
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xNetworkTeam'
 
 #region HEADER
-if ( (-not (Test-Path -Path '.\DSCResource.Tests\')) -or `
-     (-not (Test-Path -Path '.\DSCResource.Tests\TestHelper.psm1')) )
+# Integration Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git')
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path (Get-Location) -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module .\DSCResource.Tests\TestHelper.psm1 -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
 #endregion
 
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $teamMembers = (Get-NetAdapter -Physical).Name
+
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
                 Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -45,10 +45,10 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $result = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $result = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $result.Ensure                 | Should Be $TestTeam.Ensure
             $result.Name                   | Should Be $TestTeam.Name
-            $result.TeamMembers            | Should Be $Global:teamMembers
+            $result.TeamMembers            | Should Be $teamMembers
             $result.loadBalancingAlgorithm | Should Be $TestTeam.loadBalancingAlgorithm
             $result.teamingMode            | Should Be $TestTeam.teamingMode
         }

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -1,39 +1,35 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xDNSServerAddress'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xDNSServerAddress'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
-#endregion
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
 
 # Begin Testing
 try
 {
-
     #region Pester Tests
+    InModuleScope $script:DSCResourceName {
 
-    InModuleScope $Global:DSCResourceName {
+        Describe "MSFT_xDNSServerAddress\Get-TargetResource" {
 
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
-    
             # Test IPv4
-    
+
             #region Mocks
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = '192.168.0.1'
                     InterfaceAlias = 'Ethernet'
@@ -41,10 +37,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'invoking with an IPv4 address' {
                 It 'should return true' {
-    
+
                     $Splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
@@ -54,12 +50,12 @@ try
                     $Result.IPAddress | Should Be $Splat.IPAddress
                 }
             }
-    
-            # Test IPv6 
-    
+
+            # Test IPv6
+
             #region Mocks
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = 'fe80:ab04:30F5:002b::1'
                     InterfaceAlias = 'Ethernet'
@@ -67,10 +63,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'invoking with an IPv6 address' {
                 It 'should return true' {
-    
+
                     $Splat = @{
                         Address = 'fe80:ab04:30F5:002b::1'
                         InterfaceAlias = 'Ethernet'
@@ -81,14 +77,14 @@ try
                 }
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
-    
+
+        Describe "MSFT_xDNSServerAddress\Set-TargetResource" {
+
             # Test IPv4
-    
+
             #region Mocks
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = @('192.168.0.1')
                     InterfaceAlias = 'Ethernet'
@@ -98,10 +94,10 @@ try
             Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
             Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
             #endregion
-    
+
             Context 'invoking with single IPv4 Server Address that is the same as current' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.1')
                         InterfaceAlias = 'Ethernet'
@@ -117,7 +113,7 @@ try
             }
             Context 'invoking with single IPv4 Server Address that is different to current' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.2')
                         InterfaceAlias = 'Ethernet'
@@ -133,7 +129,7 @@ try
             }
             Context 'invoking with single IPv4 Server Address that is different to current and validate true' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.2')
                         InterfaceAlias = 'Ethernet'
@@ -147,10 +143,10 @@ try
                     Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $true }
                     Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
                 }
-            }        
+            }
             Context 'invoking with multiple IPv4 Server Addresses that are different to current' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.2','192.168.0.3')
                         InterfaceAlias = 'Ethernet'
@@ -164,10 +160,10 @@ try
                     Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
                 }
             }
-    
+
             #region Mocks
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = @()
                     InterfaceAlias = 'Ethernet'
@@ -175,10 +171,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'invoking with multiple IPv4 Server Addresses When there are no address assiged' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.2','192.168.0.3')
                         InterfaceAlias = 'Ethernet'
@@ -192,12 +188,12 @@ try
                     Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
                 }
             }
-    
-            # Test IPv6 
-    
+
+            # Test IPv6
+
             #region Mocks
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = @('fe80:ab04:30F5:002b::1')
                     InterfaceAlias = 'Ethernet'
@@ -207,10 +203,10 @@ try
             Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
             Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
             #endregion
-    
+
             Context 'invoking with single IPv6 Server Address that is the same as current' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::1')
                         InterfaceAlias = 'Ethernet'
@@ -226,7 +222,7 @@ try
             }
             Context 'invoking with single IPv6 Server Address that is different to current' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::2')
                         InterfaceAlias = 'Ethernet'
@@ -242,7 +238,7 @@ try
             }
             Context 'invoking with single IPv6 Server Address that is different to current and validate true' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::2')
                         InterfaceAlias = 'Ethernet'
@@ -259,7 +255,7 @@ try
             }
             Context 'invoking with multiple IPv6 Server Addresses that are different to current' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
                         InterfaceAlias = 'Ethernet'
@@ -273,10 +269,10 @@ try
                     Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
                 }
             }
-    
+
             #region Mocks
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = @()
                     InterfaceAlias = 'Ethernet'
@@ -284,10 +280,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'invoking with multiple IPv6 Server Addresses When there are no address assiged' {
                 It 'should not throw an exception' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::1')
                         InterfaceAlias = 'Ethernet'
@@ -302,15 +298,15 @@ try
                 }
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
-    
-            # Test IPv4 
-    
+
+        Describe "MSFT_xDNSServerAddress\Test-TargetResource" {
+
+            # Test IPv4
+
             #region Mocks
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = @('192.168.0.1')
                     InterfaceAlias = 'Ethernet'
@@ -318,10 +314,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'invoking with single IPv4 Server Address that is the same as current' {
                 It 'should return true' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.1')
                         InterfaceAlias = 'Ethernet'
@@ -335,7 +331,7 @@ try
             }
             Context 'invoking with single IPv4 Server Address that is different to current' {
                 It 'should return false' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.2')
                         InterfaceAlias = 'Ethernet'
@@ -349,7 +345,7 @@ try
             }
             Context 'invoking with multiple IPv4 Server Addresses that are different to current' {
                 It 'should return false' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.2','192.168.0.3')
                         InterfaceAlias = 'Ethernet'
@@ -361,11 +357,11 @@ try
                     Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
                 }
             }
-    
+
             #region Mocks
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = @()
                     InterfaceAlias = 'Ethernet'
@@ -373,10 +369,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'invoking with multiple IPv4 Server Addresses that are no addresses assigned' {
                 It 'should return false' {
-    
+
                     $Splat = @{
                         Address = @('192.168.0.2','192.168.0.3')
                         InterfaceAlias = 'Ethernet'
@@ -388,13 +384,13 @@ try
                     Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
                 }
             }
-    
-            # Test IPv6 
-    
+
+            # Test IPv6
+
             #region Mocks
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = @('fe80:ab04:30F5:002b::1')
                     InterfaceAlias = 'Ethernet'
@@ -402,10 +398,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'invoking with single IPv6 Server Address that is the same as current' {
                 It 'should return true' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::1')
                         InterfaceAlias = 'Ethernet'
@@ -419,7 +415,7 @@ try
             }
             Context 'invoking with single IPv6 Server Address that is different to current' {
                 It 'should return false' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::2')
                         InterfaceAlias = 'Ethernet'
@@ -433,7 +429,7 @@ try
             }
             Context 'invoking with multiple IPv6 Server Addresses that are different to current' {
                 It 'should return false' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
                         InterfaceAlias = 'Ethernet'
@@ -445,11 +441,11 @@ try
                     Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
                 }
             }
-    
+
             #region Mocks
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
             Mock Get-DnsClientServerAddress -MockWith {
-    
+
                 [PSCustomObject]@{
                     ServerAddresses = @()
                     InterfaceAlias = 'Ethernet'
@@ -457,10 +453,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'invoking with multiple IPv6 Server Addresses that are no addresses assigned' {
                 It 'should return false' {
-    
+
                     $Splat = @{
                         Address = @('fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2')
                         InterfaceAlias = 'Ethernet'
@@ -472,15 +468,15 @@ try
                     Assert-MockCalled -commandName Get-DnsClientServerAddress -Exactly 1
                 }
             }
-    
+
         }
-    
-        Describe "$($Global:DSCResourceName)\Test-ResourceProperty" {
-    
+
+        Describe "MSFT_xDNSServerAddress\Test-ResourceProperty" {
+
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-    
+
             Context 'invoking with bad interface alias' {
-    
+
                 It 'should throw an InterfaceNotAvailable error' {
                     $Splat = @{
                         Address = '192.168.0.1'
@@ -494,13 +490,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-    
+
             Context 'invoking with invalid IP Address' {
-    
+
                 It 'should throw an AddressFormatError error' {
                     $Splat = @{
                         Address = 'NotReal'
@@ -514,13 +510,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-    
+
             Context 'invoking with IPv4 Address and family mismatch' {
-    
+
                 It 'should throw an AddressMismatchError error' {
                     $Splat = @{
                         Address = '192.168.0.1'
@@ -534,13 +530,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-    
+
             Context 'invoking with IPv6 Address and family mismatch' {
-    
+
                 It 'should throw an AddressMismatchError error' {
                     $Splat = @{
                         Address = 'fe80::'
@@ -554,13 +550,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-    
+
             Context 'invoking with valid IPv4 Addresses' {
-    
+
                 It 'should not throw an error' {
                     $Splat = @{
                         Address = '192.168.0.1'
@@ -570,9 +566,9 @@ try
                     { Test-ResourceProperty @Splat } | Should Not Throw
                 }
             }
-    
+
             Context 'invoking with valid IPv6 Addresses' {
-    
+
                 It 'should not throw an error' {
                     $Splat = @{
                         Address = 'fe80:ab04:30F5:002b::1'
@@ -583,7 +579,7 @@ try
                 }
             }
         }
-        
+
     } #end InModuleScope $DSCResourceName
     #endregion
 }

--- a/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -1,5 +1,5 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xDefaultGatewayAddress'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xDefaultGatewayAddress'
 
 #region HEADER
 [String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
@@ -14,21 +14,19 @@ else
 }
 Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
 #endregion
 
 # Begin Testing
 try
 {
-
     #region Pester Tests
+    InModuleScope $script:DSCResourceName {
 
-    InModuleScope $Global:DSCResourceName {
+        Describe "MSFT_xDefaultGatewayAddress\Get-TargetResource" {
 
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
-    
             #region Mocks
             Mock Get-NetRoute -MockWith {
                 [PSCustomObject]@{
@@ -40,10 +38,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'checking return with default gateway' {
                 It 'should return current default gateway' {
-    
+
                     $Splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
@@ -52,14 +50,14 @@ try
                     $Result.Address | Should Be '192.168.0.1'
                 }
             }
-    
+
             #region Mocks
             Mock Get-NetRoute -MockWith {}
             #endregion
-    
+
             Context 'checking return with no default gateway' {
                 It 'should return no default gateway' {
-    
+
                     $Splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
@@ -69,9 +67,9 @@ try
                 }
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
-    
+
+        Describe "MSFT_xDefaultGatewayAddress\Set-TargetResource" {
+
             #region Mocks
             Mock Get-NetRoute -MockWith {
                 [PSCustomObject]@{
@@ -82,12 +80,12 @@ try
                     AddressFamily = 'IPv4'
                 }
             }
-    
+
             Mock Remove-NetRoute
-    
+
             Mock New-NetRoute
             #endregion
-    
+
             Context 'invoking with no Default Gateway Address' {
                 It 'should return $null' {
                     $Splat = @{
@@ -97,14 +95,14 @@ try
                     { $Result = Set-TargetResource @Splat } | Should Not Throw
                     $Result | Should BeNullOrEmpty
                 }
-    
+
                 It 'should call all the mocks' {
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                     Assert-MockCalled -commandName Remove-NetRoute -Exactly 1
                     Assert-MockCalled -commandName New-NetRoute -Exactly 0
                 }
             }
-    
+
             Context 'invoking with valid Default Gateway Address' {
                 It 'should return $null' {
                     $Splat = @{
@@ -115,7 +113,7 @@ try
                     { $Result = Set-TargetResource @Splat } | Should Not Throw
                     $Result | Should BeNullOrEmpty
                 }
-    
+
                 It 'should call all the mocks' {
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                     Assert-MockCalled -commandName Remove-NetRoute -Exactly 1
@@ -123,12 +121,12 @@ try
                 }
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
-    
+
+        Describe "MSFT_xDefaultGatewayAddress\Test-TargetResource" {
+
             #region Mocks
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-    
+
             Mock Get-NetRoute -MockWith {
                 [PSCustomObject]@{
                     NextHop = '192.168.0.1'
@@ -139,10 +137,10 @@ try
                 }
             }
             #endregion
-    
+
             Context 'checking return with default gateway that matches currently set one' {
                 It 'should return true' {
-    
+
                     $Splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
@@ -151,10 +149,10 @@ try
                     Test-TargetResource @Splat | Should Be $True
                 }
             }
-    
+
             Context 'checking return with no gateway but one is currently set' {
                 It 'should return false' {
-    
+
                     $Splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
@@ -162,14 +160,14 @@ try
                     Test-TargetResource @Splat | Should Be $False
                 }
             }
-    
+
             #region Mocks
             Mock Get-NetRoute -MockWith {}
             #endregion
-    
+
             Context 'checking return with default gateway but none are currently set' {
                 It 'should return false' {
-    
+
                     $Splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
@@ -178,10 +176,10 @@ try
                     Test-TargetResource @Splat | Should Be $False
                 }
             }
-    
+
             Context 'checking return with no gateway and none are currently set' {
                 It 'should return true' {
-    
+
                     $Splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
@@ -190,13 +188,13 @@ try
                 }
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Test-ResourceProperty" {
-    
+
+        Describe "MSFT_xDefaultGatewayAddress\Test-ResourceProperty" {
+
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-    
+
             Context 'invoking with bad interface alias' {
-    
+
                 It 'should throw an InterfaceNotAvailable error' {
                     $Splat = @{
                         Address = '192.168.0.1'
@@ -210,13 +208,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-    
+
             Context 'invoking with invalid IP Address' {
-    
+
                 It 'should throw an AddressFormatError error' {
                     $Splat = @{
                         Address = 'NotReal'
@@ -230,13 +228,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-    
+
             Context 'invoking with IPv4 Address and family mismatch' {
-    
+
                 It 'should throw an AddressMismatchError error' {
                     $Splat = @{
                         Address = '192.168.0.1'
@@ -250,13 +248,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-    
+
             Context 'invoking with IPv6 Address and family mismatch' {
-    
+
                 It 'should throw an AddressMismatchError error' {
                     $Splat = @{
                         Address = 'fe80::'
@@ -270,13 +268,13 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @Splat } | Should Throw $ErrorRecord
                 }
             }
-    
+
             Context 'invoking with valid IPv4 Address' {
-    
+
                 It 'should not throw an error' {
                     $Splat = @{
                         Address = '192.168.0.1'
@@ -286,9 +284,9 @@ try
                     { Test-ResourceProperty @Splat } | Should Not Throw
                 }
             }
-    
+
             Context 'invoking with valid IPv6 Address' {
-    
+
                 It 'should not throw an error' {
                     $Splat = @{
                         Address = 'fe80:ab04:30F5:002b::1'

--- a/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
+++ b/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
@@ -1,31 +1,27 @@
-﻿$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xDhcpClient'
+﻿$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xDhcpClient'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
-#endregion
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
 
 # Begin Testing
 try
 {
-
     #region Pester Tests
-
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
 
         # Create the Mock Objects that will be used for running tests
         $MockNetAdapter = [PSCustomObject] @{
@@ -56,11 +52,11 @@ try
             AddressFamily           = $TestNetIPInterfaceDisabled.AddressFamily
         }
 
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
-    
+        Describe "MSFT_xDhcpClient\Get-TargetResource" {
+
             Mock Get-NetAdapter -MockWith { $MockNetAdapter }
             Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceEnabled }
-    
+
             Context 'invoking with when DHCP is enabled' {
                 It 'should return DHCP state of enabled' {
                     $Result = Get-TargetResource @TestNetIPInterfaceEnabled
@@ -71,11 +67,11 @@ try
                 It 'should call all the mocks' {
                     Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
                     Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
-                }                
+                }
             }
-    
+
             Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceDisabled }
-    
+
             Context 'invoking with when DHCP is disabled' {
                 It 'should return DHCP state of disabled' {
                     $Result = Get-TargetResource @TestNetIPInterfaceDisabled
@@ -86,17 +82,17 @@ try
                 It 'should call all the mocks' {
                     Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
                     Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
-                }                
+                }
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
-    
+
+        Describe "MSFT_xDhcpClient\Set-TargetResource" {
+
             Mock Get-NetAdapter -MockWith { $MockNetAdapter }
             Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceDisabled }
             Mock Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Enabled' }
             Mock Set-NetIPInterface -ParameterFilter { $dhcp -eq 'Disabled' }
-    
+
             Context 'invoking with state enabled but DHCP is currently disabled' {
                 It 'should not throw an exception' {
                     { Set-TargetResource @TestNetIPInterfaceEnabled } | Should Not Throw
@@ -147,12 +143,12 @@ try
                 }
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
-    
+
+        Describe "MSFT_xDhcpClient\Test-TargetResource" {
+
             Mock Get-NetAdapter -MockWith { $MockNetAdapter }
             Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceDisabled }
-    
+
             Context 'invoking with state enabled but DHCP is currently disabled' {
                 It 'should return false' {
                     Test-TargetResource @TestNetIPInterfaceEnabled | Should Be $False
@@ -161,7 +157,7 @@ try
                     Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
                     Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
                 }
-            }    
+            }
 
             Context 'invoking with state disabled and DHCP is currently disabled' {
                 It 'should return true' {
@@ -171,7 +167,7 @@ try
                     Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
                     Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
                 }
-            }    
+            }
 
             Mock Get-NetIPInterface -MockWith { $MockNetIPInterfaceEnabled }
 
@@ -183,7 +179,7 @@ try
                     Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
                     Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
                 }
-            }    
+            }
 
             Context 'invoking with state disabled but DHCP is currently enabled' {
                 It 'should return false' {
@@ -193,15 +189,15 @@ try
                     Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
                     Assert-MockCalled -commandName Get-NetIPInterface -Exactly 1
                 }
-            }    
+            }
         }
-    
-        Describe "$($Global:DSCResourceName)\Test-ResourceProperty" {
-    
+
+        Describe "MSFT_xDhcpClient\Test-ResourceProperty" {
+
             Mock Get-NetAdapter
-    
+
             Context 'invoking with bad interface alias' {
-    
+
                 It 'should throw an InterfaceNotAvailable error' {
                     $errorId = 'InterfaceNotAvailable'
                     $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
@@ -210,7 +206,7 @@ try
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
                         -ArgumentList $exception, $errorId, $errorCategory, $null
-    
+
                     { Test-ResourceProperty @TestNetIPInterfaceEnabled } | Should Throw $ErrorRecord
                 }
             }

--- a/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
@@ -1,19 +1,19 @@
-$Global:DSCModuleName   = 'xNetworking'
-$Global:DSCResourceName = 'MSFT_xDnsClientGlobalSetting'
+$script:DSCModuleName   = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xDnsClientGlobalSetting'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 #endregion HEADER
 
@@ -21,7 +21,7 @@ $TestEnvironment = Initialize-TestEnvironment `
 try
 {
     #region Pester Tests
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
 
         # Create the Mock Objects that will be used for running tests
         $DnsClientGlobalSettings = [PSObject]@{
@@ -36,7 +36,7 @@ try
             UseDevolution                = $DnsClientGlobalSettings.UseDevolution
         }
 
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+        Describe "MSFT_xDnsClientGlobalSetting\Get-TargetResource" {
 
             Context 'DNS Client Global Settings Exists' {
 
@@ -54,7 +54,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+        Describe "MSFT_xDnsClientGlobalSetting\Set-TargetResource" {
 
             Mock Get-DnsClientGlobalSetting -MockWith { $DnsClientGlobalSettings }
             Mock Set-DnsClientGlobalSetting
@@ -115,7 +115,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+        Describe "MSFT_xDnsClientGlobalSetting\Test-TargetResource" {
 
             Mock Get-DnsClientGlobalSetting -MockWith { $DnsClientGlobalSettings }
 
@@ -163,7 +163,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\New-TerminatingError" {
+        Describe "MSFT_xDnsClientGlobalSetting\New-TerminatingError" {
 
             Context 'Create a TestError Exception' {
 

--- a/Tests/Unit/MSFT_xDnsConnectionSuffix.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsConnectionSuffix.Tests.ps1
@@ -1,31 +1,27 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xDnsConnectionSuffix'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xDnsConnectionSuffix'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
-#endregion
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
 
 # Begin Testing
 try
 {
-
     #region Pester Tests
-
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
 
         $testDnsSuffix = 'example.local';
         $testInterfaceAlias = 'Ethernet';
@@ -40,7 +36,7 @@ try
             RegisterThisConnectionsAddress = $true;
             UseSuffixWhenRegistering = $false;
         }
-        
+
         $fakeDnsSuffixMismatch = $fakeDnsSuffixPresent.Clone();
         $fakeDnsSuffixMismatch['ConnectionSpecificSuffix'] = 'mismatch.local';
 
@@ -48,143 +44,143 @@ try
         $fakeDnsSuffixAbsent['ConnectionSpecificSuffix'] = '';
 
 
-       Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+       Describe "MSFT_xDnsConnectionSuffix\Get-TargetResource" {
             Context 'Validates "Get-TargetResource" method' {
                 It 'Returns a "System.Collections.Hashtable" object type' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Get-TargetResource @testDnsSuffixParams;
-                    
+
                     $targetResource -is [System.Collections.Hashtable] | Should Be $true;
                 }
-    
+
                 It 'Returns "Present" when DNS suffix matches and "Ensure" = "Present"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Get-TargetResource @testDnsSuffixParams;
-                    
+
                     $targetResource.Ensure | Should Be 'Present';
                 }
-    
+
                 It 'Returns "Absent" when DNS suffix does not match and "Ensure" = "Present"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixMismatch; }
-    
+
                     $targetResource = Get-TargetResource @testDnsSuffixParams;
-                    
+
                     $targetResource.Ensure | Should Be 'Absent';
                 }
-    
+
                 It 'Returns "Absent" when no DNS suffix is defined and "Ensure" = "Present"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent; }
-    
+
                     $targetResource = Get-TargetResource @testDnsSuffixParams;
-                    
+
                     $targetResource.Ensure | Should Be 'Absent';
                 }
-    
+
                 It 'Returns "Absent" when no DNS suffix is defined and "Ensure" = "Absent"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent; }
-    
+
                     $targetResource = Get-TargetResource @testDnsSuffixParams -Ensure Absent;
-                    
+
                     $targetResource.Ensure | Should Be 'Absent';
                 }
-    
+
                 It 'Returns "Present" when DNS suffix is defined and "Ensure" = "Absent"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Get-TargetResource @testDnsSuffixParams -Ensure Absent;
-                    
+
                     $targetResource.Ensure | Should Be 'Present';
                 }
-    
+
             } #end Context 'Validates "Get-TargetResource" method'
         }
 
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+        Describe "MSFT_xDnsConnectionSuffix\Test-TargetResource" {
             Context 'Validates "Test-TargetResource" method' {
-    
+
                 It 'Passes when all properties match and "Ensure" = "Present"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams;
-    
+
                     $targetResource | Should Be $true;
                 }
                 It 'Passes when no DNS suffix is registered and "Ensure" = "Absent"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams -Ensure Absent;
-    
+
                     $targetResource | Should Be $true;
                 }
                 It 'Passes when "RegisterThisConnectionsAddress" setting is correct' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams -RegisterThisConnectionsAddress $true;
-    
+
                     $targetResource | Should Be $true;
                 }
                 It 'Passes when "UseSuffixWhenRegistering" setting is correct' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams -UseSuffixWhenRegistering $false;
-    
+
                     $targetResource | Should Be $true;
                 }
-    
+
                 It 'Fails when no DNS suffix is registered and "Ensure" = "Present"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams;
-    
+
                     $targetResource | Should Be $false;
                 }
                 It 'Fails when the registered DNS suffix is incorrect and "Ensure" = "Present"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixMismatch; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams;
-    
+
                     $targetResource | Should Be $false;
                 }
                 It 'Fails when a DNS suffix is registered and "Ensure" = "Absent"' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams -Ensure Absent;
-    
+
                     $targetResource | Should Be $false;
                 }
                 It 'Fails when "RegisterThisConnectionsAddress" setting is incorrect' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams -RegisterThisConnectionsAddress $false;
-    
+
                     $targetResource | Should Be $false;
                 }
                 It 'Fails when "UseSuffixWhenRegistering" setting is incorrect' {
                     Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-    
+
                     $targetResource = Test-TargetResource @testDnsSuffixParams -UseSuffixWhenRegistering $true;
-    
+
                     $targetResource | Should Be $false;
                 }
             } #end Context 'Validates "Test-TargetResource" method'
         }
-        
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+
+        Describe "MSFT_xDnsConnectionSuffix\Test-TargetResource" {
             Context 'Validates "Set-TargetResource" method' {
                 It 'Calls "Set-DnsClient" with specified DNS suffix when "Ensure" = "Present"' {
                     Mock Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq $testDnsSuffix } { }
-    
+
                     Set-TargetResource @testDnsSuffixParams;
-    
+
                     Assert-MockCalled Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq $testDnsSuffix } -Scope It;
                 }
                 It 'Calls "Set-DnsClient" with no DNS suffix when "Ensure" = "Absent"' {
                     Mock Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq '' } { }
-    
+
                     Set-TargetResource @testDnsSuffixParams -Ensure Absent;
-    
+
                     Assert-MockCalled Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq '' } -Scope It;
                 }
             } #end Context 'Validates "Set-TargetResource" method'

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -1,31 +1,27 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xFirewall'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xFirewall'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
-#endregion
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
 
 # Begin Testing
 try
 {
-
     #region Pester Tests
-
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
 
         #region Pester Test Initialization
         # Get the rule that will be used for testing
@@ -43,7 +39,7 @@ try
         #endregion
 
         #region Function Get-TargetResource
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+        Describe "MSFT_xFirewall\Get-TargetResource" {
             Context 'Absent should return correctly' {
                 Mock Get-NetFirewallRule
 
@@ -72,7 +68,7 @@ try
 
 
         #region Function Test-TargetResource
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+        Describe "MSFT_xFirewall\Test-TargetResource" {
             Context 'Ensure is Absent and the Firewall is not Present' {
                 Mock Get-FirewallRule
 
@@ -117,7 +113,7 @@ try
 
 
         #region Function Set-TargetResource
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+        Describe "MSFT_xFirewall\Set-TargetResource" {
             # To speed up all these tests create Mocks so that these functions are not repeatedly called
             Mock Get-FirewallRule -MockWith { $FirewallRule }
             Mock Get-FirewallRuleProperty -MockWith { $Properties }
@@ -962,7 +958,7 @@ try
 
 
         #region Function Get-FirewallRule
-        Describe "$($Global:DSCResourceName)\Get-FirewallRule" {
+        Describe "MSFT_xFirewall\Get-FirewallRule" {
             Context 'testing with firewall that exists' {
                 It "should return a firewall rule when name is passed on firewall rule $($FirewallRule.Name)" {
                     $Result = Get-FirewallRule -Name $FirewallRule.Name
@@ -995,7 +991,7 @@ try
 
 
         #region Function Get-FirewallRuleProperty
-        Describe "$($Global:DSCResourceName)\Get-FirewallRuleProperty" {
+        Describe "MSFT_xFirewall\Get-FirewallRuleProperty" {
             Context 'All Properties' {
                 $result = Get-FirewallRuleProperty -FirewallRule $FirewallRule
                 It "Should return the right address filter on firewall rule $($FirewallRule.Name)" {

--- a/Tests/Unit/MSFT_xHostsFile.Tests.ps1
+++ b/Tests/Unit/MSFT_xHostsFile.Tests.ps1
@@ -1,41 +1,40 @@
-﻿$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xHostsFile'
+﻿$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xHostsFile'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
-#endregion
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
 
 # Begin Testing
 try
 {
     #region Pester Tests
+    InModuleScope $script:DSCResourceName {
 
-    InModuleScope $Global:DSCResourceName {
+        Describe 'MSFT_xHostsFile' {
 
-        Describe $Global:DSCResourceName {
-            
             Mock Add-Content {}
             Mock Set-Content {}
-            
+
             Context "A host entry doesn't exist, and should" {
                 $testParams = @{
                     HostName = "www.contoso.com"
                     IPAddress = "192.168.0.156"
                 }
-                
-                Mock Get-Content { 
+
+                Mock Get-Content {
                     return @(
                         "# A mocked example of a host file - this line is a comment",
                         "",
@@ -44,27 +43,27 @@ try
                         ""
                     )
                 }
-                
+
                 It "should return absent from the get method" {
-                    (Get-TargetResource @testParams).Ensure | Should Be "Absent" 
+                    (Get-TargetResource @testParams).Ensure | Should Be "Absent"
                 }
-                
+
                 It "should return false from the test method" {
                     Test-TargetResource @testParams | Should Be $false
                 }
-                
+
                 It "should create the entry in the set method" {
                     Set-TargetResource @testParams
                     Assert-MockCalled Add-Content
                 }
             }
-            
+
             Context "A host entry exists but has the wrong IP address" {
                 $testParams = @{
                     HostName = "www.contoso.com"
                     IPAddress = "192.168.0.156"
                 }
-                
+
                 Mock Get-Content {
                     return @(
                         "# A mocked example of a host file - this line is a comment",
@@ -75,27 +74,27 @@ try
                         ""
                     )
                 }
-                
+
                 It "should return present from the get method" {
-                    (Get-TargetResource @testParams).Ensure | Should Be "Present" 
+                    (Get-TargetResource @testParams).Ensure | Should Be "Present"
                 }
-                
+
                 It "should return false from the test method" {
                     Test-TargetResource @testParams | Should Be $false
                 }
-                
+
                 It "should update the entry in the set method" {
                     Set-TargetResource @testParams
                     Assert-MockCalled Set-Content
                 }
             }
-            
+
             Context "A host entry exists with the correct IP address" {
                 $testParams = @{
                     HostName = "www.contoso.com"
                     IPAddress = "192.168.0.156"
                 }
-                
+
                 Mock Get-Content {
                     return @(
                         "# A mocked example of a host file - this line is a comment",
@@ -106,22 +105,22 @@ try
                         ""
                     )
                 }
-                
+
                 It "should return present from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Present"
                 }
-                
+
                 It "should return true from the test method" {
                     Test-TargetResource @testParams | Should Be $true
                 }
             }
-            
+
             Context "A host entry exists but it shouldn't" {
                 $testParams = @{
                     HostName = "www.contoso.com"
                     Ensure = "Absent"
                 }
-                
+
                 Mock Get-Content {
                     return @(
                         "# A mocked example of a host file - this line is a comment",
@@ -132,27 +131,27 @@ try
                         ""
                     )
                 }
-                
+
                 It "should return present from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Present"
                 }
-                
+
                 It "should return false from the test method" {
                     Test-TargetResource @testParams | Should Be $false
                 }
-                
+
                 It "should remove the entry in the set method" {
                     Set-TargetResource @testParams
                     Assert-MockCalled Set-Content
                 }
             }
-            
+
             Context "A host entry doesn't it exist and shouldn't" {
                 $testParams = @{
                     HostName = "www.contoso.com"
                     Ensure = "Absent"
                 }
-                
+
                 Mock Get-Content {
                     return @(
                         "# A mocked example of a host file - this line is a comment",
@@ -162,11 +161,11 @@ try
                         ""
                     )
                 }
-                
+
                 It "should return absent from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Absent"
                 }
-                
+
                 It "should return true from the test method" {
                     Test-TargetResource @testParams | Should Be $true
                 }
@@ -177,7 +176,7 @@ try
                     HostName = "www.contoso.com"
                     IPAddress = "192.168.0.156"
                 }
-                
+
                 Mock Get-Content {
                     return @(
                         "# A mocked example of a host file - this line is a comment",
@@ -188,11 +187,11 @@ try
                         ""
                     )
                 }
-                
+
                 It "should return present from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Present"
                 }
-                
+
                 It "should return true from the test method" {
                     Test-TargetResource @testParams | Should Be $true
                 }
@@ -203,7 +202,7 @@ try
                     HostName = "www.contoso.com"
                     IPAddress = "192.168.0.156"
                 }
-                
+
                 Mock Get-Content {
                     return @(
                         "# A mocked example of a host file - this line is a comment",
@@ -214,11 +213,11 @@ try
                         ""
                     )
                 }
-                
+
                 It "should return present from the get method" {
                     (Get-TargetResource @testParams).Ensure | Should Be "Present"
                 }
-                
+
                 It "should return false from the test method" {
                     Test-TargetResource @testParams | Should Be $false
                 }
@@ -233,8 +232,8 @@ try
                 $testParams = @{
                     HostName = "www.contoso.com"
                 }
-                
-                Mock Get-Content { 
+
+                Mock Get-Content {
                     return @(
                         "# A mocked example of a host file - this line is a comment",
                         "",

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -1,26 +1,27 @@
-﻿$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xNetAdapterBinding'
+﻿$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xNetAdapterBinding'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
 #endregion HEADER
 
 # Begin Testing
 try
 {
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
+
         $TestBindingEnabled = @{
             InterfaceAlias = 'Ethernet'
             ComponentId = 'ms_tcpip63'
@@ -45,7 +46,7 @@ try
             Enabled = $False
         }
 
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+        Describe "MSFT_xNetAdapterBinding\Get-TargetResource" {
             Context 'Adapter exists and binding Enabled' {
                 Mock Get-Binding -MockWith { $MockBindingEnabled }
 
@@ -75,7 +76,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+        Describe "MSFT_xNetAdapterBinding\Set-TargetResource" {
             Context 'Adapter exists and set binding to Enabled' {
                 Mock Get-Binding -MockWith { $MockBindingDisabled }
                 Mock Enable-NetAdapterBinding
@@ -105,7 +106,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+        Describe "MSFT_xNetAdapterBinding\Test-TargetResource" {
             Context 'Adapter exists, current binding set to Enabled but want it Disabled' {
                 Mock Get-Binding -MockWith { $MockBindingEnabled }
                 It 'Should return false' {
@@ -147,7 +148,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Get-Binding" {
+        Describe "MSFT_xNetAdapterBinding\Get-Binding" {
             Context 'Adapter does not exist' {
                 Mock Get-NetAdapter
                 It 'Should throw an InterfaceNotAvailable error' {

--- a/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
@@ -1,29 +1,27 @@
-$Global:DSCModuleName   = 'xNetworking'
-$Global:DSCResourceName = 'MSFT_xNetBIOS'
+$script:DSCModuleName   = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xNetBIOS'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
-#endregion
+#endregion HEADER
 
 # Begin Testing
 try
 {
     #region Pester Tests
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
 
         $InterfaceAlias = (Get-NetAdapter -Physical | Select-Object -First 1).Name
 
@@ -32,7 +30,7 @@ try
         $MockNetadapterSettingsDisable = New-Object -TypeName CimInstance -ArgumentList 'Win32_NetworkAdapterConfiguration' | Add-Member -MemberType NoteProperty -Name TcpipNetbiosOptions -Value 2 -PassThru
 
         #region Function Get-TargetResource
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+        Describe "MSFT_xNetBIOS\Get-TargetResource" {
 
             Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsDefault}
 
@@ -55,7 +53,7 @@ try
 
 
         #region Function Test-TargetResource
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+        Describe "MSFT_xNetBIOS\Test-TargetResource" {
             Context 'invoking with NetBIOS over TCP/IP set to default' {
 
                 Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsDefault}
@@ -104,7 +102,7 @@ try
 
 
         #region Function Set-TargetResource
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+        Describe "MSFT_xNetBIOS\Set-TargetResource" {
             Mock Set-ItemProperty
             Mock Invoke-CimMethod
 

--- a/Tests/Unit/MSFT_xNetconnectionProfile.tests.ps1
+++ b/Tests/Unit/MSFT_xNetconnectionProfile.tests.ps1
@@ -1,33 +1,29 @@
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xNetConnectionProfile'
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xNetConnectionProfile'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
-    -TestType Unit 
-#endregion
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
 
 # Begin Testing
 try
 {
-
     #region Pester Tests
+    InModuleScope $script:DSCResourceName {
 
-    InModuleScope $Global:DSCResourceName {
-            
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+        Describe "MSFT_xNetConnectionProfile\Get-TargetResource" {
             Mock Get-NetConnectionProfile {
                 return @{
                     InterfaceAlias   = 'InterfaceAlias'
@@ -38,7 +34,7 @@ try
             }
             $expected = Get-NetConnectionProfile | select -first 1
             $result = Get-TargetResource -InterfaceAlias $expected.InterfaceAlias
-    
+
             It 'Should return the correct values' {
                 $expected.InterfaceAlias   | Should Be $result.InterfaceAlias
                 $expected.NetworkCategory  | Should Be $result.NetworkCategory
@@ -46,53 +42,53 @@ try
                 $expected.IPv6Connectivity | Should Be $result.IPv6Connectivity
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+
+        Describe "MSFT_xNetConnectionProfile\Test-TargetResource" {
             $Splat = @{
                 InterfaceAlias   = 'Test'
                 NetworkCategory  = 'Private'
                 IPv4Connectivity = 'Internet'
                 IPv6Connectivity = 'Disconnected'
             }
-    
+
             Context 'IPv4Connectivity is incorrect' {
                 $incorrect = $Splat.Clone()
                 $incorrect.IPv4Connectivity = 'Disconnected'
                 Mock Get-TargetResource {
                     return $incorrect
                 }
-    
+
                 It 'should return false' {
                     Test-TargetResource @Splat | should be $false
                 }
             }
-    
+
             Context 'IPv6Connectivity is incorrect' {
                 $incorrect = $Splat.Clone()
                 $incorrect.IPv6Connectivity = 'Internet'
                 Mock Get-TargetResource {
                     return $incorrect
                 }
-    
+
                 It 'should return false' {
                     Test-TargetResource @Splat | should be $false
                 }
             }
-    
+
             Context 'NetworkCategory is incorrect' {
                 $incorrect = $Splat.Clone()
                 $incorrect.NetworkCategory = 'Public'
                 Mock Get-TargetResource {
                     return $incorrect
                 }
-    
+
                 It 'should return false' {
                     Test-TargetResource @Splat | should be $false
                 }
             }
         }
-    
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+
+        Describe "MSFT_xNetConnectionProfile\Set-TargetResource" {
             It 'Should do call all the mocks' {
                 $Splat = @{
                     InterfaceAlias   = 'Test'
@@ -100,11 +96,11 @@ try
                     IPv4Connectivity = 'Internet'
                     IPv6Connectivity = 'Disconnected'
                 }
-    
+
                 Mock Set-NetConnectionProfile {}
-    
+
                 Set-TargetResource @Splat
-    
+
                 Assert-MockCalled Set-NetConnectionProfile
             }
         }

--- a/Tests/Unit/MSFT_xRoute.Tests.ps1
+++ b/Tests/Unit/MSFT_xRoute.Tests.ps1
@@ -1,29 +1,27 @@
-$Global:DSCModuleName   = 'xNetworking'
-$Global:DSCResourceName = 'MSFT_xRoute'
+$script:DSCModuleName   = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xRoute'
 
 #region HEADER
-[String] $moduleRoot = Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))
-if ( (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+# Unit Test Template Version: 1.1.0
+[String] $script:moduleRoot = Split-Path -Parent (Split-Path -Parent $PSScriptRoot)
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
-else
-{
-    & git @('-C',(Join-Path -Path $moduleRoot -ChildPath '\DSCResource.Tests\'),'pull')
-}
-Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Unit
-#endregion
+#endregion HEADER
 
 # Begin Testing
 try
 {
     #region Pester Tests
-    InModuleScope $Global:DSCResourceName {
+    InModuleScope $script:DSCResourceName {
 
         # Create the Mock Objects that will be used for running tests
         $MockNetAdapter = [PSCustomObject] @{
@@ -59,7 +57,7 @@ try
             PreferredLifetime       = ([Timespan]::FromSeconds($TestRoute.PreferredLifetime))
         }
 
-        Describe "$($Global:DSCResourceName)\Get-TargetResource" {
+        Describe "MSFT_xRoute\Get-TargetResource" {
 
             Context 'Route does not exist' {
 
@@ -97,7 +95,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Set-TargetResource" {
+        Describe "MSFT_xRoute\Set-TargetResource" {
 
             Context 'Route does not exist but should' {
 
@@ -246,7 +244,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Test-TargetResource" {
+        Describe "MSFT_xRoute\Test-TargetResource" {
 
             Context 'Route does not exist but should' {
 
@@ -365,7 +363,7 @@ try
             }
         }
 
-        Describe "$($Global:DSCResourceName)\Test-ResourceProperty" {
+        Describe "MSFT_xRoute\Test-ResourceProperty" {
 
             Context 'invoking with bad interface alias' {
 


### PR DESCRIPTION
This PR updates all unit tests and integration tests to use the v1.1.0 Template as well as convert the global scoped variables to script scope.

- fixes #131 
- fixes #141

Changes:
* Corrected integration test filenames:
    * MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
    * MSFT_xDhcpClient.Integration.Tests.ps1
    * MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
    * MSFT_xNetAdapterBinding.Integration.Tests.ps1
* Updated all integration tests to use v1.1.0 header and script variable context.
* Updated all unit tests to use v1.1.0 header and script variable context.
* Removed uneccessary global variable from MSFT_xNetworkTeam.integration.tests.ps1
* Converted Invoke-Expression in all integration tests to &.
* Fixed unit test description in xNetworkAdapter.Tests.ps1