### PR TITLE
Improve xNetAdapterName Resource to handle already renamed adapters - Fixes #209

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,12 @@
 
 ## Unreleased
 
+- Find-NetworkAdapter:
+  - Fixed to return null if exception thrown.
+  - Allowed passing no selection parameters.
 - MSFT_xNetAdapterName:
+  - Fixed bug in Get-TargetResource when Name is the only adapter selector parameter.
+  - Improved verbose logging.
   - More improvements to verbose logging.
 
 ## 4.1.0.0
@@ -25,12 +30,6 @@
   - Created new resource for renaming network adapters.
   - Added Find-NetAdapter cmdlet to NetworkingDsc.Common.
 - Correct example parameters format to meet style guidelines.
-- Find-NetworkAdapter:
-  - Fixed to return null if exception thrown.
-  - Allowed passing no selection parameters.
-- MSFT_xNetAdapterName:
-  - Fixed bug in Get-TargetResource when Name is the only adapter selector parameter.
-  - Improved verbose logging.
 
 ## 3.2.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## Unreleased
 
+- MSFT_xNetAdapterName:
+  - More improvements to verbose logging.
+
 ## 4.1.0.0
 
 - Added integration test to test for conflicts with other common resource kit modules.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,12 @@
   - Created new resource for renaming network adapters.
   - Added Find-NetAdapter cmdlet to NetworkingDsc.Common.
 - Correct example parameters format to meet style guidelines.
+- Find-NetworkAdapter:
+  - Fixed to return null if exception thrown.
+  - Allowed passing no selection parameters.
+- MSFT_xNetAdapterName:
+  - Fixed bug in Get-TargetResource when Name is the only adapter selector parameter.
+  - Improved verbose logging.
 
 ## 3.2.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
@@ -119,7 +119,12 @@ function Get-TargetResource
 
     if (-not $adapter)
     {
-        $PSBoundParameters.Remove('NewName')
+        Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+            $($LocalizedData.FindNetAdapterMessage)
+            ) -join '')
+
+        $null = $PSBoundParameters.Remove('NewName')
+
         $adapter = Find-NetworkAdapter `
             @PSBoundParameters `
             -ErrorAction Stop
@@ -375,6 +380,10 @@ function Test-TargetResource
     else
     {
         # Find an adapter matching the parameters - throw if none can be found
+        Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
+            $($LocalizedData.FindNetAdapterMessage)
+            ) -join '')
+
         $adapter = Find-NetworkAdapter `
             @PSBoundParameters `
             -ErrorAction Stop

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/en-us/MSFT_xNetAdapterName.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/en-us/MSFT_xNetAdapterName.strings.psd1
@@ -1,10 +1,11 @@
 ConvertFrom-StringData @'
-    GettingNetAdapterNameMessage = Getting the Network Adapter Name '{0}'.
-    NetAdapterNameFoundMessage = Network Adapter '{0}' found.
-    SettingNetAdapterNameMessage = Setting the Network Adapter Name '{0}'.
-    RenamingNetAdapterNameMessage = Renaming Network Adapter '{0}' to '{1}'.
-    NetAdapterNameRenamedMessage = Network Adapter renamed to '{0}'.
-    TestingNetAdapterNameMessage = Testing the Network Adapter Name '{0}'.
-    NetAdapterWithNewNameExistsMessage = A Network Adapter was found with the intended new name '{0}' of the Adapter. No rename required.
-    NetAdapterNameNotMatchMessage = Network Adapter Name '{0}' does not match the adapter '{1}' that was found. Rename required.
+    GettingNetAdapterNameMessage = Getting the network adapter Name '{0}'.
+    FindNetAdapterMessage = Finding network adapter matching search criteria.
+    NetAdapterNameFoundMessage = network adapter '{0}' found.
+    SettingNetAdapterNameMessage = Setting the network adapter Name '{0}'.
+    RenamingNetAdapterNameMessage = Renaming network adapter '{0}' to '{1}'.
+    NetAdapterNameRenamedMessage = network adapter renamed to '{0}'.
+    TestingNetAdapterNameMessage = Testing the network adapter Name '{0}'.
+    NetAdapterWithNewNameExistsMessage = A network adapter was found with the intended new name '{0}' of the Adapter. No rename required.
+    NetAdapterNameNotMatchMessage = network adapter Name '{0}' does not match the adapter '{1}' that was found. Rename required.
 '@

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/en-us/MSFT_xNetAdapterName.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/en-us/MSFT_xNetAdapterName.strings.psd1
@@ -1,10 +1,10 @@
 ConvertFrom-StringData @'
