### PR TITLE
Wait until Adapter is available

### DIFF
--- a/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -191,10 +191,29 @@ function Test-TargetResource
     Test-ResourceProperty @PSBoundParameters
 
     # Get the current IP Address based on the parameters given.
-    $currentIPs = @(Get-NetIPAddress `
-        -InterfaceAlias $InterfaceAlias `
-        -AddressFamily $AddressFamily `
-        -ErrorAction Stop)
+    # First make sure that adapter is available
+    [Boolean] $AdapterBindingReady = $false
+    [DateTime] $StartTime = Get-Date 
+
+
+    while (-not $AdapterBindingReady -and (((Get-Date) - $StartTime).TotalSeconds) -lt 30)
+    {
+        try
+        {
+            $currentIPs = @(Get-NetIPAddress `
+                -InterfaceAlias $InterfaceAlias `
+                -AddressFamily $AddressFamily `
+                -ErrorAction Stop)
+            if ($currentIPs)
+            {
+                $AdapterBindingReady = $true
+            } # if
+            Start-Sleep -Milliseconds = 200
+        }
+        catch
+        {
+        }
+    } # while
 
     # Test if the IP Address passed is present
     if ($IPAddress -notin $currentIPs.IPAddress)

--- a/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -191,28 +191,21 @@ function Test-TargetResource
     Test-ResourceProperty @PSBoundParameters
 
     # Get the current IP Address based on the parameters given.
-    # First make sure that adapter is available
+     # First make sure that adapter is available
     [Boolean] $AdapterBindingReady = $false
     [DateTime] $StartTime = Get-Date 
 
-
     while (-not $AdapterBindingReady -and (((Get-Date) - $StartTime).TotalSeconds) -lt 30)
-    {
-        try
+    {      
+        $currentIPs = @(Get-NetIPAddress `
+            -InterfaceAlias $InterfaceAlias `
+            -AddressFamily $AddressFamily `
+            -ErrorAction SilentlyContinue)
+        if ($currentIPs)
         {
-            $currentIPs = @(Get-NetIPAddress `
-                -InterfaceAlias $InterfaceAlias `
-                -AddressFamily $AddressFamily `
-                -ErrorAction Stop)
-            if ($currentIPs)
-            {
-                $AdapterBindingReady = $true
-            } # if
-            Start-Sleep -Milliseconds = 200
-        }
-        catch
-        {
-        }
+            $AdapterBindingReady = $true
+        } # if
+            Start-Sleep -Milliseconds 200
     } # while
 
     # Test if the IP Address passed is present

--- a/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -192,10 +192,10 @@ function Test-TargetResource
 
     # Get the current IP Address based on the parameters given.
      # First make sure that adapter is available
-    [Boolean] $AdapterBindingReady = $false
-    [DateTime] $StartTime = Get-Date 
+    [Boolean] $adapterBindingReady = $false
+    [DateTime] $startTime = Get-Date 
 
-    while (-not $AdapterBindingReady -and (((Get-Date) - $StartTime).TotalSeconds) -lt 30)
+    while (-not $adapterBindingReady -and (((Get-Date) - $startTime).TotalSeconds) -lt 30)
     {      
         $currentIPs = @(Get-NetIPAddress `
             -InterfaceAlias $InterfaceAlias `
@@ -203,9 +203,12 @@ function Test-TargetResource
             -ErrorAction SilentlyContinue)
         if ($currentIPs)
         {
-            $AdapterBindingReady = $true
-        } # if
+            $adapterBindingReady = $true
+        }
+        else
+        {
             Start-Sleep -Milliseconds 200
+        }
     } # while
 
     # Test if the IP Address passed is present

--- a/README.md
+++ b/README.md
@@ -191,6 +191,7 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 ## Versions
 
 ### Unreleased
+* Fixed bug in MSFT_xIPAddress resource when xIPAddress follows xVMSwitch.
 
 ### 2.11.0.0
 * Added the following resources:


### PR DESCRIPTION
This fix is taken directly from @PlagueHO fix at https://github.com/PlagueHO/LoopbackAdapter/pull/2/files

When xIPAddress follows xVMSwitch without any wait time, it causes an error:

PowerShell DSC resource MSFT_xIPAddress  failed to execute Test-TargetResource functionality with error message: The running command stopped because the preference variable 
"ErrorActionPreference" or common parameter is set to Stop: No matching MSFT_NetIPAddress objects found by CIM query for instances of the ROOT/StandardCimv2/MSFT_NetIPAddress class on the  
CIM server: SELECT * FROM MSFT_NetIPAddress  WHERE ((InterfaceAlias LIKE 'vEthernet (Internal)')) AND ((AddressFamily = 2)). Verify query parameters and retry.

In searching for a fix, I found the above-referenced issue in a  @PlagueHO repo. Following his example, this addition of a loop/test/wait fixes the problem.