### PR TITLE
xNetAdapterBinding: Added support for the use of wildcard (*) in InterfaceAlias parameter (Fixes #153) 

### DIFF
--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -43,7 +43,7 @@ function Get-TargetResource
 
     If ( $AdaptersState.Count -eq 2)
     {
-        $CurrentEnabled = 'MixedState'
+        $CurrentEnabled = 'Mixed'
     }         
     ElseIf ( $AdaptersState -eq $true )
     {
@@ -54,7 +54,7 @@ function Get-TargetResource
         $CurrentEnabled = 'Disabled'
     }
 
-    $returnValue = @{
+    $returnValue[$_.InterfaceAlias] = @{
         InterfaceAlias = $InterfaceAlias
         ComponentId    = $ComponentId
         State          = $State
@@ -136,7 +136,7 @@ function Test-TargetResource
 
     If ( $AdaptersState.Count -eq 2)
     {
-        $CurrentEnabled = 'MixedState'
+        $CurrentEnabled = 'Mixed'
     }         
     ElseIf ( $AdaptersState -eq $true )
     {

--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -38,14 +38,21 @@ function Get-TargetResource
 
     $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
 
-    if ($CurrentNetAdapterBinding.Enabled)
+    $AdaptersState = $CurrentNetAdapterBinding.Enabled |
+        Sort-Object -Unique
+
+    If ( $AdaptersState.Count -eq 2)
     {
-        $State = 'Enabled'
+        $CurrentEnabled = 'MixedState'
+    }         
+    ElseIf ( $AdaptersState -eq $true )
+    {
+        $CurrentEnabled = 'Enabled'
     }
-    else
+    Else
     {
-        $State = 'Disabled'
-    } # if
+        $CurrentEnabled = 'Disabled'
+    }
 
     $returnValue = @{
         InterfaceAlias = $InterfaceAlias
@@ -124,14 +131,21 @@ function Test-TargetResource
 
     $CurrentNetAdapterBinding = Get-Binding @PSBoundParameters
 
-    if ($CurrentNetAdapterBinding.Enabled)
+    $AdaptersState = $CurrentNetAdapterBinding.Enabled |
+        Sort-Object -Unique
+
+    If ( $AdaptersState.Count -eq 2)
+    {
+        $CurrentEnabled = 'MixedState'
+    }         
+    ElseIf ( $AdaptersState -eq $true )
     {
         $CurrentEnabled = 'Enabled'
     }
-    else
+    Else
     {
         $CurrentEnabled = 'Disabled'
-    } # if
+    }
 
     # Test if the binding is in the correct state
     if ($CurrentEnabled -ne $State)

--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -54,10 +54,11 @@ function Get-TargetResource
         $CurrentEnabled = 'Disabled'
     }
 
-    $returnValue[$_.InterfaceAlias] = @{
+    $returnValue = @{
         InterfaceAlias = $InterfaceAlias
         ComponentId    = $ComponentId
         State          = $State
+        CurrentState   = $CurrentEnabled
     }
 
     $returnValue

--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.schema.mof
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.schema.mof
@@ -3,5 +3,6 @@ class MSFT_xNetAdapterBinding : OMI_BaseResource
 {
   [Key,Description("Specifies the alias of a network interface.")] string InterfaceAlias;
   [Key,Description("Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip.")] string ComponentId;
-  [Write,Description("Specifies if the component ID for the Interface should be Enabled or Disabled."),ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled", "Mixed"}] string State;
+  [Write,Description("Specifies if the component ID for the Interface should be Enabled or Disabled."),ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled"}] string State;
+  [Read,Description("Returns the current state of the component ID for the Interfaces."),ValueMap{"Enabled", "Disabled","Mixed"},Values{"Enabled", "Disabled","Mixed"}] string CurrentState;
 };

--- a/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.schema.mof
+++ b/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.schema.mof
@@ -3,5 +3,5 @@ class MSFT_xNetAdapterBinding : OMI_BaseResource
 {
   [Key,Description("Specifies the alias of a network interface.")] string InterfaceAlias;
   [Key,Description("Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip.")] string ComponentId;
-  [Write,Description("Specifies if the component ID for the Interface should be Enabled or Disabled."),ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled"}] string State;
+  [Write,Description("Specifies if the component ID for the Interface should be Enabled or Disabled."),ValueMap{"Enabled", "Disabled"},Values{"Enabled", "Disabled", "Mixed"}] string State;
 };

--- a/README.md
+++ b/README.md
@@ -208,6 +208,8 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 * Removed uneccessary global variable from MSFT_xNetworkTeam.integration.tests.ps1
 * Converted Invoke-Expression in all integration tests to &.
 * Fixed unit test description in xNetworkAdapter.Tests.ps1
+* xNetAdapterBinding
+  * Added support for the use of wildcard (*) in InterfaceAlias parameter.
 
 ### 2.12.0.0
 * Fixed bug in MSFT_xIPAddress resource when xIPAddress follows xVMSwitch.

--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ Please check out common DSC Resources [contributing guidelines](https://github.c
 * **Ensure**: Specifies if the hosts file entry should be created or deleted. { Present | Absent }.
 
 ### xNetAdapterBinding
-* **InterfaceAlias**: Specifies the alias of a network interface. Mandatory.
+* **InterfaceAlias**: Specifies the alias of a network interface. Supports the use of '*'. Mandatory.
 * **ComponentId**: Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip. Mandatory.
 * **State**: Specifies if the component ID for the Interface should be Enabled or Disabled. Optional. Defaults to Enabled. { Enabled | Disabled }.
 

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -51,9 +51,9 @@ try
                 Mock Get-Binding -MockWith { $MockBindingEnabled }
 
                 It 'should return existing binding' {
-                    $Result = Get-TargetResource @TestBindingDisabled
-                    $Result.InterfaceAlias | Should Be $TestBindingDisabled.InterfaceAlias
-                    $Result.ComponentId | Should Be $TestBindingDisabled.ComponentId
+                    $Result = Get-TargetResource @TestBindingEnabled
+                    $Result.InterfaceAlias | Should Be $TestBindingEnabled.InterfaceAlias
+                    $Result.ComponentId | Should Be $TestBindingEnabled.ComponentId
                     $Result.State | Should Be 'Enabled'
                 }
                 It 'Should call all the mocks' {
@@ -65,9 +65,9 @@ try
                 Mock Get-Binding -MockWith { $MockBindingDisabled }
 
                 It 'should return existing binding' {
-                    $Result = Get-TargetResource @TestBindingEnabled
-                    $Result.InterfaceAlias | Should Be $TestBindingEnabled.InterfaceAlias
-                    $Result.ComponentId | Should Be $TestBindingEnabled.ComponentId
+                    $Result = Get-TargetResource @TestBindingDisabled
+                    $Result.InterfaceAlias | Should Be $TestBindingDisabled.InterfaceAlias
+                    $Result.ComponentId | Should Be $TestBindingDisabled.ComponentId
                     $Result.State | Should Be 'Disabled'
                 }
                 It 'Should call all the mocks' {

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -7,7 +7,7 @@ $script:DSCResourceName    = 'MSFT_xNetAdapterBinding'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
      (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    #& git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -35,7 +35,7 @@ try
         $TestBindingMixed = @{
             InterfaceAlias = '*'
             ComponentId = 'ms_tcpip63'
-            State = 'Mixed'
+            State = 'Enabled'
         }
         $MockAdapter = @{
             InterfaceAlias = 'Ethernet'
@@ -71,6 +71,7 @@ try
                     $Result.InterfaceAlias | Should Be $TestBindingEnabled.InterfaceAlias
                     $Result.ComponentId | Should Be $TestBindingEnabled.ComponentId
                     $Result.State | Should Be 'Enabled'
+                    $Result.CurrentState | Should Be 'Enabled'
                 }
                 It 'Should call all the mocks' {
                     Assert-MockCalled -commandName Get-Binding -Exactly 1
@@ -85,6 +86,7 @@ try
                     $Result.InterfaceAlias | Should Be $TestBindingDisabled.InterfaceAlias
                     $Result.ComponentId | Should Be $TestBindingDisabled.ComponentId
                     $Result.State | Should Be 'Disabled'
+                    $Result.CurrentState | Should Be 'Disabled'
                 }
                 It 'Should call all the mocks' {
                     Assert-MockCalled -commandName Get-Binding -Exactly 1
@@ -98,7 +100,8 @@ try
                     $Result = Get-TargetResource @TestBindingMixed
                     $Result.InterfaceAlias | Should Be $TestBindingMixed.InterfaceAlias
                     $Result.ComponentId | Should Be $TestBindingMixed.ComponentId
-                    $Result.State | Should Be 'Mixed'
+                    $Result.State | Should Be 'Enabled'
+                    $Result.CurrentState | Should Be 'Mixed'
                 }
                 It 'Should call all the mocks' {
                     Assert-MockCalled -commandName Get-Binding -Exactly 1

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -32,6 +32,11 @@ try
             ComponentId = 'ms_tcpip63'
             State = 'Disabled'
         }
+        $TestBindingMixed = @{
+            InterfaceAlias = '*'
+            ComponentId = 'ms_tcpip63'
+            State = 'Mixed'
+        }
         $MockAdapter = @{
             InterfaceAlias = 'Ethernet'
         }
@@ -44,6 +49,17 @@ try
             InterfaceAlias = 'Ethernet'
             ComponentId = 'ms_tcpip63'
             Enabled = $False
+        }
+
+        $MockBindingMixed = @{
+            InterfaceAlias = 'Ethernet'
+            ComponentId = 'ms_tcpip63'
+            Enabled = $False
+        },
+        @{
+            InterfaceAlias = 'Ethernet2'
+            ComponentId = 'ms_tcpip63'
+            Enabled = $True
         }
 
         Describe "MSFT_xNetAdapterBinding\Get-TargetResource" {
@@ -74,6 +90,21 @@ try
                     Assert-MockCalled -commandName Get-Binding -Exactly 1
                 }
             }
+
+            Context 'More than one Adapter exists and binding is Disabled on one and Enabled on another' {
+                Mock Get-Binding -MockWith { $MockBindingMixed }
+
+                It 'should return existing binding' {
+                    $Result = Get-TargetResource @TestBindingMixed
+                    $Result.InterfaceAlias | Should Be $TestBindingMixed.InterfaceAlias
+                    $Result.ComponentId | Should Be $TestBindingMixed.ComponentId
+                    $Result.State | Should Be 'Mixed'
+                }
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Get-Binding -Exactly 1
+                }
+            }
+
         }
 
         Describe "MSFT_xNetAdapterBinding\Set-TargetResource" {


### PR DESCRIPTION
Added support for the use of wildcard (*) in InterfaceAlias parameter.
This is done by testing the all states of the adapters targeted by the use of wildcards, to see if ALL of them have the desired state.

Also fixed some unrelated tests, that made the AppVeyor not run.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/155)
<!-- Reviewable:end -->