-    GettingNetAdapterNameMessage = Getting the Network Adapter Name.
+    GettingNetAdapterNameMessage = Getting the Network Adapter Name '{0}'.
     NetAdapterNameFoundMessage = Network Adapter '{0}' found.
-    SettingNetAdapterNameMessage = Setting the Network Adapter Name.
+    SettingNetAdapterNameMessage = Setting the Network Adapter Name '{0}'.
     RenamingNetAdapterNameMessage = Renaming Network Adapter '{0}' to '{1}'.
     NetAdapterNameRenamedMessage = Network Adapter renamed to '{0}'.
-    TestingNetAdapterNameMessage = Testing the Network Adapter Name.
-    NetAdapterNameMatchMessage = Network Adapter Name '{0}' matches the adapter that was found.
-    NetAdapterNameNotMatchMessage = Network Adapter Name '{0}' does not match the adapter '{1}' that was found.
+    TestingNetAdapterNameMessage = Testing the Network Adapter Name '{0}'.
+    NetAdapterWithNewNameExistsMessage = A Network Adapter was found with the intended new name '{0}' of the Adapter. No rename required.
+    NetAdapterNameNotMatchMessage = Network Adapter Name '{0}' does not match the adapter '{1}' that was found. Rename required.
 '@

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -220,6 +220,8 @@ function Find-NetworkAdapter
     {
         New-InvalidOperationException `
             -Message ($LocalizedData.NetAdapterNotFoundError)
+        
+        # Return a null so that ErrorAction SilentlyContinue works correctly
         return $null
     }
     else
@@ -238,6 +240,8 @@ function Find-NetworkAdapter
                     New-InvalidOperationException `
                         -Message ($LocalizedData.InvalidNetAdapterNumberError `
                             -f $matchingAdapters.Count,$InterfaceNumber)
+                    
+                    # Return a null so that ErrorAction SilentlyContinue works correctly
                     return $null
                 } # if
             }
@@ -246,6 +250,8 @@ function Find-NetworkAdapter
                 New-InvalidOperationException `
                     -Message ($LocalizedData.MultipleMatchingNetAdapterFound `
                         -f $matchingAdapters.Count)
+
+                # Return a null so that ErrorAction SilentlyContinue works correctly
                 return $null
             } # if
         } # if

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -108,6 +108,7 @@ function Convert-CIDRToSubhetMask
 #>
 function Find-NetworkAdapter
 {
+    [CmdletBinding()]
     [OutputType([System.Collections.Hashtable])]
     param
     (
@@ -200,21 +201,26 @@ function Find-NetworkAdapter
 
     if ($adapterFilters.Count -eq 0)
     {
-        New-InvalidOperationException `
-            -Message ($LocalizedData.NetAdapterParameterError)
+        Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
+            $($LocalizedData.AllNetAdaptersFoundMessage)
+            ) -join '')
+
+        $matchingAdapters = @(Get-NetAdapter)
     }
