### PR TITLE
Fix Test-TargetResource failing on subsequent runs. - Fixes #207

### DIFF
--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
@@ -341,7 +341,6 @@ function Test-TargetResource
         $($LocalizedData.TestingNetAdapterNameMessage)
         ) -join '')
 
-    $NewName = $PSBoundParameters.NewName
     $null = $PSBoundParameters.Remove('NewName')
     try 
     { 
@@ -349,7 +348,7 @@ function Test-TargetResource
             @PSBoundParameters `
             -ErrorAction Stop
     }    
-    Catch
+    catch
     {
         $PSBoundParameters.Name = $NewName
         $adapter = Find-NetworkAdapter `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
@@ -343,12 +343,13 @@ function Test-TargetResource
 
     $NewName = $PSBoundParameters.NewName
     $null = $PSBoundParameters.Remove('NewName')
-
-    $adapter = Find-NetworkAdapter `
-        @PSBoundParameters `
-        -ErrorAction SilentlyContinue
-    
-    if (-not ($adapter))
+    try 
+    { 
+        $adapter = Find-NetworkAdapter `
+            @PSBoundParameters `
+            -ErrorAction Stop
+    }    
+    Catch
     {
         $PSBoundParameters.Name = $NewName
         $adapter = Find-NetworkAdapter `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
@@ -341,12 +341,19 @@ function Test-TargetResource
         $($LocalizedData.TestingNetAdapterNameMessage)
         ) -join '')
 
+    $NewName = $PSBoundParameters.NewName
     $null = $PSBoundParameters.Remove('NewName')
 
     $adapter = Find-NetworkAdapter `
         @PSBoundParameters `
-        -ErrorAction Stop
-
+        -ErrorAction SilentlyContinue
+    
+    if (-not ($adapter))
+    {
+        $adapter = Find-NetworkAdapter `
+            @PSBoundParameters `
+            -ErrorAction Stop
+    }
     if ($adapter.Name -eq $NewName)
     {
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
@@ -350,6 +350,7 @@ function Test-TargetResource
     
     if (-not ($adapter))
     {
+        $PSBoundParameters.Name = $NewName
         $adapter = Find-NetworkAdapter `
             @PSBoundParameters `
             -ErrorAction Stop

--- a/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
@@ -61,6 +61,8 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
+                Start-DscConfiguration -Path $TestDrive `
+                    -ComputerName localhost -Wait -Verbose -Force
             } | Should Not Throw
         }
 
@@ -72,33 +74,6 @@ try
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
             $current.Name                     | Should Be $newAdapterName
-        }
-
-        It 'should compile and apply the MOF a second time without throwing' {
-            {
-                # This is to pass to the Config
-                $configData = @{
-                    AllNodes = @(
-                        @{
-                            NodeName             = 'localhost'
-                            NewName              = $newAdapterName
-                            Name                 = $adapter.Name
-                            PhysicalMediaType    = $adapter.PhysicalMediaType
-                            Status               = $adapter.Status
-                            MacAddress           = $adapter.MacAddress
-                            InterfaceDescription = $adapter.InterfaceDescription
-                            InterfaceIndex       = $adapter.InterfaceIndex
-                            InterfaceGuid        = $adapter.InterfaceGuid
-                        }
-                    )
-                }
-
-                & "$($script:DSCResourceName)_Config" `
-                    -OutputPath $TestDrive `
-                    -ConfigurationData $configData
-                Start-DscConfiguration -Path $TestDrive `
-                    -ComputerName localhost -Wait -Verbose -Force
-            } | Should Not Throw
         }
 
         AfterAll {

--- a/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
@@ -74,6 +74,33 @@ try
             $current.Name                     | Should Be $newAdapterName
         }
 
+        It 'should compile and apply the MOF a second time without throwing' {
+            {
+                # This is to pass to the Config
+                $configData = @{
+                    AllNodes = @(
+                        @{
+                            NodeName             = 'localhost'
+                            NewName              = $newAdapterName
+                            Name                 = $adapter.Name
+                            PhysicalMediaType    = $adapter.PhysicalMediaType
+                            Status               = $adapter.Status
+                            MacAddress           = $adapter.MacAddress
+                            InterfaceDescription = $adapter.InterfaceDescription
+                            InterfaceIndex       = $adapter.InterfaceIndex
+                            InterfaceGuid        = $adapter.InterfaceGuid
+                        }
+                    )
+                }
+
+                & "$($script:DSCResourceName)_Config" `
+                    -OutputPath $TestDrive `
+                    -ConfigurationData $configData
+                Start-DscConfiguration -Path $TestDrive `
+                    -ComputerName localhost -Wait -Verbose -Force
+            } | Should Not Throw
+        }
+
         AfterAll {
             # Remove Loopback Adapter
             Remove-IntegrationLoopbackAdapter -AdapterName $newAdapterName

--- a/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
@@ -61,9 +61,12 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
-                Start-DscConfiguration -Path $TestDrive `
-                    -ComputerName localhost -Wait -Verbose -Force
             } | Should Not Throw
+        }
+
+        it 'should reapply the MOF without throwing' {
+            {Start-DscConfiguration -Path $TestDrive `
+                -ComputerName localhost -Wait -Verbose -Force} | Should Not Throw
         }
 
         It 'should be able to call Get-DscConfiguration without throwing' {

--- a/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
@@ -168,7 +168,7 @@ try
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 2
                 }
             }
         }

--- a/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
@@ -155,16 +155,16 @@ try
                 }
             }
 
-            Context 'Matching adapter can be found and has wrong Name' {
+            Context 'Adapter name changed by Set-TargetResource' {
                 Mock -CommandName Find-NetworkAdapter -MockWith { $PSCmdlet.ThrowTerminatingError('Wrong Adapter') } -ParameterFilter {$Name -and $Name -eq $script:adapterName}
-                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter } -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
+                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter } -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
 
                 It 'should not throw' {
                     { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
                 }
 
                 It 'should return false' {
-                    $script:result                      | Should Be $false
+                    $script:result                      | Should Be $True
                 }
 
                 It 'Should call all the mocks' {

--- a/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
@@ -154,6 +154,23 @@ try
                     Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1
                 }
             }
+
+            Context 'Matching adapter can be found and has wrong Name' {
+                Mock -CommandName Find-NetworkAdapter -MockWith { $PSCmdlet.ThrowTerminatingError('Wrong Adapter') } -ParameterFilter {$Name -and $Name -eq $script:adapterName}
+                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter } -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
+
+                It 'should not throw' {
+                    { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
+                }
+
+                It 'should return false' {
+                    $script:result                      | Should Be $false
+                }
+
+                It 'Should call all the mocks' {
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1
+                }
+            }
         }
     } #end InModuleScope $DSCResourceName
     #endregion


### PR DESCRIPTION
As seen in #207 Test-TargetResource will fail on subsequent runs as the Name passed into Find-NetworkAdapter will be wrong as Set-TargetResource will have changed it.

Passing in NewName to Find-NetworkAdapter means it will return false on the first run and then return True on subsequent runs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/208)
<!-- Reviewable:end -->
