### PR TITLE
Remove Invoke-Expression usage to resolve PSSA Warnings - Fixes #166

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
   - Moved ParameterList into a new file (MSFT_xDnsClientGlobalSetting.data.psd1).
   - Style changes to meet HQRM standards.
   - Removed New-TerminatingError function because never called.
+  - Converted to remove Invoke-Expression.
 - MSFT_xDnsConnectionSuffix:
   - Separated Localization strings into strings file.
   - Style changes to meet HQRM standards.
@@ -57,10 +58,13 @@
 - MSFT_xNetworkTeam:
   - Style changes to meet HQRM standards.
 - MSFT_xNetworkTeamInterface:
+  - Updated integration tests to remove Invoke-Expression.
   - Style changes to meet HQRM standards.
 - MSFT_xRoute:
   - Separated Localization strings into strings file.
   - Style changes to meet HQRM standards.
+- MSFT_xFirewall:
+  - Converted to remove Invoke-Expression.
 
 ## 3.1.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
@@ -108,7 +108,6 @@ function Set-TargetResource
     {
         $parameterSource = $dnsClientGlobalSetting.$($parameter.name)
         $parameterNew = (Get-Variable -Name ($parameter.name)).Value
-        # $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
         if ($PSBoundParameters.ContainsKey($parameter.Name) `
             -and (Compare-Object -ReferenceObject $parameterSource -DifferenceObject $parameterNew -SyncWindow 0))
         {
@@ -191,7 +190,6 @@ function Test-TargetResource
     {
         $parameterSource = $DnsClientGlobalSetting.$($parameter.name)
         $parameterNew = (Get-Variable -Name ($parameter.name)).Value
-        # $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
         if ($PSBoundParameters.ContainsKey($parameter.Name) `
             -and (Compare-Object -ReferenceObject $parameterSource -DifferenceObject $parameterNew -SyncWindow 0)) {
             Write-Verbose -Message ( @(

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
@@ -107,7 +107,8 @@ function Set-TargetResource
     foreach ($parameter in $script:parameterList)
     {
         $parameterSource = $dnsClientGlobalSetting.$($parameter.name)
-        $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
+        $parameterNew = Get-Variable -Name ($parameter.name)
+        # $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
         if ($PSBoundParameters.ContainsKey($parameter.Name) `
             -and (Compare-Object -ReferenceObject $parameterSource -DifferenceObject $parameterNew -SyncWindow 0))
         {
@@ -189,7 +190,8 @@ function Test-TargetResource
     foreach ($parameter in $script:parameterList)
     {
         $parameterSource = $DnsClientGlobalSetting.$($parameter.name)
-        $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
+        $parameterNew = Get-Variable -Name ($parameter.name)
+        # $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
         if ($PSBoundParameters.ContainsKey($parameter.Name) `
             -and (Compare-Object -ReferenceObject $parameterSource -DifferenceObject $parameterNew -SyncWindow 0)) {
             Write-Verbose -Message ( @(

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
@@ -107,7 +107,7 @@ function Set-TargetResource
     foreach ($parameter in $script:parameterList)
     {
         $parameterSource = $dnsClientGlobalSetting.$($parameter.name)
-        $parameterNew = Get-Variable -Name ($parameter.name)
+        $parameterNew = (Get-Variable -Name ($parameter.name)).Value
         # $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
         if ($PSBoundParameters.ContainsKey($parameter.Name) `
             -and (Compare-Object -ReferenceObject $parameterSource -DifferenceObject $parameterNew -SyncWindow 0))
@@ -190,7 +190,7 @@ function Test-TargetResource
     foreach ($parameter in $script:parameterList)
     {
         $parameterSource = $DnsClientGlobalSetting.$($parameter.name)
-        $parameterNew = Get-Variable -Name ($parameter.name)
+        $parameterNew = (Get-Variable -Name ($parameter.name)).Value
         # $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
         if ($PSBoundParameters.ContainsKey($parameter.Name) `
             -and (Compare-Object -ReferenceObject $parameterSource -DifferenceObject $parameterNew -SyncWindow 0)) {

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.data.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.data.psd1
@@ -1,36 +1,36 @@
 @{
     ParameterList = @(
-        @{ Name = 'Name';                Source = 'Name';                               Variable = 'FirewallRule'; Type = 'String'                  }
-        @{ Name = 'DisplayName';         Source = 'DisplayName';                        Variable = 'FirewallRule'; Type = 'String'                  }
-        @{ Name = 'Group';               Source = 'Group';                              Variable = 'FirewallRule'; Type = 'String'                  }
-        @{ Name = 'DisplayGroup';        Source = 'DisplayGroup';                       Variable = 'FirewallRule'; Type = ''                        }
-        @{ Name = 'Enabled';             Source = 'Enabled';                            Variable = 'FirewallRule'; Type = 'String'                  }
-        @{ Name = 'Action';              Source = 'Action';                             Variable = 'FirewallRule'; Type = 'String'                  }
-        @{ Name = 'Profile';             Source = 'Profile';                            Variable = 'FirewallRule'; Type = 'Array'; Delimiter = ', ' }
-        @{ Name = 'Direction';           Source = 'Direction';                          Variable = 'FirewallRule'; Type = 'String'                  }
-        @{ Name = 'Description';         Source = 'Description';                        Variable = 'FirewallRule'; Type = 'String'                  }
-        @{ Name = 'RemotePort';          Source = 'PortFilters.RemotePort';             Variable = 'properties';   Type = 'Array'                   }
-        @{ Name = 'LocalPort';           Source = 'PortFilters.LocalPort';              Variable = 'properties';   Type = 'Array'                   }
-        @{ Name = 'Protocol';            Source = 'PortFilters.Protocol';               Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'Program';             Source = 'ApplicationFilters.Program';         Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'Service';             Source = 'ServiceFilters.Service';             Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'Authentication';      Source = 'SecurityFilters.Authentication';     Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'Encryption';          Source = 'SecurityFilters.Encryption';         Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'InterfaceAlias';      Source = 'InterfaceFilters.InterfaceAlias';    Variable = 'properties';   Type = 'Array'                   }
-        @{ Name = 'InterfaceType';       Source = 'InterfaceTypeFilters.InterfaceType'; Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'LocalAddress';        Source = 'AddressFilters.LocalAddress';        Variable = 'properties';   Type = 'ArrayIP'                 }
-        @{ Name = 'LocalUser';           Source = 'SecurityFilters.LocalUser';          Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'Package';             Source = 'ApplicationFilters.Package';         Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'Platform';            Source = 'Platform';                           Variable = 'FirewallRule'; Type = 'Array'                   }
-        @{ Name = 'RemoteAddress';       Source = 'AddressFilters.RemoteAddress';       Variable = 'properties';   Type = 'ArrayIP'                 }
-        @{ Name = 'RemoteMachine';       Source = 'SecurityFilters.RemoteMachine';      Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'RemoteUser';          Source = 'SecurityFilters.RemoteUser';         Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'DynamicTransport';    Source = 'PortFilters.DynamicTransport';       Variable = 'properties';   Type = 'String'                  }
-        @{ Name = 'EdgeTraversalPolicy'; Source = 'EdgeTraversalPolicy';                Variable = 'FirewallRule'; Type = 'String'                  }
-        @{ Name = 'IcmpType';            Source = 'PortFilters.IcmpType';               Variable = 'properties';   Type = 'Array'                   }
-        @{ Name = 'LocalOnlyMapping';    Source = 'LocalOnlyMapping';                   Variable = 'FirewallRule'; Type = 'Boolean'                 }
-        @{ Name = 'LooseSourceMapping';  Source = 'LooseSourceMapping';                 Variable = 'FirewallRule'; Type = 'Boolean'                 }
-        @{ Name = 'OverrideBlockRules';  Source = 'SecurityFilters.OverrideBlockRules'; Variable = 'properties';   Type = 'Boolean'                 }
-        @{ Name = 'Owner';               Source = 'Owner';                              Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'Name';                Variable = 'FirewallRule';                                    Type = 'String'                  }
+        @{ Name = 'DisplayName';         Variable = 'FirewallRule';                                    Type = 'String'                  }
+        @{ Name = 'Group';               Variable = 'FirewallRule';                                    Type = 'String'                  }
+        @{ Name = 'DisplayGroup';        Variable = 'FirewallRule';                                    Type = ''                        }
+        @{ Name = 'Enabled';             Variable = 'FirewallRule';                                    Type = 'String'                  }
+        @{ Name = 'Action';              Variable = 'FirewallRule';                                    Type = 'String'                  }
+        @{ Name = 'Profile';             Variable = 'FirewallRule';                                    Type = 'Array'; Delimiter = ', ' }
+        @{ Name = 'Direction';           Variable = 'FirewallRule';                                    Type = 'String'                  }
+        @{ Name = 'Description';         Variable = 'FirewallRule';                                    Type = 'String'                  }
+        @{ Name = 'RemotePort';          Variable = 'properties';   Property = 'PortFilters';          Type = 'Array'                   }
+        @{ Name = 'LocalPort';           Variable = 'properties';   Property = 'PortFilters';          Type = 'Array'                   }
+        @{ Name = 'Protocol';            Variable = 'properties';   Property = 'PortFilters';          Type = 'String'                  }
+        @{ Name = 'Program';             Variable = 'properties';   Property = 'ApplicationFilters';   Type = 'String'                  }
+        @{ Name = 'Service';             Variable = 'properties';   Property = 'ServiceFilters';       Type = 'String'                  }
+        @{ Name = 'Authentication';      Variable = 'properties';   Property = 'SecurityFilters';      Type = 'String'                  }
+        @{ Name = 'Encryption';          Variable = 'properties';   Property = 'SecurityFilters';      Type = 'String'                  }
+        @{ Name = 'InterfaceAlias';      Variable = 'properties';   Property = 'InterfaceFilters';     Type = 'Array'                   }
+        @{ Name = 'InterfaceType';       Variable = 'properties';   Property = 'InterfaceTypeFilters'; Type = 'String'                  }
+        @{ Name = 'LocalAddress';        Variable = 'properties';   Property = 'AddressFilters';       Type = 'ArrayIP'                 }
+        @{ Name = 'LocalUser';           Variable = 'properties';   Property = 'SecurityFilters';      Type = 'String'                  }
+        @{ Name = 'Package';             Variable = 'properties';   Property = 'ApplicationFilters';   Type = 'String'                  }
+        @{ Name = 'Platform';            Variable = 'FirewallRule';                                    Type = 'Array'                   }
+        @{ Name = 'RemoteAddress';       Variable = 'properties';   Property = 'AddressFilters';       Type = 'ArrayIP'                 }
+        @{ Name = 'RemoteMachine';       Variable = 'properties';   Property = 'SecurityFilters';      Type = 'String'                  }
+        @{ Name = 'RemoteUser';          Variable = 'properties';   Property = 'SecurityFilters';      Type = 'String'                  }
+        @{ Name = 'DynamicTransport';    Variable = 'properties';   Property = 'PortFilters';          Type = 'String'                  }
+        @{ Name = 'EdgeTraversalPolicy'; Variable = 'FirewallRule';                                    Type = 'String'                  }
+        @{ Name = 'IcmpType';            Variable = 'properties';   Property = 'PortFilters';          Type = 'Array'                   }
+        @{ Name = 'LocalOnlyMapping';    Variable = 'FirewallRule';                                    Type = 'Boolean'                 }
+        @{ Name = 'LooseSourceMapping';  Variable = 'FirewallRule';                                    Type = 'Boolean'                 }
+        @{ Name = 'OverrideBlockRules';  Variable = 'properties';   Property = 'SecurityFilters';      Type = 'Boolean'                 }
+        @{ Name = 'Owner';               Variable = 'FirewallRule';                                    Type = 'String'                  }
     )
 }

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.data.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.data.psd1
@@ -1,36 +1,36 @@
 @{
     ParameterList = @(
-        @{ Name = 'Name';                Source = '$FirewallRule.Name';                             Type = 'String'                  }
-        @{ Name = 'DisplayName';         Source = '$FirewallRule.DisplayName';                      Type = 'String'                  }
-        @{ Name = 'Group';               Source = '$FirewallRule.Group';                            Type = 'String'                  }
-        @{ Name = 'DisplayGroup';        Source = '$FirewallRule.DisplayGroup';                     Type = ''                        }
-        @{ Name = 'Enabled';             Source = '$FirewallRule.Enabled';                          Type = 'String'                  }
-        @{ Name = 'Action';              Source = '$FirewallRule.Action';                           Type = 'String'                  }
-        @{ Name = 'Profile';             Source = '$firewallRule.Profile';                          Type = 'Array'; Delimiter = ', ' }
-        @{ Name = 'Direction';           Source = '$FirewallRule.Direction';                        Type = 'String'                  }
-        @{ Name = 'Description';         Source = '$FirewallRule.Description';                      Type = 'String'                  }
-        @{ Name = 'RemotePort';          Source = '$properties.PortFilters.RemotePort';             Type = 'Array'                   }
-        @{ Name = 'LocalPort';           Source = '$properties.PortFilters.LocalPort';              Type = 'Array'                   }
-        @{ Name = 'Protocol';            Source = '$properties.PortFilters.Protocol';               Type = 'String'                  }
-        @{ Name = 'Program';             Source = '$properties.ApplicationFilters.Program';         Type = 'String'                  }
-        @{ Name = 'Service';             Source = '$properties.ServiceFilters.Service';             Type = 'String'                  }
-        @{ Name = 'Authentication';      Source = '$properties.SecurityFilters.Authentication';     Type = 'String'                  }
-        @{ Name = 'Encryption';          Source = '$properties.SecurityFilters.Encryption';         Type = 'String'                  }
-        @{ Name = 'InterfaceAlias';      Source = '$properties.InterfaceFilters.InterfaceAlias';    Type = 'Array'                   }
-        @{ Name = 'InterfaceType';       Source = '$properties.InterfaceTypeFilters.InterfaceType'; Type = 'String'                  }
-        @{ Name = 'LocalAddress';        Source = '$properties.AddressFilters.LocalAddress';        Type = 'ArrayIP'                 }
-        @{ Name = 'LocalUser';           Source = '$properties.SecurityFilters.LocalUser';          Type = 'String'                  }
-        @{ Name = 'Package';             Source = '$properties.ApplicationFilters.Package';         Type = 'String'                  }
-        @{ Name = 'Platform';            Source = '$firewallRule.Platform';                         Type = 'Array'                   }
-        @{ Name = 'RemoteAddress';       Source = '$properties.AddressFilters.RemoteAddress';       Type = 'ArrayIP'                 }
-        @{ Name = 'RemoteMachine';       Source = '$properties.SecurityFilters.RemoteMachine';      Type = 'String'                  }
-        @{ Name = 'RemoteUser';          Source = '$properties.SecurityFilters.RemoteUser';         Type = 'String'                  }
-        @{ Name = 'DynamicTransport';    Source = '$properties.PortFilters.DynamicTransport';       Type = 'String'                  }
-        @{ Name = 'EdgeTraversalPolicy'; Source = '$FirewallRule.EdgeTraversalPolicy';              Type = 'String'                  }
-        @{ Name = 'IcmpType';            Source = '$properties.PortFilters.IcmpType';               Type = 'Array'                   }
-        @{ Name = 'LocalOnlyMapping';    Source = '$FirewallRule.LocalOnlyMapping';                 Type = 'Boolean'                 }
-        @{ Name = 'LooseSourceMapping';  Source = '$FirewallRule.LooseSourceMapping';               Type = 'Boolean'                 }
-        @{ Name = 'OverrideBlockRules';  Source = '$properties.SecurityFilters.OverrideBlockRules'; Type = 'Boolean'                 }
-        @{ Name = 'Owner';               Source = '$FirewallRule.Owner';                            Type = 'String'                  }
+        @{ Name = 'Name';                Source = 'Name';                               Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'DisplayName';         Source = 'DisplayName';                        Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'Group';               Source = 'Group';                              Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'DisplayGroup';        Source = 'DisplayGroup';                       Variable = 'FirewallRule'; Type = ''                        }
+        @{ Name = 'Enabled';             Source = 'Enabled';                            Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'Action';              Source = 'Action';                             Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'Profile';             Source = 'Profile';                            Variable = 'FirewallRule'; Type = 'Array'; Delimiter = ', ' }
+        @{ Name = 'Direction';           Source = 'Direction';                          Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'Description';         Source = 'Description';                        Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'RemotePort';          Source = 'PortFilters.RemotePort';             Variable = 'properties';   Type = 'Array'                   }
+        @{ Name = 'LocalPort';           Source = 'PortFilters.LocalPort';              Variable = 'properties';   Type = 'Array'                   }
+        @{ Name = 'Protocol';            Source = 'PortFilters.Protocol';               Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'Program';             Source = 'ApplicationFilters.Program';         Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'Service';             Source = 'ServiceFilters.Service';             Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'Authentication';      Source = 'SecurityFilters.Authentication';     Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'Encryption';          Source = 'SecurityFilters.Encryption';         Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'InterfaceAlias';      Source = 'InterfaceFilters.InterfaceAlias';    Variable = 'properties';   Type = 'Array'                   }
+        @{ Name = 'InterfaceType';       Source = 'InterfaceTypeFilters.InterfaceType'; Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'LocalAddress';        Source = 'AddressFilters.LocalAddress';        Variable = 'properties';   Type = 'ArrayIP'                 }
+        @{ Name = 'LocalUser';           Source = 'SecurityFilters.LocalUser';          Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'Package';             Source = 'ApplicationFilters.Package';         Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'Platform';            Source = 'Platform';                           Variable = 'FirewallRule'; Type = 'Array'                   }
+        @{ Name = 'RemoteAddress';       Source = 'AddressFilters.RemoteAddress';       Variable = 'properties';   Type = 'ArrayIP'                 }
+        @{ Name = 'RemoteMachine';       Source = 'SecurityFilters.RemoteMachine';      Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'RemoteUser';          Source = 'SecurityFilters.RemoteUser';         Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'DynamicTransport';    Source = 'PortFilters.DynamicTransport';       Variable = 'properties';   Type = 'String'                  }
+        @{ Name = 'EdgeTraversalPolicy'; Source = 'EdgeTraversalPolicy';                Variable = 'FirewallRule'; Type = 'String'                  }
+        @{ Name = 'IcmpType';            Source = 'PortFilters.IcmpType';               Variable = 'properties';   Type = 'Array'                   }
+        @{ Name = 'LocalOnlyMapping';    Source = 'LocalOnlyMapping';                   Variable = 'FirewallRule'; Type = 'Boolean'                 }
+        @{ Name = 'LooseSourceMapping';  Source = 'LooseSourceMapping';                 Variable = 'FirewallRule'; Type = 'Boolean'                 }
+        @{ Name = 'OverrideBlockRules';  Source = 'SecurityFilters.OverrideBlockRules'; Variable = 'properties';   Type = 'Boolean'                 }
+        @{ Name = 'Owner';               Source = 'Owner';                              Variable = 'FirewallRule'; Type = 'String'                  }
     )
 }

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -79,7 +79,7 @@ function Get-TargetResource
         {
             $parameterValue = @(Get-FirewallPropertyValue `
                 -FirewallRule $firewallRule `
-                -Propeties $properties `
+                -Properties $properties `
                 -Parameter $parameter)
             if ($parameter.Delimiter)
             {
@@ -98,7 +98,7 @@ function Get-TargetResource
         {
             $parameterValue = Get-FirewallPropertyValue `
                 -FirewallRule $firewallRule `
-                -Propeties $properties `
+                -Properties $properties `
                 -Parameter $parameter
 
             $result += @{
@@ -416,7 +416,7 @@ function Set-TargetResource
                         {
                             $parameterValue = Get-FirewallPropertyValue `
                                 -FirewallRule $firewallRule `
-                                -Propeties $properties `
+                                -Properties $properties `
                                 -Parameter $parameter
 
                             if ($ParameterValue) {
@@ -1034,7 +1034,7 @@ function Test-RuleProperties
     {
         $parameterValue = Get-FirewallPropertyValue `
             -FirewallRule $firewallRule `
-            -Propeties $properties `
+            -Properties $properties `
             -Parameter $parameter
 
         $parameterNew = (Get-Variable -Name ($parameter.Name)).Value

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -77,8 +77,15 @@ function Get-TargetResource
     {
         if ($parameter.Type -in @('Array','ArrayIP'))
         {
-            $parameterValue = @((Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source))
-            #$parameterValue = @(Invoke-Expression -Command "`$($($parameter.source))")
+            if ($parameter.Property) {
+                $parameterValue = @((Get-Variable `
+                    -Name ($parameter.Variable)).value.$($parameter.Property).$($parameter.Name))
+            }
+            else
+            {
+                $parameterValue = @((Get-Variable `
+                    -Name ($parameter.Variable)).value.$($parameter.Name))
+            }
             if ($parameter.Delimiter)
             {
                 $parameterValue = $parameterValue -split $parameter.Delimiter
@@ -94,8 +101,15 @@ function Get-TargetResource
         }
         else
         {
-            $parameterValue = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
-            #$parameterValue = (Invoke-Expression -Command "`$($($parameter.Source))")
+            if ($parameter.Property) {
+                $parameterValue = (Get-Variable `
+                    -Name ($parameter.Variable)).value.$($parameter.Property).$($parameter.Name)
+            }
+            else
+            {
+                $parameterValue = (Get-Variable `
+                    -Name ($parameter.Variable)).value.$($parameter.Name)
+            }
             $result += @{
                 $parameter.Name = $parameterValue
             }
@@ -409,8 +423,15 @@ function Set-TargetResource
                     Foreach ($parameter in $ParametersList) {
                         if (-not $PSBoundParameters.ContainsKey($parameter.Name))
                         {
-                            $parameterValue = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
-                            #$ParameterValue = (Invoke-Expression -Command "`$($($parameter.source))")
+                            if ($parameter.Property) {
+                                $parameterValue = (Get-Variable `
+                                    -Name ($parameter.Variable)).value.$($parameter.Property).$($parameter.Name)
+                            }
+                            else
+                            {
+                                $parameterValue = (Get-Variable `
+                                    -Name ($parameter.Variable)).value.$($parameter.Name)
+                            }
                             if ($ParameterValue) {
                                 $null = $PSBoundParameters.Add($parameter.Name,$ParameterValue)
                             }
@@ -1024,10 +1045,16 @@ function Test-RuleProperties
     # set $desiredConfigurationMatch to false.
     foreach ($parameter in $script:parameterList)
     {
-        $parameterSource = (Get-Variable -Name ($parameter.Variable)).Value.$($parameter.Source)
-        #$parameterSource = (Invoke-Expression -Command "`$($($parameter.source))")
+        if ($parameter.Property) {
+            $parameterValue = (Get-Variable `
+                -Name ($parameter.Variable)).value.$($parameter.Property).$($parameter.Name)
+        }
+        else
+        {
+            $parameterValue = (Get-Variable `
+                -Name ($parameter.Variable)).value.$($parameter.Name)
+        }
         $parameterNew = (Get-Variable -Name ($parameter.Name)).Value
-        #$parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
         switch -Wildcard ($parameter.Type)
         {
             'String'

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -74,12 +74,13 @@ function Get-TargetResource
     # the parameter array list and adding the values to
     foreach ($parameter in $script:parameterList)
     {
-        if ($parameter.type -in @('Array','ArrayIP'))
+        if ($parameter.Type -in @('Array','ArrayIP'))
         {
-            $parameterValue = @(Invoke-Expression -Command "`$($($parameter.source))")
-            if ($parameter.delimiter)
+            $parameterValue = @((Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source))
+            #$parameterValue = @(Invoke-Expression -Command "`$($($parameter.source))")
+            if ($parameter.Delimiter)
             {
-                $parameterValue = $parameterValue -split $parameter.delimiter
+                $parameterValue = $parameterValue -split $parameter.Delimiter
             }
             $result += @{
                 $parameter.Name = $parameterValue
@@ -92,7 +93,8 @@ function Get-TargetResource
         }
         else
         {
-            $parameterValue = (Invoke-Expression -Command "`$($($parameter.source))")
+            $parameterValue = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
+            #$parameterValue = (Invoke-Expression -Command "`$($($parameter.Source))")
             $result += @{
                 $parameter.Name = $parameterValue
             }
@@ -374,7 +376,8 @@ function Set-TargetResource
                     Foreach ($parameter in $ParametersList) {
                         if (-not $PSBoundParameters.ContainsKey($parameter.Name))
                         {
-                            $ParameterValue = (Invoke-Expression -Command "`$($($parameter.source))")
+                            $parameterValue = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
+                            #$ParameterValue = (Invoke-Expression -Command "`$($($parameter.source))")
                             if ($ParameterValue) {
                                 $null = $PSBoundParameters.Add($parameter.Name,$ParameterValue)
                             }
@@ -923,9 +926,11 @@ function Test-RuleProperties
     # set $desiredConfigurationMatch to false.
     foreach ($parameter in $script:parameterList)
     {
-        $parameterSource = (Invoke-Expression -Command "`$($($parameter.source))")
-        $parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
-        switch -Wildcard ($parameter.type)
+        $parameterSource = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
+        #$parameterSource = (Invoke-Expression -Command "`$($($parameter.source))")
+        $parameterNew = (Get-Variable -Name ($parameter.Name)).value
+        #$parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
+        switch -Wildcard ($parameter.Type)
         {
             'String'
             {
@@ -958,11 +963,11 @@ function Test-RuleProperties
                 {
                     $parameterSource = @()
                 }
-                if ($parameter.delimiter)
+                if ($parameter.Delimiter)
                 {
-                    $parameterSource = $parameterSource -split $parameter.delimiter
+                    $parameterSource = $parameterSource -split $parameter.Delimiter
                 }
-                if ($parameter.type -eq 'IPArray') {
+                if ($parameter.Type -eq 'IPArray') {
                     <#
                         IPArray comparison uses Compare-Object, except needs to convert any IP addresses
                         that use CIDR notation to use Subnet Mask notification because this is the

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -1198,7 +1198,6 @@ function Get-FirewallRuleProperty
 function Get-FirewallPropertyValue
 {
     [CmdletBinding()]
-    [OutputType([HashTable])]
     param (
         [Parameter(Mandatory = $true)]
         $FirewallRule,

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -42,7 +42,8 @@ function Get-TargetResource
         # Name of the Firewall Rule
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String] $Name
+        [String]
+        $Name
     )
     $ErrorActionPreference = 'Stop'
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -233,95 +234,127 @@ function Set-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String] $Name,
+        [String]
+        $Name,
 
         [ValidateNotNullOrEmpty()]
-        [String] $DisplayName,
+        [String]
+        $DisplayName,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Group,
+        [String]
+        $Group,
 
         [ValidateSet('Present', 'Absent')]
-        [String] $Ensure = 'Present',
+        [String]
+        $Ensure = 'Present',
 
         [ValidateSet('True', 'False')]
-        [String] $Enabled,
+        [String]
+        $Enabled,
 
         [ValidateSet('NotConfigured', 'Allow', 'Block')]
-        [String] $Action,
+        [String]
+        $Action,
 
-        [String[]] $Profile,
+        [String[]]
+        $Profile,
 
         [ValidateSet('Inbound', 'Outbound')]
-        [String] $Direction,
+        [String]
+        $Direction,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $RemotePort,
+        [String[]]
+        $RemotePort,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $LocalPort,
+        [String[]]
+        $LocalPort,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Protocol,
+        [String]
+        $Protocol,
 
-        [String] $Description,
+        [String]
+        $Description,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Program,
+        [String]
+        $Program,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Service,
+        [String]
+        $Service,
 
         [ValidateSet('NotRequired', 'Required', 'NoEncap')]
-        [String] $Authentication,
+        [String]
+        $Authentication,
 
         [ValidateSet('NotRequired', 'Required', 'Dynamic')]
-        [String] $Encryption,
+        [String]
+        $Encryption,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $InterfaceAlias,
+        [String[]]
+        $InterfaceAlias,
 
         [ValidateSet('Any', 'Wired', 'Wireless', 'RemoteAccess')]
-        [String] $InterfaceType,
+        [String]
+        $InterfaceType,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $LocalAddress,
+        [String[]]
+        $LocalAddress,
 
         [ValidateNotNullOrEmpty()]
-        [String] $LocalUser,
+        [String]
+        $LocalUser,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Package,
+        [String]
+        $Package,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $Platform,
+        [String[]]
+        $Platform,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $RemoteAddress,
+        [String[]]
+        $RemoteAddress,
 
         [ValidateNotNullOrEmpty()]
-        [String] $RemoteMachine,
+        [String]
+        $RemoteMachine,
 
         [ValidateNotNullOrEmpty()]
-        [String] $RemoteUser,
+        [String]
+        $RemoteUser,
 
         [ValidateSet('Any','ProximityApps','ProximitySharing','WifiDirectPrinting','WifiDirectDisplay','WifiDirectDevices')]
-        [String] $DynamicTransport,
+        [String]
+        $DynamicTransport,
 
         [ValidateSet('Block','Allow','DeferToUser','DeferToApp')]
-        [String] $EdgeTraversalPolicy,
+        [String]
+        $EdgeTraversalPolicy,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $IcmpType,
+        [String[]]
+        $IcmpType,
 
-        [Boolean] $LocalOnlyMapping,
+        [Boolean]
+        $LocalOnlyMapping,
 
-        [Boolean] $LooseSourceMapping,
+        [Boolean]
+        $LooseSourceMapping,
 
-        [Boolean] $OverrideBlockRules,
+        [Boolean]
+        $OverrideBlockRules,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Owner
+        [String]
+        $Owner
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -573,95 +606,127 @@ function Test-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String] $Name,
+        [String]
+        $Name,
 
         [ValidateNotNullOrEmpty()]
-        [String] $DisplayName,
+        [String]
+        $DisplayName,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Group,
+        [String]
+        $Group,
 
         [ValidateSet('Present', 'Absent')]
-        [String] $Ensure = 'Present',
+        [String]
+        $Ensure = 'Present',
 
         [ValidateSet('True', 'False')]
-        [String] $Enabled,
+        [String]
+        $Enabled,
 
         [ValidateSet('NotConfigured', 'Allow', 'Block')]
-        [String] $Action,
+        [String]
+        $Action,
 
-        [String[]] $Profile,
+        [String[]]
+        $Profile,
 
         [ValidateSet('Inbound', 'Outbound')]
-        [String] $Direction,
+        [String]
+        $Direction,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $RemotePort,
+        [String[]]
+        $RemotePort,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $LocalPort,
+        [String[]]
+        $LocalPort,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Protocol,
+        [String]
+        $Protocol,
 
-        [String] $Description,
+        [String]
+        $Description,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Program,
+        [String]
+        $Program,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Service,
+        [String]
+        $Service,
 
         [ValidateSet('NotRequired', 'Required', 'NoEncap')]
-        [String] $Authentication,
+        [String]
+        $Authentication,
 
         [ValidateSet('NotRequired', 'Required', 'Dynamic')]
-        [String] $Encryption,
+        [String]
+        $Encryption,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $InterfaceAlias,
+        [String[]]
+        $InterfaceAlias,
 
         [ValidateSet('Any', 'Wired', 'Wireless', 'RemoteAccess')]
-        [String] $InterfaceType,
+        [String]
+        $InterfaceType,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $LocalAddress,
+        [String[]]
+        $LocalAddress,
 
         [ValidateNotNullOrEmpty()]
-        [String] $LocalUser,
+        [String]
+        $LocalUser,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Package,
+        [String]
+        $Package,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $Platform,
+        [String[]]
+        $Platform,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $RemoteAddress,
+        [String[]]
+        $RemoteAddress,
 
         [ValidateNotNullOrEmpty()]
-        [String] $RemoteMachine,
+        [String]
+        $RemoteMachine,
 
         [ValidateNotNullOrEmpty()]
-        [String] $RemoteUser,
+        [String]
+        $RemoteUser,
 
         [ValidateSet('Any','ProximityApps','ProximitySharing','WifiDirectPrinting','WifiDirectDisplay','WifiDirectDevices')]
-        [String] $DynamicTransport,
+        [String]
+        $DynamicTransport,
 
         [ValidateSet('Block','Allow','DeferToUser','DeferToApp')]
-        [String] $EdgeTraversalPolicy,
+        [String]
+        $EdgeTraversalPolicy,
 
         [ValidateNotNullOrEmpty()]
-        [String[]] $IcmpType,
+        [String[]]
+        $IcmpType,
 
-        [Boolean] $LocalOnlyMapping,
+        [Boolean]
+        $LocalOnlyMapping,
 
-        [Boolean] $LooseSourceMapping,
+        [Boolean]
+        $LooseSourceMapping,
 
-        [Boolean] $OverrideBlockRules,
+        [Boolean]
+        $OverrideBlockRules,
 
         [ValidateNotNullOrEmpty()]
-        [String] $Owner
+        [String]
+        $Owner
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -841,80 +906,113 @@ function Test-RuleProperties
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String] $Name,
+        [String]
+        $Name,
 
-        [String] $DisplayName,
+        [String]
+        $DisplayName,
 
-        [String] $Group,
+        [String]
+        $Group,
 
-        [String] $DisplayGroup,
+        [String]
+        $DisplayGroup,
 
         [ValidateSet('Present', 'Absent')]
-        [String] $Ensure = 'Present',
+        [String]
+        $Ensure = 'Present',
 
         [ValidateSet('True', 'False')]
-        [String] $Enabled,
+        [String]
+        $Enabled,
 
         [ValidateSet('NotConfigured', 'Allow', 'Block')]
-        [String] $Action,
+        [String]
+        $Action,
 
-        [String[]] $Profile,
+        [String[]]
+        $Profile,
 
         [ValidateSet('Inbound', 'Outbound')]
-        [String] $Direction,
+        [String]
+        $Direction,
 
-        [String[]] $RemotePort,
+        [String[]]
+        $RemotePort,
 
-        [String[]] $LocalPort,
+        [String[]]
+        $LocalPort,
 
-        [String] $Protocol,
+        [String]
+        $Protocol,
 
-        [String] $Description,
+        [String]
+        $Description,
 
-        [String] $Program,
+        [String]
+        $Program,
 
-        [String] $Service,
+        [String]
+        $Service,
 
         [ValidateSet('NotRequired', 'Required', 'NoEncap')]
-        [String] $Authentication,
+        [String]
+        $Authentication,
 
         [ValidateSet('NotRequired', 'Required', 'Dynamic')]
-        [String] $Encryption,
+        [String]
+        $Encryption,
 
-        [String[]] $InterfaceAlias,
+        [String[]]
+        $InterfaceAlias,
 
         [ValidateSet('Any', 'Wired', 'Wireless', 'RemoteAccess')]
-        [String] $InterfaceType,
+        [String]
+        $InterfaceType,
 
-        [String[]] $LocalAddress,
+        [String[]]
+        $LocalAddress,
 
-        [String] $LocalUser,
+        [String]
+        $LocalUser,
 
-        [String] $Package,
+        [String]
+        $Package,
 
-        [String[]] $Platform,
+        [String[]]
+        $Platform,
 
-        [String[]] $RemoteAddress,
+        [String[]]
+        $RemoteAddress,
 
-        [String] $RemoteMachine,
+        [String]
+        $RemoteMachine,
 
-        [String] $RemoteUser,
+        [String]
+        $RemoteUser,
 
         [ValidateSet('Any','ProximityApps','ProximitySharing','WifiDirectPrinting','WifiDirectDisplay','WifiDirectDevices')]
-        [String] $DynamicTransport,
+        [String]
+        $DynamicTransport,
 
         [ValidateSet('Block','Allow','DeferToUser','DeferToApp')]
-        [String] $EdgeTraversalPolicy,
+        [String]
+        $EdgeTraversalPolicy,
 
-        [String[]] $IcmpType,
+        [String[]]
+        $IcmpType,
 
-        [Boolean] $LocalOnlyMapping,
+        [Boolean]
+        $LocalOnlyMapping,
 
-        [Boolean] $LooseSourceMapping,
+        [Boolean]
+        $LooseSourceMapping,
 
-        [Boolean] $OverrideBlockRules,
+        [Boolean]
+        $OverrideBlockRules,
 
-        [String] $Owner
+        [String]
+        $Owner
     )
 
     $properties = Get-FirewallRuleProperty -FirewallRule $FirewallRule
@@ -926,9 +1024,9 @@ function Test-RuleProperties
     # set $desiredConfigurationMatch to false.
     foreach ($parameter in $script:parameterList)
     {
-        $parameterSource = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
+        $parameterSource = (Get-Variable -Name ($parameter.Variable)).Value.$($parameter.Source)
         #$parameterSource = (Invoke-Expression -Command "`$($($parameter.source))")
-        $parameterNew = (Get-Variable -Name ($parameter.Name)).value
+        $parameterNew = (Get-Variable -Name ($parameter.Name)).Value
         #$parameterNew = (Invoke-Expression -Command "`$$($parameter.name)")
         switch -Wildcard ($parameter.Type)
         {
@@ -1012,7 +1110,8 @@ function Get-FirewallRule
     param (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String] $Name
+        [String]
+        $Name
     )
 
     $firewallRule = @(Get-NetFirewallRule -Name $Name -ErrorAction SilentlyContinue)

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -1117,7 +1117,8 @@ function Get-FirewallRule
 {
     [CmdletBinding()]
     [OutputType([Microsoft.Management.Infrastructure.CimInstance])]
-    param (
+    param
+    (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String]
@@ -1162,7 +1163,8 @@ function Get-FirewallRuleProperty
 {
     [CmdletBinding()]
     [OutputType([HashTable])]
-    param (
+    param
+    (
         [Parameter(Mandatory = $true)]
         $FirewallRule
      )
@@ -1198,7 +1200,8 @@ function Get-FirewallRuleProperty
 function Get-FirewallPropertyValue
 {
     [CmdletBinding()]
-    param (
+    param
+    (
         [Parameter(Mandatory = $true)]
         $FirewallRule,
 
@@ -1222,4 +1225,4 @@ function Get-FirewallPropertyValue
 
 #endregion
 
-Export-ModuleMember -Function *-TargetResource,Convert-CIDRToSubhetMask
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -1043,11 +1043,11 @@ function Test-RuleProperties
             'String'
             {
                 # Perform a plain string comparison.
-                if ($parameterNew -and ($parameterSource -ne $parameterNew))
+                if ($parameterNew -and ($parameterValue -ne $parameterNew))
                 {
                     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
                         $($script:localizedData.PropertyNoMatchMessage) `
-                            -f $parameter.Name,$parameterSource,$parameterNew
+                            -f $parameter.Name,$parameterValue,$parameterNew
                         ) -join '')
                     $desiredConfigurationMatch = $false
                 }
@@ -1055,11 +1055,11 @@ function Test-RuleProperties
             'Boolean'
             {
                 # Perform a boolean comparison.
-                if ($parameterNew -and ($parameterSource -ne $parameterNew))
+                if ($parameterNew -and ($parameterValue -ne $parameterNew))
                 {
                     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
                         $($script:localizedData.PropertyNoMatchMessage) `
-                            -f $parameter.Name,$parameterSource,$parameterNew
+                            -f $parameter.Name,$parameterValue,$parameterNew
                         ) -join '')
                     $desiredConfigurationMatch = $false
                 }
@@ -1067,13 +1067,13 @@ function Test-RuleProperties
             'Array*'
             {
                 # Array comparison uses Compare-Object
-                if ($null -eq $parameterSource)
+                if ($null -eq $parameterValue)
                 {
-                    $parameterSource = @()
+                    $parameterValue = @()
                 }
                 if ($parameter.Delimiter)
                 {
-                    $parameterSource = $parameterSource -split $parameter.Delimiter
+                    $parameterValue = $parameterValue -split $parameter.Delimiter
                 }
                 if ($parameter.Type -eq 'IPArray') {
                     <#
@@ -1087,12 +1087,12 @@ function Test-RuleProperties
 
                 if ($parameterNew `
                     -and ((Compare-Object `
-                        -ReferenceObject $parameterSource `
+                        -ReferenceObject $parameterValue `
                         -DifferenceObject $parameterNew).Count -ne 0))
                 {
                     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
                         $($script:localizedData.PropertyNoMatchMessage) `
-                            -f $parameter.Name,($parameterSource -join ','),($parameterNew -join ',')
+                            -f $parameter.Name,($parameterValue -join ','),($parameterNew -join ',')
                         ) -join '')
                     $desiredConfigurationMatch = $false
                 }

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -20,7 +20,8 @@ function Convert-CIDRToSubhetMask
 {
     [CmdletBinding()]
     [OutputType([ Microsoft.Management.Infrastructure.CimInstance])]
-    param (
+    param
+    (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [String[]] $Address

--- a/Tests/Integration/IntegrationHelper.ps1
+++ b/Tests/Integration/IntegrationHelper.ps1
@@ -1,7 +1,8 @@
 function New-IntegrationLoopbackAdapter
 {
     [cmdletbinding()]
-    param (
+    param
+    (
         [String]
         $AdapterName
     )
@@ -39,7 +40,8 @@ function New-IntegrationLoopbackAdapter
 function Remove-IntegrationLoopbackAdapter
 {
     [cmdletbinding()]
-    param (
+    param
+    (
         [String]
         $AdapterName
     )

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
@@ -80,10 +80,11 @@ try
         # Use the Parameters List to perform these tests
         foreach ($parameter in $parameterList)
         {
-            $parameterSource = (Invoke-Expression -Command "`$DnsClientGlobalSettingNew.$($parameter.name)")
-            $parameterNew = (Invoke-Expression -Command "`$configData.AllNodes[0].$($parameter.name)")
+            $parameterValue = (Get-Variable -Name 'DnsClientGlobalSettingNew').value.$($parameter.name)
+            $parameterNew = (Get-Variable -Name configData).Value.AllNodes[0].$($parameter.Name)
+
             It "Should have set the '$parameterName' to '$parameterNew'" {
-                $parameterSource | Should Be $parameterNew
+                $parameterValue | Should Be $parameterNew
             }
         }
     }

--- a/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
@@ -115,15 +115,15 @@ try
         {
             $parameterName = $parameter.Name
             if ($parameterName -ne 'Name') {
-                $parameterSource = (Invoke-Expression -Command "`$($($parameter.source))")
-                $parameterNew = (Invoke-Expression -Command "`$configData.AllNodes[0].$($parameter.name)")
-                if ($parameter.type -eq 'Array' -and $parameter.Delimiter) {
+                $parameterSource = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
+                $parameterNew = (Get-Variable -Name configData).Value.AllNodes[0].$($parameter.Name)
+                if ($parameter.Type -eq 'Array' -and $parameter.Delimiter) {
                     $parameterNew = $parameterNew -join $parameter.Delimiter
                     It "Should have set the '$parameterName' to '$parameterNew'" {
                         $parameterSource | Should Be $parameterNew
                     }
                 }
-                elseif ($parameter.type -eq 'ArrayIP')
+                elseif ($parameter.Type -eq 'ArrayIP')
                 {
                     for ([int] $entry = 0; $entry -lt $parameterNew.Count; $entry++)
                     {

--- a/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
@@ -115,12 +115,20 @@ try
         {
             $parameterName = $parameter.Name
             if ($parameterName -ne 'Name') {
-                $parameterSource = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
+                if ($parameter.Property) {
+                    $parameterValue = (Get-Variable `
+                        -Name ($parameter.Variable)).value.$($parameter.Property).$($parameter.Name)
+                }
+                else
+                {
+                    $parameterValue = (Get-Variable `
+                        -Name ($parameter.Variable)).value.$($parameter.Name)
+                }
                 $parameterNew = (Get-Variable -Name configData).Value.AllNodes[0].$($parameter.Name)
                 if ($parameter.Type -eq 'Array' -and $parameter.Delimiter) {
                     $parameterNew = $parameterNew -join $parameter.Delimiter
                     It "Should have set the '$parameterName' to '$parameterNew'" {
-                        $parameterSource | Should Be $parameterNew
+                        $parameterValue | Should Be $parameterNew
                     }
                 }
                 elseif ($parameter.Type -eq 'ArrayIP')
@@ -128,14 +136,14 @@ try
                     for ([int] $entry = 0; $entry -lt $parameterNew.Count; $entry++)
                     {
                         It "Should have set the '$parameterName' arry item $entry to '$($parameterNew[$entry])'" {
-                            $parameterSource[$entry] | Should Be (Convert-CIDRToSubhetMask -Address $parameterNew[$entry])
+                            $parameterValue[$entry] | Should Be (Convert-CIDRToSubhetMask -Address $parameterNew[$entry])
                         }
                     }
                 }
                 else
                 {
                     It "Should have set the '$parameterName' to '$parameterNew'" {
-                        $parameterSource | Should Be $parameterNew
+                        $parameterValue | Should Be $parameterNew
                     }
                 }
             }

--- a/Tests/Integration/MSFT_xNetworkTeamInterface.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeamInterface.Integration.Tests.ps1
@@ -1,9 +1,9 @@
 #Remove this following line before using this integration test script
 return
 
-$Global:DSCModuleName      = 'xNetworking'
-$Global:DSCResourceName    = 'MSFT_xNetworkTeamInterface'
-$Global:teamMembers        = (Get-NetAdapter -Physical).Name
+$script:DSCModuleName      = 'xNetworking'
+$script:DSCResourceName    = 'MSFT_xNetworkTeamInterface'
+$script:teamMembers        = (Get-NetAdapter -Physical).Name
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
@@ -17,8 +17,8 @@ if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCR
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
 $TestEnvironment = Initialize-TestEnvironment `
-    -DSCModuleName $Global:DSCModuleName `
-    -DSCResourceName $Global:DSCResourceName `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
     -TestType Integration
 #endregion
 
@@ -26,14 +26,14 @@ $TestEnvironment = Initialize-TestEnvironment `
 try
 {
     #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($Global:DSCResourceName).config.ps1"
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($Global:DSCResourceName)_Integration" {
+    Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
         It 'Should compile without throwing' {
             {
-                Invoke-Expression -Command "$($Global:DSCResourceName)_Config -OutputPath `$TestDrive"
+                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
@@ -45,10 +45,10 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $result = Get-DscConfiguration    | Where-Object {$_.ConfigurationName -eq "$($Global:DSCResourceName)_Config"}
+            $result = Get-DscConfiguration    | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $result[0].Ensure                 | Should Be $TestTeam.Ensure
             $result[0].Name                   | Should Be $TestTeam.Name
-            $result[0].TeamMembers            | Should Be $Global:teamMembers
+            $result[0].TeamMembers            | Should Be $script:teamMembers
             $result[0].loadBalancingAlgorithm | Should Be $TestTeam.loadBalancingAlgorithm
             $result[0].teamingMode            | Should Be $TestTeam.teamingMode
             $result[1].Ensure                 | Should Be $TestInterface.Ensure

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -51,7 +51,7 @@ try
             }
 
             Context 'Present should return correctly' {
-                $result = Get-TargetResource -Name $FirewallRule.Name -Verbose
+                $result = Get-TargetResource -Name $FirewallRule.Name
 
                 # Looping these tests
                 foreach ($parameter in $ParameterList)
@@ -652,7 +652,7 @@ try
             Context 'testing with a rule with no property differences' {
                 $CompareRule = $Splat.Clone()
                 It "should return True on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $True
                 }
             }
@@ -660,7 +660,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Name = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -668,7 +668,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.DisplayName = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -676,7 +676,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Group = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -690,7 +690,7 @@ try
                     $CompareRule.Enabled = 'True'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -704,7 +704,7 @@ try
                     $CompareRule.Action = 'Allow'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -718,7 +718,7 @@ try
                     $CompareRule.Profile = @('Domain','Public')
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -732,7 +732,7 @@ try
                     $CompareRule.Direction = 'Inbound'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -740,7 +740,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.RemotePort = 1
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -748,7 +748,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LocalPort = 1
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -762,7 +762,7 @@ try
                     $CompareRule.Protocol = 'TCP'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -770,7 +770,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Description = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -778,7 +778,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Program = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -786,7 +786,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Service = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -800,7 +800,7 @@ try
                     $CompareRule.Authentication = 'Required'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -814,7 +814,7 @@ try
                     $CompareRule.Encryption = 'Required'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -822,7 +822,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.InterfaceAlias = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -836,7 +836,7 @@ try
                     $CompareRule.InterfaceType = 'Wired'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -844,7 +844,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LocalAddress = @('10.0.0.1/255.0.0.0','10.1.1.0-10.1.2.0')
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -852,7 +852,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LocalUser = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -860,7 +860,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Package = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -868,7 +868,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Platform = @('6.2')
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -876,7 +876,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.RemoteAddress = @('10.0.0.1/255.0.0.0','10.1.1.0-10.1.2.0')
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -884,7 +884,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.RemoteMachine = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -892,7 +892,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.RemoteUser = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -900,7 +900,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.DynamicTransport = 'WifiDirectDevices'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -908,7 +908,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.EdgeTraversalPolicy = 'DeferToApp'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -916,7 +916,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.IcmpType = @('53','54')
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -924,7 +924,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LocalOnlyMapping = ! $CompareRule.LocalOnlyMapping
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -932,7 +932,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LooseSourceMapping = ! $CompareRule.LooseSourceMapping
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -940,7 +940,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.OverrideBlockRules = ! $CompareRule.OverrideBlockRules
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }
@@ -948,7 +948,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Owner = (Get-CimInstance win32_useraccount | Select-Object -First 1).Sid
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
                     $Result | Should be $False
                 }
             }

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -51,12 +51,12 @@ try
             }
 
             Context 'Present should return correctly' {
-                $result = Get-TargetResource -Name $FirewallRule.Name
+                $result = Get-TargetResource -Name $FirewallRule.Name -Verbose
 
                 # Looping these tests
                 foreach ($parameter in $ParameterList)
                 {
-                    $parameterSource = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
+                    $parameterSource = (Get-Variable -Name ($parameter.Variable)).Value.$($parameter.Source)
                     $parameterNew = (Get-Variable -Name 'Result').Value.$($parameter.Name)
                     It "should have the correct $($parameter.Name) on firewall rule $($FirewallRule.Name)" {
                         if ($parameter.Delimiter)
@@ -619,12 +619,12 @@ try
             $Splat = @{}
             foreach ($parameter in $ParameterList)
             {
-                $parameterSource = (Invoke-Expression -Command "`$($($parameter.source))")
-                if ($parameter.delimiter)
+                $parameterSource = (Get-Variable -Name ($parameter.Variable)).Value.$($parameter.Source)
+                if ($parameter.Delimiter)
                 {
-                    $parameterSource = $parameterSource -split $parameter.delimiter
+                    $parameterSource = $parameterSource -split $parameter.Delimiter
                 }
-                $Splat += @{ $parameter.name = $parameterSource }
+                $Splat += @{ $parameter.Name = $parameterSource }
             }
 
             # To speed up all these tests create Mocks so that these functions are not repeatedly called

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -652,7 +652,7 @@ try
             Context 'testing with a rule with no property differences' {
                 $CompareRule = $Splat.Clone()
                 It "should return True on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $True
                 }
             }
@@ -660,7 +660,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Name = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -668,7 +668,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.DisplayName = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -676,7 +676,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Group = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -690,7 +690,7 @@ try
                     $CompareRule.Enabled = 'True'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -704,7 +704,7 @@ try
                     $CompareRule.Action = 'Allow'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -718,7 +718,7 @@ try
                     $CompareRule.Profile = @('Domain','Public')
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -732,7 +732,7 @@ try
                     $CompareRule.Direction = 'Inbound'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -740,7 +740,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.RemotePort = 1
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -748,7 +748,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LocalPort = 1
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -762,7 +762,7 @@ try
                     $CompareRule.Protocol = 'TCP'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -770,7 +770,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Description = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -778,7 +778,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Program = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -786,7 +786,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Service = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -800,7 +800,7 @@ try
                     $CompareRule.Authentication = 'Required'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -814,7 +814,7 @@ try
                     $CompareRule.Encryption = 'Required'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -822,7 +822,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.InterfaceAlias = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -836,7 +836,7 @@ try
                     $CompareRule.InterfaceType = 'Wired'
                 }
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -844,7 +844,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LocalAddress = @('10.0.0.1/255.0.0.0','10.1.1.0-10.1.2.0')
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -852,7 +852,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LocalUser = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -860,7 +860,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Package = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -868,7 +868,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Platform = @('6.2')
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -876,7 +876,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.RemoteAddress = @('10.0.0.1/255.0.0.0','10.1.1.0-10.1.2.0')
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -884,7 +884,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.RemoteMachine = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -892,7 +892,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.RemoteUser = 'Different'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -900,7 +900,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.DynamicTransport = 'WifiDirectDevices'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -908,7 +908,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.EdgeTraversalPolicy = 'DeferToApp'
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -916,7 +916,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.IcmpType = @('53','54')
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -924,7 +924,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LocalOnlyMapping = ! $CompareRule.LocalOnlyMapping
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -932,7 +932,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.LooseSourceMapping = ! $CompareRule.LooseSourceMapping
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -940,7 +940,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.OverrideBlockRules = ! $CompareRule.OverrideBlockRules
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }
@@ -948,7 +948,7 @@ try
                 $CompareRule = $Splat.Clone()
                 $CompareRule.Owner = (Get-CimInstance win32_useraccount | Select-Object -First 1).Sid
                 It "should return False on firewall rule $($FirewallRule.Name)" {
-                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule
+                    $Result = Test-RuleProperties -FirewallRule $FirewallRule @CompareRule -Verbose
                     $Result | Should be $False
                 }
             }

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -56,14 +56,23 @@ try
                 # Looping these tests
                 foreach ($parameter in $ParameterList)
                 {
-                    $parameterSource = (Get-Variable -Name ($parameter.Variable)).Value.$($parameter.Source)
+                    if ($parameter.Property) {
+                        $parameterValue = (Get-Variable `
+                            -Name ($parameter.Variable)).value.$($parameter.Property).$($parameter.Name)
+                    }
+                    else
+                    {
+                        $parameterValue = (Get-Variable `
+                            -Name ($parameter.Variable)).value.$($parameter.Name)
+                    }
+
                     $parameterNew = (Get-Variable -Name 'Result').Value.$($parameter.Name)
                     It "should have the correct $($parameter.Name) on firewall rule $($FirewallRule.Name)" {
                         if ($parameter.Delimiter)
                         {
                             $parameterNew = $parameterNew -join ','
                         }
-                        $parameterNew | Should Be $parameterSource
+                        $parameterNew | Should Be $parameterValue
                     }
                 }
             }
@@ -619,13 +628,21 @@ try
             $Splat = @{}
             foreach ($parameter in $ParameterList)
             {
-                $parameterSource = (Get-Variable -Name ($parameter.Variable)).Value.$($parameter.Source)
-                Write-Verbose -Verbose -Message "$($parameter.Variable).$($parameter.Source) -> $($parameter.Name) = $parameterSource"
+                if ($parameter.Property) {
+                    $parameterValue = (Get-Variable `
+                        -Name ($parameter.Variable)).value.$($parameter.Property).$($parameter.Name)
+                }
+                else
+                {
+                    $parameterValue = (Get-Variable `
+                        -Name ($parameter.Variable)).value.$($parameter.Name)
+                }
+
                 if ($parameter.Delimiter)
                 {
-                    $parameterSource = $parameterSource -split $parameter.Delimiter
+                    $parameterValue = $parameterValue -split $parameter.Delimiter
                 }
-                $Splat += @{ $parameter.Name = $parameterSource }
+                $Splat += @{ $parameter.Name = $parameterValue }
             }
 
             # To speed up all these tests create Mocks so that these functions are not repeatedly called

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -56,10 +56,10 @@ try
                 # Looping these tests
                 foreach ($parameter in $ParameterList)
                 {
-                    $parameterSource = (Invoke-Expression -Command "`$($($parameter.source))")
-                    $parameterNew = (Invoke-Expression -Command "`$result.$($parameter.name)")
+                    $parameterSource = (Get-Variable -Name ($parameter.Variable)).value.$($parameter.Source)
+                    $parameterNew = (Get-Variable -Name 'Result').Value.$($parameter.Name)
                     It "should have the correct $($parameter.Name) on firewall rule $($FirewallRule.Name)" {
-                        if ($parameter.delimiter)
+                        if ($parameter.Delimiter)
                         {
                             $parameterNew = $parameterNew -join ','
                         }

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -620,6 +620,7 @@ try
             foreach ($parameter in $ParameterList)
             {
                 $parameterSource = (Get-Variable -Name ($parameter.Variable)).Value.$($parameter.Source)
+                Write-Verbose -Verbose -Message "$($parameter.Variable).$($parameter.Source) -> $($parameter.Name) = $parameterSource"
                 if ($parameter.Delimiter)
                 {
                     $parameterSource = $parameterSource -split $parameter.Delimiter

--- a/Tests/Unit/MSFT_xNetAdapterRDMA.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterRDMA.Tests.ps1
@@ -62,7 +62,8 @@ try
         Describe "$($script:DSCResourceName)\Set-TargetResource" {
             function Get-NetAdapterRdma { }
             function Set-NetAdapterRdma {
-                param (
+                param
+                (
                     [String] $Name,
                     [Boolean] $Enabled = $true
                 )


### PR DESCRIPTION
This PR converts all the Invoke-Expression code (including the tests) over to the ```Get-Variable``` method.

This resolves the last of the PSSA warnings.

I also fixed the Integration Tests for xNetworkTeamInterface to remove Invoke-Expression, but also bring it up to the current Integration test template level (removed $Global etc).

And finally I fixed the parameter block layout of xFirewall to meet HQRM (I missed it last time).

I'll try and look at #176 and #177 over the weekend if I get time (or unless you get to them first :grin: )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/179)
<!-- Reviewable:end -->