-
-    # Join all the filters together
-    $adapterFilterScript = '(' + ($adapterFilters -join ' -and ') + ')'
-
-    $matchingAdapters = @(Get-NetAdapter |
-        Where-Object -FilterScript ([ScriptBlock]::Create($adapterFilterScript)))
+    else
+    {
+        # Join all the filters together
+        $adapterFilterScript = '(' + ($adapterFilters -join ' -and ') + ')'
+        $matchingAdapters = @(Get-NetAdapter |
+            Where-Object -FilterScript ([ScriptBlock]::Create($adapterFilterScript)))
+    }
 
     # Were any adapters found matching the criteria?
     if ($matchingAdapters.Count -eq 0)
     {
         New-InvalidOperationException `
             -Message ($LocalizedData.NetAdapterNotFoundError)
+        return $null
     }
     else
     {
@@ -232,6 +238,7 @@ function Find-NetworkAdapter
                     New-InvalidOperationException `
                         -Message ($LocalizedData.InvalidNetAdapterNumberError `
                             -f $matchingAdapters.Count,$InterfaceNumber)
+                    return $null
                 } # if
             }
             else
@@ -239,6 +246,7 @@ function Find-NetworkAdapter
                 New-InvalidOperationException `
                     -Message ($LocalizedData.MultipleMatchingNetAdapterFound `
                         -f $matchingAdapters.Count)
+                return $null
             } # if
         } # if
     } # if
@@ -257,7 +265,7 @@ function Find-NetworkAdapter
         MatchingAdapterCount = $matchingAdapters.Count
     }
 
-    $returnValue
+    return $returnValue
 } # Find-NetworkAdapter
 
 Export-ModuleMember -Function `

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/en-us/NetworkingDsc.Common.strings.psd1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/en-us/NetworkingDsc.Common.strings.psd1
@@ -1,7 +1,7 @@
 ConvertFrom-StringData @'
     FindingNetAdapterMessage = Finding Network Adapters matching the parameters.
+    AllNetAdaptersFoundMessage = Found all Network Adapters because no filter parameters provided.
     NetAdapterFoundMessage = {0} Network Adapters were found matching the parameters.
-    NetAdapterParameterError = At least one Network Adapter parameter must be passed.
     NetAdapterNotFoundError = A Network Adapter matching the parameters was not found. Please correct the properties and try again.
     MultipleMatchingNetAdapterFound = Please adjust the parameters or specify IgnoreMultipleMatchingAdapters to only use the first and try again.
     InvalidNetAdapterNumberError = Network Adapter interface number {0} was specified but only {1} was found. Please correct the interface number and try again.

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/en-us/NetworkingDsc.Common.strings.psd1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/en-us/NetworkingDsc.Common.strings.psd1
@@ -1,8 +1,8 @@
 ConvertFrom-StringData @'
-    FindingNetAdapterMessage = Finding Network Adapters matching the parameters.
-    AllNetAdaptersFoundMessage = Found all Network Adapters because no filter parameters provided.
-    NetAdapterFoundMessage = {0} Network Adapters were found matching the parameters.
-    NetAdapterNotFoundError = A Network Adapter matching the parameters was not found. Please correct the properties and try again.
+    FindingNetAdapterMessage = Finding network adapters matching the parameters.
+    AllNetAdaptersFoundMessage = Found all network adapters because no filter parameters provided.
+    NetAdapterFoundMessage = {0} network adapters were found matching the parameters.
+    NetAdapterNotFoundError = A network adapter matching the parameters was not found. Please correct the properties and try again.
     MultipleMatchingNetAdapterFound = Please adjust the parameters or specify IgnoreMultipleMatchingAdapters to only use the first and try again.
-    InvalidNetAdapterNumberError = Network Adapter interface number {0} was specified but only {1} was found. Please correct the interface number and try again.
+    InvalidNetAdapterNumberError = network adapter interface number {0} was specified but only {1} was found. Please correct the interface number and try again.
 '@

--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ The **xNetworking** module contains the following resources:
 - **xNetAdapterRDMA**: Enable or disable RDMA on a network adapter.
 - **xNetAdapterLso**: Enable or disable Lso for different protocols
     on a network adapter.
+- **xNetAdapterName**: Rename a network interface that matches specified search parameters.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)

--- a/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
@@ -37,7 +37,7 @@ try
         }
 
         #region DEFAULT TESTS
-        It 'should compile and apply the MOF without throwing' {
+        It 'Should compile and apply the MOF without throwing' {
             {
                 # This is to pass to the Config
                 $configData = @{
@@ -59,6 +59,7 @@ try
                 & "$($script:DSCResourceName)_Config_All" `
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
+
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
             } | Should Not Throw
@@ -69,7 +70,7 @@ try
                 -ComputerName localhost -Wait -Verbose -Force } | Should Not Throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion
@@ -100,7 +101,7 @@ try
         }
 
         #region DEFAULT TESTS
-        It 'should compile and apply the MOF without throwing' {
+        It 'Should compile and apply the MOF without throwing' {
             {
                 # This is to pass to the Config
                 $configData = @{
@@ -116,6 +117,7 @@ try
                 & "$($script:DSCResourceName)_Config_NameOnly" `
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
+
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
             } | Should Not Throw
@@ -126,7 +128,7 @@ try
                 -ComputerName localhost -Wait -Verbose -Force } | Should Not Throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion

--- a/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
@@ -24,11 +24,11 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
-    #region Integration Tests
-    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
-    . $ConfigFile -Verbose -ErrorAction Stop
+    #region Integration Tests with all parameters
+    Describe "$($script:DSCResourceName)_Integration using all parameters" {
+        $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName)_all.config.ps1"
+        . $ConfigFile -Verbose -ErrorAction Stop
 
-    Describe "$($script:DSCResourceName)_Integration" {
         BeforeAll {
             $adapterName = 'xNetworkingLBA'
             New-IntegrationLoopbackAdapter -AdapterName $adapterName
@@ -56,7 +56,7 @@ try
                     )
                 }
 
-                & "$($script:DSCResourceName)_Config" `
+                & "$($script:DSCResourceName)_Config_All" `
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
                 Start-DscConfiguration -Path $TestDrive `
@@ -65,8 +65,8 @@ try
         }
 
         it 'should reapply the MOF without throwing' {
-            {Start-DscConfiguration -Path $TestDrive `
-                -ComputerName localhost -Wait -Verbose -Force} | Should Not Throw
+            { Start-DscConfiguration -Path $TestDrive `
+                -ComputerName localhost -Wait -Verbose -Force } | Should Not Throw
         }
 
         It 'should be able to call Get-DscConfiguration without throwing' {
@@ -75,12 +75,70 @@ try
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config_All"}
             $current.Name                     | Should Be $newAdapterName
         }
 
         AfterAll {
             # Remove Loopback Adapter
+            Remove-IntegrationLoopbackAdapter -AdapterName $adapterName
+            Remove-IntegrationLoopbackAdapter -AdapterName $newAdapterName
+        }
+    }
+    #endregion
+
+    #region Integration Tests with name parameter only
+    Describe "$($script:DSCResourceName)_Integration using name parameter only" {
+        $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName)_nameonly.config.ps1"
+        . $ConfigFile -Verbose -ErrorAction Stop
+
+        BeforeAll {
+            $adapterName = 'xNetworkingLBA'
+            New-IntegrationLoopbackAdapter -AdapterName $adapterName
+            $adapter = Get-NetAdapter -Name $adapterName
+            $newAdapterName = 'xNetworkingLBANew'
+        }
+
+        #region DEFAULT TESTS
+        It 'should compile and apply the MOF without throwing' {
+            {
+                # This is to pass to the Config
+                $configData = @{
+                    AllNodes = @(
+                        @{
+                            NodeName             = 'localhost'
+                            NewName              = $newAdapterName
+                            Name                 = $adapter.Name
+                        }
+                    )
+                }
+
+                & "$($script:DSCResourceName)_Config_NameOnly" `
+                    -OutputPath $TestDrive `
+                    -ConfigurationData $configData
+                Start-DscConfiguration -Path $TestDrive `
+                    -ComputerName localhost -Wait -Verbose -Force
+            } | Should Not Throw
+        }
+
+        it 'should reapply the MOF without throwing' {
+            { Start-DscConfiguration -Path $TestDrive `
+                -ComputerName localhost -Wait -Verbose -Force } | Should Not Throw
+        }
+
+        It 'should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        }
+        #endregion
+
+        It 'Should have set the resource and all the parameters should match' {
+            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config_NameOnly"}
+            $current.Name                     | Should Be $newAdapterName
+        }
+
+        AfterAll {
+            # Remove Loopback Adapter
+            Remove-IntegrationLoopbackAdapter -AdapterName $adapterName
             Remove-IntegrationLoopbackAdapter -AdapterName $newAdapterName
         }
     }

--- a/Tests/Integration/MSFT_xNetAdapterName_all.config.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterName_all.config.ps1
@@ -1,4 +1,4 @@
-configuration MSFT_xNetAdapterName_Config {
+configuration MSFT_xNetAdapterName_Config_All {
     Import-DscResource -ModuleName xNetworking
 
     node localhost {

--- a/Tests/Integration/MSFT_xNetAdapterName_nameonly.config.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterName_nameonly.config.ps1
@@ -1,0 +1,10 @@
+configuration MSFT_xNetAdapterName_Config_NameOnly {
+    Import-DscResource -ModuleName xNetworking
+
+    node localhost {
+        xNetAdapterName Integration_Test {
+            Name                 = $Node.Name
+            NewName              = $Node.NewName
+        }
+    }
+}

--- a/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
@@ -139,8 +139,11 @@ try
                 }
             }
 
-            Context 'Matching adapter can be found and has wrong Name' {
-                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter }
+            Context 'Renamed adapter does not exist, but matching adapter can be found and has wrong Name' {
+                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter } `
+                    -ParameterFilter {$Name -and $Name -eq $script:AdapterName}
+                Mock -CommandName Find-NetworkAdapter -MockWith { } `
+                    -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
 
                 It 'should not throw' {
                     { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
@@ -151,13 +154,16 @@ try
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                        -ParameterFilter {$Name -and $Name -eq $script:AdapterName}
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                        -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
                 }
             }
 
             Context 'Adapter name changed by Set-TargetResource' {
-                Mock -CommandName Find-NetworkAdapter -MockWith { $PSCmdlet.ThrowTerminatingError('Wrong Adapter') } -ParameterFilter {$Name -and $Name -eq $script:adapterName}
-                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter } -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
+                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter } `
+                    -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
 
                 It 'should not throw' {
                     { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
@@ -168,7 +174,8 @@ try
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 2
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                        -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
                 }
             }
         }

--- a/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
@@ -80,11 +80,11 @@ try
                 Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter } `
                     -ParameterFilter { $Name -eq $script:newAdapterName }
 
-                It 'should not throw' {
+                It 'Should not throw' {
                     { $script:result = Get-TargetResource @adapterParameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return existing adapter' {
+                It 'Should return existing adapter' {
                     $script:result.Name                 | Should Be $script:mockRenamedAdapter.Name
                     $script:result.PhysicalMediaType    | Should Be $script:mockRenamedAdapter.PhysicalMediaType
                     $script:result.Status               | Should Be $script:mockRenamedAdapter.Status
@@ -96,7 +96,7 @@ try
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter { $Name -eq $script:newAdapterName }
                 }
             }
@@ -107,11 +107,11 @@ try
                 Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter } `
                     -ParameterFilter { $Name -eq $script:adapterName }
 
-                It 'should not throw' {
+                It 'Should not throw' {
                     { $script:result = Get-TargetResource -Name $script:adapterName -NewName $script:newAdapterName -Verbose } | Should Not Throw
                 }
 
-                It 'should return existing adapter' {
+                It 'Should return existing adapter' {
                     $script:result.Name                 | Should Be $script:mockAdapter.Name
                     $script:result.PhysicalMediaType    | Should Be $script:mockAdapter.PhysicalMediaType
                     $script:result.Status               | Should Be $script:mockAdapter.Status
@@ -123,9 +123,9 @@ try
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter { $Name -eq $script:adapterName }
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter { $Name -eq $script:newAdapterName }
                 }
             }
@@ -139,16 +139,16 @@ try
                     -ParameterFilter { $NewName -eq $script:newAdapterName } `
                     -MockWith { $script:mockRenamedAdapter }
 
-                It 'should not throw' {
+                It 'Should not throw' {
                     { Set-TargetResource @adapterParameters -Verbose } | Should Not Throw
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1
                     Assert-MockCalled `
                         -commandName Rename-NetAdapter `
                         -ParameterFilter { $NewName -eq $script:newAdapterName } `
-                        -Exactly 1
+                        -Exactly -Times 1
                 }
             }
         }
