### PR TITLE
BREAKING CHANGE - Renamed xIPAddress SubnetMask parameter to PrefixLength - Fixes #145

### DIFF
--- a/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.schema.mof
+++ b/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.schema.mof
@@ -1,8 +1,8 @@
-[ClassVersion("1.0.0"), FriendlyName("xIPAddress")]
+[ClassVersion("1.0.0.0"), FriendlyName("xIPAddress")]
 class MSFT_xIPAddress : OMI_BaseResource
 {
   [Key] string IPAddress;
   [Key] string InterfaceAlias;
-  [Write] uint32 SubnetMask;
+  [Write] uint32 PrefixLength;
   [Write,ValueMap{"IPv4", "IPv6"},Values{"IPv4", "IPv6"}] string AddressFamily;
 };

--- a/Examples/Sample_xIPAddress_StaticIP_FixedValue.ps1
+++ b/Examples/Sample_xIPAddress_StaticIP_FixedValue.ps1
@@ -20,7 +20,7 @@ configuration Sample_xIPAddress_FixedValue
         {
             IPAddress      = "2001:4898:200:7:6c71:a102:ebd8:f482"
             InterfaceAlias = "Ethernet"
-            SubnetMask     = 24
+            PrefixLength   = 24
             AddressFamily  = "IPV6"
         }
     }

--- a/Examples/Sample_xIPAddress_StaticIP_Parameterized.ps1
+++ b/Examples/Sample_xIPAddress_StaticIP_Parameterized.ps1
@@ -11,7 +11,7 @@ configuration Sample_xIPAddress_StaticIP_Parameterized
         [Parameter(Mandatory)]
         [string]$InterfaceAlias,
 
-        [int]$SubnetMask = 16,
+        [int]$PrefixLength = 16,
 
         [ValidateSet("IPv4","IPv6")]
         [string]$AddressFamily = 'IPv4'
@@ -32,7 +32,7 @@ configuration Sample_xIPAddress_StaticIP_Parameterized
         {
             IPAddress      = $IPAddress
             InterfaceAlias = $InterfaceAlias
-            SubnetMask     = $SubnetMask
+            PrefixLength   = $PrefixLength
             AddressFamily  = $AddressFamily
         }
     }

--- a/README.md
+++ b/README.md
@@ -37,7 +37,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 
 * **IPAddress**: The desired IP address.
 * **InterfaceAlias**: Alias of the network interface for which the IP address should be set.
-* **SubnetMask**: Local subnet size.
+* **PrefixLength**: The prefix length of the IP Address.
 * **AddressFamily**: IP address family: { IPv4 | IPv6 }
 
 ### xDnsServerAddress
@@ -208,6 +208,7 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 * Removed uneccessary global variable from MSFT_xNetworkTeam.integration.tests.ps1
 * Converted Invoke-Expression in all integration tests to &.
 * Fixed unit test description in xNetworkAdapter.Tests.ps1
+* BREAKING CHANGE - MSFT_xIPAddress: SubnetMask parameter renamed to PrefixLength.
 
 ### 2.12.0.0
 * Fixed bug in MSFT_xIPAddress resource when xIPAddress follows xVMSwitch.
@@ -383,7 +384,7 @@ Configuration Sample_xIPAddress_FixedValue
         {
             IPAddress      = "2001:4898:200:7:6c71:a102:ebd8:f482"
             InterfaceAlias = "Ethernet"
-            SubnetMask     = 24
+            PrefixLength   = 24
             AddressFamily  = "IPV6"
         }
     }
@@ -404,7 +405,7 @@ Configuration Sample_xIPAddress_Parameterized
         [string]$IPAddress,
         [Parameter(Mandatory)]
         [string]$InterfaceAlias,
-        [int]$SubnetMask = 16,
+        [int]$PrefixLength = 16,
         [ValidateSet("IPv4","IPv6")]
         [string]$AddressFamily = 'IPv4'
     )
@@ -415,7 +416,7 @@ Configuration Sample_xIPAddress_Parameterized
         {
             IPAddress      = $IPAddress
             InterfaceAlias = $InterfaceAlias
-            SubnetMask     = $SubnetMask
+            PrefixLength   = $PrefixLength
             AddressFamily  = $AddressFamily
         }
     }
@@ -883,7 +884,7 @@ configuration Sample_xNetworkTeamInterface_AddInterface
           TeamMembers = 'NIC1','NIC2'
           Ensure = 'Present'
         }
-        
+
         xNetworkTeamInterface NewInterface {
             Name = 'NewInterface'
             TeamName = 'HostTeam'

--- a/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
@@ -47,7 +47,7 @@ try
             $current.InterfaceAlias             | Should Be $TestIPAddress.InterfaceAlias
             $current.AddressFamily              | Should Be $TestIPAddress.AddressFamily
             $current.IPAddress                  | Should Be $TestIPAddress.IPAddress
-            $current.SubnetMask                 | Should Be $TestIPAddress.SubnetMask
+            $current.PrefixLength               | Should Be $TestIPAddress.PrefixLength
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xIPAddress.config.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.config.ps1
@@ -2,7 +2,7 @@ $TestIPAddress = [PSObject]@{
     InterfaceAlias          = 'xNetworkingLBA'
     AddressFamily           = 'IPv4'
     IPAddress               = '10.11.12.13'
-    SubnetMask              = 16
+    PrefixLength            = 16
 }
 
 configuration MSFT_xIPAddress_Config {
@@ -12,7 +12,7 @@ configuration MSFT_xIPAddress_Config {
             InterfaceAlias          = $TestIPAddress.InterfaceAlias
             AddressFamily           = $TestIPAddress.AddressFamily
             IPAddress               = $TestIPAddress.IPAddress
-            SubnetMask              = $TestIPAddress.SubnetMask
+            PrefixLength            = $TestIPAddress.PrefixLength
         }
     }
 }

