### PR TITLE
Fix Test Failures due to changes in DSCResource.Tests - Fixes #167

### DIFF
--- a/README.md
+++ b/README.md
@@ -207,6 +207,7 @@ The following error may occur when applying xFirewall configurations on Windows 
 - Changed parameter format in Readme.md to improve information coverage and consistency.
 - Changed all MOF files to be consistent and meet HQRM guidelines.
 - Removed most markdown errors (MD*) in Readme.md.
+- Fixes to support changes to DSCResource.Tests.
 
 ### 3.0.0.0
 

--- a/Tests/Integration/IntegrationHelper.ps1
+++ b/Tests/Integration/IntegrationHelper.ps1
@@ -6,21 +6,19 @@ function New-IntegrationLoopbackAdapter
         $AdapterName
     )
 
+    # Ensure the loopback adapter module is downloaded
     $LoopbackAdapterModuleName = 'LoopbackAdapter'
     $LoopbackAdapterModulePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\$LoopbackAdapterModuleName"
-    $LoopbackAdapterModule = Install-ModuleFromPowerShellGallery `
+    Install-ModuleFromPowerShellGallery `
         -ModuleName $LoopbackAdapterModuleName `
         -DestinationPath $LoopbackAdapterModulePath
 
-    if ($LoopbackAdapterModule) {
-        # Import the module if it is available
-        $LoopbackAdapterModule | Import-Module -Force
-    }
-    else
-    {
-        # Module could not/would not be installed - so warn user that tests will fail.
-        Throw 'LoopbackAdapter Module could not be installed.'
-    } # if
+    $LoopbackAdapterModule = Join-Path `
+        -Path $LoopbackAdapterModulePath `
+        -ChildPath "$($LoopbackAdapterModuleName).psm1"
+
+    # Import the loopback adapter module
+    Import-Module -Name $LoopbackAdapterModule -Force
 
     try
     {
@@ -33,8 +31,7 @@ function New-IntegrationLoopbackAdapter
         # The loopback Adapter does not exist so create it
         $null = New-LoopbackAdapter `
             -Name $AdapterName `
-            -ErrorAction Stop `
-            @Splat
+            -ErrorAction Stop
     } # try
 } # function New-IntegrationLoopbackAdapter
 

--- a/Tests/Integration/IntegrationHelper.ps1
+++ b/Tests/Integration/IntegrationHelper.ps1
@@ -31,6 +31,7 @@ function New-IntegrationLoopbackAdapter
         # The loopback Adapter does not exist so create it
         $null = New-LoopbackAdapter `
             -Name $AdapterName `
+            -Force `
             -ErrorAction Stop
     } # try
 } # function New-IntegrationLoopbackAdapter

--- a/Tests/Integration/IntegrationHelper.ps1
+++ b/Tests/Integration/IntegrationHelper.ps1
@@ -5,22 +5,12 @@ function New-IntegrationLoopbackAdapter
         [String]
         $AdapterName
     )
-    # Configure Loopback Adapter
-    if ($env:APPVEYOR) {
-        # Running in AppVeyor so force silent install of LoopbackAdapter
-        $Splat = @{ Force = $true }
-    }
-    else
-    {
-        $Splat = @{ Force = $false }
-    } # if
 
     $LoopbackAdapterModuleName = 'LoopbackAdapter'
     $LoopbackAdapterModulePath = "$env:USERPROFILE\Documents\WindowsPowerShell\Modules\$LoopbackAdapterModuleName"
     $LoopbackAdapterModule = Install-ModuleFromPowerShellGallery `
         -ModuleName $LoopbackAdapterModuleName `
-        -ModulePath $LoopbackAdapterModulePath `
-        @Splat
+        -DestinationPath $LoopbackAdapterModulePath
 
     if ($LoopbackAdapterModule) {
         # Import the module if it is available

--- a/Tests/Integration/MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
@@ -37,8 +37,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
@@ -28,8 +28,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xHostsFile.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostsFile.Integration.Tests.ps1
@@ -30,8 +30,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xNetAdapterBinding.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterBinding.Integration.Tests.ps1
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xNetBIOS.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetBIOS.Integration.Tests.ps1
@@ -28,8 +28,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xNetConnectionProfile.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetConnectionProfile.Integration.Tests.ps1
@@ -28,8 +28,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xNetworkTeam.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeam.Integration.Tests.ps1
@@ -33,8 +33,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 

--- a/Tests/Integration/MSFT_xNetworkTeamInterface.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeamInterface.Integration.Tests.ps1
@@ -18,7 +18,7 @@ Import-Module (Join-Path -Path $moduleRoot -ChildPath 'DSCResource.Tests\TestHel
 $TestEnvironment = Initialize-TestEnvironment `
     -DSCModuleName $Global:DSCModuleName `
     -DSCResourceName $Global:DSCResourceName `
-    -TestType Integration 
+    -TestType Integration
 #endregion
 
 # Using try/finally to always cleanup even if something awful happens.
@@ -32,8 +32,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestEnvironment.WorkingFolder"
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestDrive"
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -55,7 +55,7 @@ try
             $result[1].TeamName               | Should be $TestInterface.TeamName
             $result[1].VlanID                 | Should be $TestInterface.VlanID
         }
-        
+
         Remove-NetLbfoTeamNic `
             -Team $TestInterface.TeamName `
             -VlanID $TestInterface.VlanID `

--- a/Tests/Integration/MSFT_xRoute.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xRoute.Integration.Tests.ps1
@@ -38,8 +38,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Add_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Add_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
@@ -78,8 +78,8 @@ try
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                & "$($script:DSCResourceName)_Remove_Config" -OutputPath $TestEnvironment.WorkingFolder
-                Start-DscConfiguration -Path $TestEnvironment.WorkingFolder -ComputerName localhost -Wait -Verbose -Force
+                & "$($script:DSCResourceName)_Remove_Config" -OutputPath $TestDrive
+                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 


### PR DESCRIPTION
Changes were made to DSCResource.Tests a few weeks ago which broke all Integration tests for xNetworking (and all other resources that have them). It also broke the code that pulled the Loopback Adapter module.

This PR fixes the issues.

@tysonjhayes - if you're about and have the time, would love the review :grin: - but no worries if not!

@rchaganti - after this PR is through it will fix the failures your PR is experiencing.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/168)
<!-- Reviewable:end -->
