### PR TITLE
xNetAdapterBinding: Added support for the use of wildcard (*) in InterfaceAlias parameter (Fixes #153)

### DIFF
--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -38,14 +38,21 @@ function Get-TargetResource
 
     $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
 
-    if ($CurrentNetAdapterBinding.Enabled)
+    $AdaptersState = $CurrentNetAdapterBinding.Enabled |
+        Sort-Object -Unique
+
+    If ( $AdaptersState.Count -eq 2)
     {
-        $State = 'Enabled'
+        $CurrentEnabled = 'MixedState'
+    }         
+    ElseIf ( $AdaptersState -eq $true )
+    {
+        $CurrentEnabled = 'Enabled'
     }
-    else
+    Else
     {
-        $State = 'Disabled'
-    } # if
+        $CurrentEnabled = 'Disabled'
+    }
 
     $returnValue = @{
         InterfaceAlias = $InterfaceAlias
@@ -124,14 +131,21 @@ function Test-TargetResource
 
     $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
 
-    if ($CurrentNetAdapterBinding.Enabled)
+    $AdaptersState = $CurrentNetAdapterBinding.Enabled |
+        Sort-Object -Unique
+
+    If ( $AdaptersState.Count -eq 2)
+    {
+        $CurrentEnabled = 'MixedState'
+    }         
+    ElseIf ( $AdaptersState -eq $true )
     {
         $CurrentEnabled = 'Enabled'
     }
-    else
+    Else
     {
         $CurrentEnabled = 'Disabled'
-    } # if
+    }
 
     # Test if the binding is in the correct state
     if ($CurrentEnabled -ne $State)

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 * Removed uneccessary global variable from MSFT_xNetworkTeam.integration.tests.ps1
 * Converted Invoke-Expression in all integration tests to &.
 * Fixed unit test description in xNetworkAdapter.Tests.ps1
+* xNetAdapterBinding
+  * Added support for the use of wildcard (*) in InterfaceAlias parameter.
 
 ### 2.12.0.0
 * Fixed bug in MSFT_xIPAddress resource when xIPAddress follows xVMSwitch.

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -51,9 +51,9 @@ try
                 Mock Get-Binding -MockWith { $MockBindingEnabled }
 
                 It 'should return existing binding' {
-                    $Result = Get-TargetResource @TestBindingDisabled
-                    $Result.InterfaceAlias | Should Be $TestBindingDisabled.InterfaceAlias
-                    $Result.ComponentId | Should Be $TestBindingDisabled.ComponentId
+                    $Result = Get-TargetResource @TestBindingEnabled
+                    $Result.InterfaceAlias | Should Be $TestBindingEnabled.InterfaceAlias
+                    $Result.ComponentId | Should Be $TestBindingEnabled.ComponentId
                     $Result.State | Should Be 'Enabled'
                 }
                 It 'Should call all the mocks' {
@@ -65,9 +65,9 @@ try
                 Mock Get-Binding -MockWith { $MockBindingDisabled }
 
                 It 'should return existing binding' {
-                    $Result = Get-TargetResource @TestBindingEnabled
-                    $Result.InterfaceAlias | Should Be $TestBindingEnabled.InterfaceAlias
-                    $Result.ComponentId | Should Be $TestBindingEnabled.ComponentId
+                    $Result = Get-TargetResource @TestBindingDisabled
+                    $Result.InterfaceAlias | Should Be $TestBindingDisabled.InterfaceAlias
+                    $Result.ComponentId | Should Be $TestBindingDisabled.ComponentId
                     $Result.State | Should Be 'Disabled'
                 }
                 It 'Should call all the mocks' {


### PR DESCRIPTION
Added support for the use of wildcard (*) in InterfaceAlias parameter.
This is done by testing the all states of the adapters targeted by the use of wildcards, to see if ALL of them have the desired state.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/154)
<!-- Reviewable:end -->