--- a/Tests/Unit/MSFT_xIPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xIPAddress.Tests.ps1
@@ -46,16 +46,16 @@ try
                     }
                     $Result = Get-TargetResource @Splat
                     $Result.IPAddress | Should Be $Splat.IPAddress
-                    $Result.SubnetMask | Should Be 24
+                    $Result.PrefixLength | Should Be 24
                 }
             }
 
-            Context 'Subnet Mask' {
+            Context 'Prefix Length' {
                 It 'should fail if passed a negative number' {
                     $Splat = @{
                         IPAddress = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
-                        Subnet = -16
+                        PrefixLength = -16
                     }
 
                     { Get-TargetResource @Splat } `
@@ -202,7 +202,7 @@ try
                     $Splat = @{
                         IPAddress = 'BadAddress'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = 64
+                        PrefixLength = 64
                         AddressFamily = 'IPv6'
                     }
                     $errorId = 'AddressFormatError'
@@ -223,7 +223,7 @@ try
                     $Splat = @{
                         IPAddress = 'fe80::1'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = 64
+                        PrefixLength = 64
                         AddressFamily = 'IPv6'
                     }
                     $Result = Test-TargetResource @Splat
@@ -240,7 +240,7 @@ try
                     $Splat = @{
                         IPAddress = 'fe80::15'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = 64
+                        PrefixLength = 64
                         AddressFamily = 'IPv6'
                     }
                     $Result = Test-TargetResource @Splat
@@ -334,25 +334,25 @@ try
                     $Splat = @{
                         IPAddress = 'fe80:ab04:30F5:002b::1'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = 64
+                        PrefixLength = 64
                         AddressFamily = 'IPv6'
                     }
                     { Test-ResourceProperty @Splat } | Should Not Throw
                 }
             }
 
-            Context 'invoking with invalid IPv4 subnet mask' {
+            Context 'invoking with invalid IPv4 prefix length' {
 
-                It 'should throw a SubnetMaskError when greater than 32' {
+                It 'should throw a PrefixLengthError when greater than 32' {
                     $Splat = @{
                         IPAddress = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = 33
+                        PrefixLength = 33
                         AddressFamily = 'IPv4'
                     }
-                    $errorId = 'SubnetMaskError'
+                    $errorId = 'PrefixLengthError'
                     $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                    $errorMessage = $($LocalizedData.SubnetMaskError) -f $Splat.SubnetMask,$Splat.AddressFamily
+                    $errorMessage = $($LocalizedData.PrefixLengthError) -f $Splat.PrefixLength,$Splat.AddressFamily
                     $exception = New-Object -TypeName System.InvalidOperationException `
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
@@ -364,7 +364,7 @@ try
                     $Splat = @{
                         IPAddress = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = -1
+                        PrefixLength = -1
                         AddressFamily = 'IPv4'
                     }
                     { Test-ResourceProperty @Splat } `
@@ -372,19 +372,19 @@ try
                 }
             }
 
-            Context 'invoking with invalid IPv6 subnet mask' {
+            Context 'invoking with invalid IPv6 prefix length' {
 
-                It 'should throw a SubnetMaskError error when greater than 128' {
+                It 'should throw a PrefixLengthError error when greater than 128' {
                     $Splat = @{
                         IPAddress = 'fe80::1'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = 129
+                        PrefixLength = 129
                         AddressFamily = 'IPv6'
                     }
 
-                    $errorId = 'SubnetMaskError'
+                    $errorId = 'PrefixLengthError'
                     $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                    $errorMessage = $($LocalizedData.SubnetMaskError) -f $Splat.SubnetMask,$Splat.AddressFamily
+                    $errorMessage = $($LocalizedData.PrefixLengthError) -f $Splat.PrefixLength,$Splat.AddressFamily
                     $exception = New-Object -TypeName System.InvalidOperationException `
                         -ArgumentList $errorMessage
                     $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
@@ -396,7 +396,7 @@ try
                     $Splat = @{
                         IPAddress = 'fe80::1'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = -1
+                        PrefixLength = -1
                         AddressFamily = 'IPv6'
                     }
 
@@ -405,13 +405,13 @@ try
                 }
             }
 
-            Context 'invoking with valid string IPv6 subnet mask' {
+            Context 'invoking with valid string IPv6 prefix length' {
 
                 It 'should not throw an error' {
                     $Splat = @{
                         IPAddress = 'fe80::1'
                         InterfaceAlias = 'Ethernet'
-                        SubnetMask = '64'
+                        PrefixLength = '64'
                         AddressFamily = 'IPv6'
                     }
                     { Test-ResourceProperty @Splat } | Should Not Throw


### PR DESCRIPTION
Changes:
* BREAKING CHANGE - MSFT_xIPAddress: SubnetMask parameter renamed to PrefixLength.

See #145

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/149)
<!-- Reviewable:end -->
