### PR TITLE
Removed InModuleScope from xNetworkAdapter tests

### DIFF
--- a/Tests/Unit/xNetworkAdapter.Tests.ps1
+++ b/Tests/Unit/xNetworkAdapter.Tests.ps1
@@ -16,252 +16,257 @@ Import-Module (Join-Path -Path $script:moduleRoot -ChildPath "$script:ModuleName
 # Begin Testing
 try
 {
+    Set-StrictMode -Version latest
+    $ErrorActionPreference = 'stop'
+    
     #region Pester Tests
-    InModuleScope $script:ModuleName {
 
-        # Create the Mock Objects that will be used for running tests
-        $MockNetAdapter = [PSCustomObject] @{
-            Name                    = 'Ethernet'
-            PhysicalMediaType              = '802.3'
-            Status                         = 'Up'
+    $GetNetAdapter_PhysicalNetAdapterMock = {
+        return [PSCustomObject] @{
+            Name              = 'Ethernet'
+            PhysicalMediaType = '802.3'
+            Status            = 'Up'
         }
+    }
 
-        $MockHypervVmNetAdapter = [PSCustomObject] @{
-            Name                    = 'Ethernet'
-            PhysicalMediaType              = 'Unspecified'
-            Status                         = 'Up'
+    $GetNetAdapter_HypervVmNetAdapterMock = {
+        return [PSCustomObject] @{
+            Name              = 'Ethernet'
+            PhysicalMediaType = 'Unspecified'
+            Status            = 'Up'
         }
+    }
 
-        $MockMultipleNetAdapter = @(
+    $GetNetAdapter_MultipleNetAdapterMock = {
+        return @(
             [PSCustomObject] @{
-                Name                    = 'Ethernet1'
-                PhysicalMediaType              = '802.3'
-                Status                         = 'Up'
+                Name               = 'Ethernet1'
+                PhysicalMediaType  = '802.3'
+                Status             = 'Up'
             },
             [PSCustomObject] @{
-                Name                    = 'MyEthernet'
-                PhysicalMediaType              = '802.3'
-                Status                         = 'Up'
+                Name               = 'MyEthernet'
+                PhysicalMediaType  = '802.3'
+                Status             = 'Up'
             }
         )
+    }
 
-        $TestAdapterKeys = @{
-            Name                           = 'MyEthernet'
-            PhysicalMediaType              = '802.3'
-            Status                         = 'Up'
-        }
+    $TestAdapterKeys = @{
+        Name               = 'MyEthernet'
+        PhysicalMediaType  = '802.3'
+        Status             = 'Up'
+    }
 
-        $TestHypervVmAdapterKeys = @{
-            Name                           = 'MyEthernet'
-            Status                         = 'Up'
-        }
+    $TestHypervVmAdapterKeys = @{
+        Name                       = 'MyEthernet'
+        Status                     = 'Up'
+    }
 
-        Describe "xNetworkAdapter\Get-xNetworkAdapterName" {
+    Describe "xNetworkAdapter\Get-xNetworkAdapterName" {
 
-            Context 'Adapter does not exist' {
+        Context 'Adapter does not exist' {
 
-                Mock Get-NetAdapter
-
-                It 'should return absent Route' {
-                    $Result = Get-xNetworkAdapterName @TestAdapterKeys
-                    $Result.MatchingAdapterCount | Should Be 0
-                    $Result.Name | Should Be $null
-                }
-                It 'should call the expected mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                }
+            Mock Get-NetAdapter -ModuleName $script:ModuleName
+            
+            It 'should return absent Route' {
+                $Result = Get-xNetworkAdapterName @TestAdapterKeys
+                $Result.MatchingAdapterCount | Should Be 0
+                $Result.Name | Should Be $null
             }
-
-            Context 'Adapter does exist' {
-
-                Mock Get-NetAdapter -MockWith { $MockNetAdapter }
-
-                It 'should return correct Route' {
-                    $Result = Get-xNetworkAdapterName @TestAdapterKeys
-                    $Result.MatchingAdapterCount | Should Be 1
-                    $Result.Name | Should Be 'Ethernet'
-                }
-                It 'should call the expected mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                }
-            }
-
-            Context 'Hyperv VM Adapter does exist' {
-
-                Mock Get-NetAdapter -MockWith { $MockHypervVmNetAdapter }
-
-                It 'should return correct Route' {
-                    $Result = Get-xNetworkAdapterName @TestHypervVmAdapterKeys
-                    $Result.MatchingAdapterCount | Should Be 1
-                    $Result.Name | Should Be 'Ethernet'
-                }
-                It 'should call the expected mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                }
-            }
-
-            Context 'Multiple Adapters exist' {
-
-                Mock Get-NetAdapter -MockWith { $MockMultipleNetAdapter }
-
-                It 'should return correct Route' {
-                    $Result = Get-xNetworkAdapterName `
-                        @TestAdapterKeys
-                    $Result.MatchingAdapterCount | Should Be 1
-                    $Result.Name | Should Be 'MyEthernet'
-                }
-                It 'should call the expected mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                }
+            It 'should call the expected mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
             }
         }
 
-        Describe "xNetworkAdapter\Set-xNetworkAdapterName" {
+        Context 'Adapter does exist' {
 
-            Context 'Adapter does not exist' {
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_PhysicalNetAdapterMock
 
-                Mock Get-NetAdapter
-                Mock Rename-NetAdapter
-
-                It 'should not throw error' {
-                    {
-                        $Splat = $TestAdapterKeys.Clone()
-                        Set-xNetworkAdapterName @Splat
-                    } | Should Throw 'A NetAdapter matching the properties was not found. Please correct the properties and try again.'
-                }
-                It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                    Assert-MockCalled -commandName Rename-NetAdapter -Exactly 0
-                }
+            It 'should return correct Route' {
+                $Result = Get-xNetworkAdapterName @TestAdapterKeys
+                $Result.MatchingAdapterCount | Should Be 1
+                $Result.Name | Should Be 'Ethernet'
             }
-
-            Context 'Adapter exists and should be renamed' {
-
-                Mock Get-NetAdapter -MockWith { $MockNetAdapter }
-                Mock Rename-NetAdapter
-
-                It 'should not throw error' {
-                    {
-                        $Splat = $TestAdapterKeys.Clone()
-                        Set-xNetworkAdapterName @Splat
-                    } | Should Not Throw
-                }
-                It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                    Assert-MockCalled -commandName Rename-NetAdapter -Exactly 1
-                }
-            }
-
-            Context 'Hyperv VM Adapter exists and should be renamed' {
-
-                Mock Get-NetAdapter -MockWith { $MockHypervVmNetAdapter }
-                Mock Rename-NetAdapter
-
-                It 'should not throw error' {
-                    {
-                        $Splat = $TestHypervVmAdapterKeys.Clone()
-                        Set-xNetworkAdapterName @Splat
-                    } | Should Not Throw
-                }
-                It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                    Assert-MockCalled -commandName Rename-NetAdapter -Exactly 1
-                }
-            }
-
-            Context 'Multiple matching adapter exists and IgnoreMultipleMatchingAdapters is true and name matches' {
-
-                Mock Get-NetAdapter -MockWith { $MockMultipleNetAdapter }
-                Mock Rename-NetAdapter
-
-                It 'should not throw error' {
-                    {
-                        $Splat = $TestAdapterKeys.Clone()
-                        Set-xNetworkAdapterName @Splat
-                    } | Should Not Throw
-                }
-                It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                    Assert-MockCalled -commandName Rename-NetAdapter -Exactly 0
-                }
-            }
-
-            Context 'Multiple matching adapter exists and IgnoreMultipleMatchingAdapters is true and name mismatches' {
-
-                Mock Get-NetAdapter -MockWith { $MockMultipleNetAdapter }
-                Mock Rename-NetAdapter
-
-                It 'should not throw error' {
-                    {
-                        $Splat = $TestAdapterKeys.Clone()
-                        $Splat.Name = 'MyEthernet2'
-                        $Splat.IgnoreMultipleMatchingAdapters = $true
-                        Set-xNetworkAdapterName @Splat
-                    } | Should Not Throw
-                }
-                It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                    Assert-MockCalled -commandName Rename-NetAdapter -Exactly 1
-                }
-            }
-
-            Context 'Multiple matching adapter exists and IgnoreMultipleMatchingAdapters is false' {
-
-                Mock Get-NetAdapter -MockWith { $MockMultipleNetAdapter }
-                Mock Rename-NetAdapter
-
-                It 'should not throw error' {
-                    {
-                        $Splat = $TestAdapterKeys.Clone()
-                        $Splat.Name = 'MyEthernet2'
-                        $Splat.IgnoreMultipleMatchingAdapters = $false
-                        Set-xNetworkAdapterName @Splat
-                    } | Should Throw 'Multiple matching NetAdapters where found for the properties. Please correct the properties or specify IgnoreMultipleMatchingAdapters to only use the first and try again.'
-                }
-                It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                    Assert-MockCalled -commandName Rename-NetAdapter -Exactly 0
-                }
+            It 'should call the expected mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
             }
         }
 
-        Describe "xNetworkAdapter\Test-xNetworkAdapterName" {
+        Context 'Hyperv VM Adapter does exist' {
 
-            Context 'NetAdapter does not exist' {
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_HypervVmNetAdapterMock
 
-                Mock Get-NetAdapter -MockWith { $MockNetAdapter }
+            It 'should return correct Route' {
+                $Result = Get-xNetworkAdapterName @TestHypervVmAdapterKeys
+                $Result.MatchingAdapterCount | Should Be 1
+                $Result.Name | Should Be 'Ethernet'
+            }
+            It 'should call the expected mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+            }
+        }
 
-                It 'should return false' {
+        Context 'Multiple Adapters exist' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_MultipleNetAdapterMock
+
+            It 'should return correct Route' {
+                $Result = Get-xNetworkAdapterName @TestAdapterKeys
+                $Result.MatchingAdapterCount | Should Be 1
+                $Result.Name | Should Be 'MyEthernet'
+            }
+            It 'should call the expected mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+            }
+        }
+    }
+
+    Describe "xNetworkAdapter\Set-xNetworkAdapterName" {
+
+        Context 'Adapter does not exist' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName 
+            Mock Rename-NetAdapter -ModuleName $script:ModuleName 
+
+            It 'should not throw error' {
+                {
+                    $Splat = $TestAdapterKeys.Clone()
+                    Set-xNetworkAdapterName @Splat
+                } | Should Throw 'A NetAdapter matching the properties was not found. Please correct the properties and try again.'
+            }
+            It 'should call expected Mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Rename-NetAdapter -Exactly 0
+            }
+        }
+
+        Context 'Adapter exists and should be renamed' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_PhysicalNetAdapterMock
+            Mock Rename-NetAdapter -ModuleName $script:ModuleName 
+
+            It 'should not throw error' {
+                {
+                    $Splat = $TestAdapterKeys.Clone()
+                    Set-xNetworkAdapterName @Splat
+                } | Should Not Throw
+            }
+            It 'should call expected Mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Rename-NetAdapter -Exactly 1
+            }
+        }
+
+        Context 'Hyperv VM Adapter exists and should be renamed' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_HypervVmNetAdapterMock
+            Mock Rename-NetAdapter -ModuleName $script:ModuleName 
+
+            It 'should not throw error' {
+                {
+                    $Splat = $TestHypervVmAdapterKeys.Clone()
+                    Set-xNetworkAdapterName @Splat
+                } | Should Not Throw
+            }
+            It 'should call expected Mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Rename-NetAdapter -Exactly 1
+            }
+        }
+
+        Context 'Multiple matching adapter exists and IgnoreMultipleMatchingAdapters is true and name matches' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_MultipleNetAdapterMock
+            Mock Rename-NetAdapter -ModuleName $script:ModuleName 
+
+            It 'should not throw error' {
+                {
+                    $Splat = $TestAdapterKeys.Clone()
+                    Set-xNetworkAdapterName @Splat
+                } | Should Not Throw
+            }
+            It 'should call expected Mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Rename-NetAdapter -Exactly 0
+            }
+        }
+
+        Context 'Multiple matching adapter exists and IgnoreMultipleMatchingAdapters is true and name mismatches' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_MultipleNetAdapterMock
+            Mock Rename-NetAdapter -ModuleName $script:ModuleName 
+
+            It 'should not throw error' {
+                {
+                    $Splat = $TestAdapterKeys.Clone()
+                    $Splat.Name = 'MyEthernet2'
+                    $Splat.IgnoreMultipleMatchingAdapters = $true
+                    Set-xNetworkAdapterName @Splat
+                } | Should Not Throw
+            }
+            It 'should call expected Mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Rename-NetAdapter -Exactly 1
+            }
+        }
+
+        Context 'Multiple matching adapter exists and IgnoreMultipleMatchingAdapters is false' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_MultipleNetAdapterMock
+            Mock Rename-NetAdapter -ModuleName $script:ModuleName 
+
+            It 'should not throw error' {
+                {
+                    $Splat = $TestAdapterKeys.Clone()
+                    $Splat.Name = 'MyEthernet2'
+                    $Splat.IgnoreMultipleMatchingAdapters = $false
+                    Set-xNetworkAdapterName @Splat
+                } | Should Throw 'Multiple matching NetAdapters where found for the properties. Please correct the properties or specify IgnoreMultipleMatchingAdapters to only use the first and try again.'
+            }
+            It 'should call expected Mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Rename-NetAdapter -Exactly 0
+            }
+        }
+    }
+
+    Describe "xNetworkAdapter\Test-xNetworkAdapterName" {
+
+        Context 'NetAdapter does not exist' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_PhysicalNetAdapterMock
+
+            It 'should return false' {
+                $Splat = $TestAdapterKeys.Clone()
+                Test-xNetworkAdapterName @Splat | Should Be $False
+
+            }
+            It 'should call expected Mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
+            }
+        }
+
+        Context 'NetAdapter exists and should but renamed' {
+
+            Mock Get-NetAdapter -ModuleName $script:ModuleName -MockWith $GetNetAdapter_PhysicalNetAdapterMock
+
+            It 'should return false' {
+                {
                     $Splat = $TestAdapterKeys.Clone()
                     Test-xNetworkAdapterName @Splat | Should Be $False
-
-                }
-                It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                }
+                } | Should Not Throw
             }
-
-            Context 'NetAdapter exists and should but renamed' {
-
-                Mock Get-NetAdapter -MockWith { $MockNetAdapter }
-
-                It 'should return false' {
-                    {
-                       $Splat = $TestAdapterKeys.Clone()
-                        Test-xNetworkAdapterName @Splat | Should Be $False
-                    } | Should Not Throw
-                }
-                It 'should call expected Mocks' {
-                    Assert-MockCalled -commandName Get-NetAdapter -Exactly 1
-                }
+            It 'should call expected Mocks' {
+                Assert-MockCalled -ModuleName $script:ModuleName -commandName Get-NetAdapter -Exactly 1
             }
-
         }
 
-        Describe "xNetworkAdapter\Test-ResourceProperty" {
+    }
 
-            Context 'TBD' {
-            }
+    Describe "xNetworkAdapter\Test-ResourceProperty" {
+
+        Context 'TBD' {
         }
     }
     #endregion


### PR DESCRIPTION
I was reviewing the comments in PowerShell/DscResources#175. @PlagueHO mentions issues trying to use the variables at the top of the script that hold the mock definitions.

Submitting one possible way to deal with those issues. My concern wrt InModuleScope is not as much about this particular test, but about using it in our test templates to write the entire test code.

@PlagueHO Let me know if you hit other issues with InModuleScope and I can look into them in the next few days.

Thanks