### PR TITLE
Corrected example's action value

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@ Configuration Disable_AccessToApplication
             DisplayName           = "Firewall Rule for Notepad.exe"
             Group                 = "NotePad Firewall Rule Group"
             Ensure                = "Present"
-            Action                = 'Blocked'
+            Action                = 'Block'
             Description           = "Firewall Rule for Notepad.exe"
             Program               = "c:\windows\system32\notepad.exe"
         }

--- a/README.md
+++ b/README.md
@@ -208,6 +208,7 @@ The cmdlet does not fully support the Inquire action for debug messages. Cmdlet 
 * Removed uneccessary global variable from MSFT_xNetworkTeam.integration.tests.ps1
 * Converted Invoke-Expression in all integration tests to &.
 * Fixed unit test description in xNetworkAdapter.Tests.ps1
+* Fixed typo in the example's Action property from "Blocked" (which isn't a valid value) to "Block"
 
 ### 2.12.0.0
 * Fixed bug in MSFT_xIPAddress resource when xIPAddress follows xVMSwitch.


### PR DESCRIPTION
Corrected the Action property of the example in the readme from "Blocked" (which isn't a valid value) to "Block". The example would blow up if the user tried to use the example code as-is.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/157)

<!-- Reviewable:end -->