@@ -157,16 +157,16 @@ try
             Context 'Matching adapter can be found and has correct Name' {
                 Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter }
 
-                It 'should not throw' {
+                It 'Should not throw' {
                     { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return true' {
+                It 'Should return true' {
                     $script:result                      | Should Be $true
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1
                 }
             }
 
@@ -176,18 +176,18 @@ try
                 Mock -CommandName Find-NetworkAdapter -MockWith { } `
                     -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
 
-                It 'should not throw' {
+                It 'Should not throw' {
                     { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return false' {
+                It 'Should return false' {
                     $script:result                      | Should Be $false
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter {$Name -and $Name -eq $script:AdapterName}
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
                 }
             }
@@ -196,16 +196,16 @@ try
                 Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter } `
                     -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
 
-                It 'should not throw' {
+                It 'Should not throw' {
                     { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return false' {
+                It 'Should return false' {
                     $script:result                      | Should Be $True
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly 1 `
+                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
                 }
             }

--- a/Tests/Unit/NetworkingDsc.Common.tests.ps1
+++ b/Tests/Unit/NetworkingDsc.Common.tests.ps1
@@ -111,15 +111,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -Name $adapterName -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -132,11 +132,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -Name 'NOMATCH' -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -146,15 +146,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -167,11 +167,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -PhysicalMediaType 'NOMATCH' -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -181,15 +181,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -Status $adapterStatus -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -202,11 +202,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -Status 'Disabled' -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -216,15 +216,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -MacAddress $adapterMacAddress -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -237,11 +237,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -MacAddress '00-00-00-00-00-00' -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -251,15 +251,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -InterfaceDescription $adapterInterfaceDescription -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -272,11 +272,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -InterfaceDescription 'NOMATCH' -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -286,15 +286,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -InterfaceIndex $adapterInterfaceIndex -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -307,11 +307,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -InterfaceIndex 99 -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -321,15 +321,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -InterfaceGuid $adapterInterfaceGuid -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -342,11 +342,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -InterfaceGuid 'NOMATCH' -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -356,15 +356,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -DriverDescription $adapterDriverDescription -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -377,11 +377,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -DriverDescription 'NOMATCH' -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -394,11 +394,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.MultipleMatchingNetAdapterFound -f 2)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -408,15 +408,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $adapterArray }
 
-                It 'should throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -IgnoreMultipleMatchingAdapters:$true -InterfaceNumber 2 -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -429,11 +429,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.MultipleMatchingNetAdapterFound -f 2)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -443,15 +443,15 @@ try
                     -CommandName Get-NetAdapter `
                     -MockWith { $multipleMatchingAdapterArray }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -IgnoreMultipleMatchingAdapters:$true -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected adapter' {
+                It 'Should return expected adapter' {
                     $script:result.Name | Should Be $adapterName
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -464,11 +464,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.InvalidNetAdapterNumberError -f 2,3)
 
-                It 'should throw exception' {
+                It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -IgnoreMultipleMatchingAdapters:$true -InterfaceNumber 3 -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }


### PR DESCRIPTION
I've improved the log information as well and extended the integration and unit tests to provide better coverage of these scenarios.

The resource can now be correctly used to rename an adapter by just identifying it by name. But this isn't the primary user story that drove this. If you know the adapter name already, then renaming it isn't really that useful (but it'll work).

The primary user story that this should address is when you don't know the adapter name in the OS - you only know various parameters of the adapter (e.g. MAC Address, Driver) and therefore need to rename it so that that all other resources have a known name they can reference.

For example:
```powershell
        xNetAdapterName RenameNetAdapterCluster
        {
            NewName        = 'Cluster'
            MacAddress     = '9C-D2-1E-61-B5-DA'
        }
```

This will work fine - but it's not really the primary purpose:
```powershell
        xNetAdapterName RenameNetAdapterCluster
        {
            NewName        = 'Cluster'
            Name      = 'Ethernet 1'
        }
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/210)
<!-- Reviewable:end -->
