### PR TITLE
Prevent ResourceHelper and Common cmdlets from being exported - Fixes #213

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+- Added integration test to test for conflicts with other common resource kit modules.
+
 ## 4.0.0.0
 
 - Converted to use AppVeyor.psm1 in DSCResource.Tests repository.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@
 ## Unreleased
 
 - Added integration test to test for conflicts with other common resource kit modules.
+- Prevented ResourceHelper and Common module cmdlets from being exported to resolve
+  conflicts with other resource modules.
 
 ## 4.0.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xHostsFile/MSFT_xHostsFile.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xHostsFile/MSFT_xHostsFile.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xHostsFile/MSFT_xHostsFile.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xHostsFile/MSFT_xHostsFile.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xIPAddress/MSFT_xIPAddress.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterBinding/MSFT_xNetAdapterBinding.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterLso/MSFT_xNetAdapterLso.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterLso/MSFT_xNetAdapterLso.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterLso/MSFT_xNetAdapterLso.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterLso/MSFT_xNetAdapterLso.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterRDMA/MSFT_xNetAdapterRDMA.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterRDMA/MSFT_xNetAdapterRDMA.psm1
@@ -1,7 +1,12 @@
-﻿$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+﻿# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterRDMA/MSFT_xNetAdapterRDMA.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterRDMA/MSFT_xNetAdapterRDMA.psm1
@@ -1,10 +1,12 @@
-﻿# Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+﻿$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/MSFT_xNetConnectionProfile.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/MSFT_xNetConnectionProfile.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/MSFT_xNetConnectionProfile.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/MSFT_xNetConnectionProfile.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.psm1
@@ -1,7 +1,12 @@
-﻿$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+﻿# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.psm1
@@ -1,10 +1,12 @@
-﻿# Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+﻿$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/DSCResources/MSFT_xRoute/MSFT_xRoute.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xRoute/MSFT_xRoute.psm1
@@ -1,10 +1,12 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
 # Import the Networking Common Modules
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
                                                      -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
-Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+Import-Module -Name (Join-Path -Path $modulePath `
                                -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
                                                      -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 

--- a/Modules/xNetworking/DSCResources/MSFT_xRoute/MSFT_xRoute.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xRoute/MSFT_xRoute.psm1
@@ -1,7 +1,12 @@
-$script:ResourceRootPath = Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent)
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
 
-# Import the xNetworking Resource Module (to import the common modules)
-Import-Module -Name (Join-Path -Path $script:ResourceRootPath -ChildPath 'xNetworking.psd1')
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path (Split-Path -Path $PSScriptRoot -Parent) `
+                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `

--- a/Modules/xNetworking/xNetworking.psd1
+++ b/Modules/xNetworking/xNetworking.psd1
@@ -29,7 +29,7 @@ FunctionsToExport = '*'
 # Cmdlets to export from this module
 CmdletsToExport = '*'
 
-NestedModules = @('Modules\NetworkingDsc.Common\NetworkingDsc.Common.psm1','Modules\NetworkingDsc.ResourceHelper\NetworkingDsc.ResourceHelper.psm1')
+# NestedModules = @()
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.
 PrivateData = @{

--- a/Modules/xNetworking/xNetworking.psd1
+++ b/Modules/xNetworking/xNetworking.psd1
@@ -29,6 +29,7 @@ FunctionsToExport = '*'
 # Cmdlets to export from this module
 CmdletsToExport = '*'
 
+# Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()
 
 # Private data to pass to the module specified in RootModule/ModuleToProcess. This may also contain a PSData hashtable with additional module metadata used by PowerShell.

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -34,7 +34,7 @@ try
             It "Should be able to install DSC Resource module '$moduleToTest'" {
                 {
                     Install-Module -Name $moduleToTest -ErrorAction Stop
-                } | Should not throw
+                } | Should Not Throw
             }
         }
     }

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,18 +1,47 @@
 $script:DSCModuleName      = 'xNetworking'
-$script:ModulesToTest = @( 'xStorage','xCertificate','xComputerManagement' )
 <#
-    These integration tests ensure that cmdlets names are not conflicting with any other
-    names that are exposed by the modules.
+    These integration tests ensure that exported cmdlets names do not conflict
+     with any other names that are exposed by other common resource kit modules.
 #>
+$script:ModulesToTest = @( 'xStorage','xCertificate','xComputerManagement','xDFS' )
 
-Describe "$($script:DSCModuleName)_ModuleConflict" {
-    
-    foreach ($moduleToTest in $script:ModulesToTest)
-    {
-        It "Should not contain any conlficting cmdlet names with '$moduleToTest'" {
-            {
-                Install-Module -Name $moduleToTest -Force
-            } | Should not throw
+#region HEADER
+# Integration Test Template Version: 1.1.0
+[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
+
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath "$($script:DSCModuleName).psd1") -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName 'All' `
+    -TestType Integration
+
+#endregion
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    Describe "$($script:DSCModuleName)_CommonModuleConflict" {
+        
+        foreach ($moduleToTest in $script:ModulesToTest)
+        {
+            It "Should not contain any conlficting cmdlet names with '$moduleToTest'" {
+                {
+                    Install-Module -Name $moduleToTest -Force -ErrorAction Stop
+                } | Should not throw
+            }
         }
     }
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
 }

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -3,7 +3,7 @@ $script:DSCModuleName      = 'xNetworking'
     These integration tests ensure that exported cmdlets names do not conflict
     with any other names that are exposed by other common resource kit modules.
 #>
-$script:ModulesToTest = @( 'xStorage','xCertificate','xComputerManagement','xDFS' )
+$script:ModulesToTest = @( 'xStorage','xComputerManagement','xDFS' )
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
@@ -33,7 +33,7 @@ try
         {
             It "Should be able to install DSC Resource module '$moduleToTest'" {
                 {
-                    Install-Module -Name $moduleToTest -Verbose -ErrorAction Stop
+                    Install-Module -Name $moduleToTest -ErrorAction Stop
                 } | Should not throw
             }
         }

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,0 +1,18 @@
+$script:DSCModuleName      = 'xNetworking'
+$script:ModulesToTest = @( 'xStorage','xCertificate','xComputerManagement' )
+<#
+    These integration tests ensure that cmdlets names are not conflicting with any other
+    names that are exposed by the modules.
+#>
+
+Describe "$($script:DSCModuleName)_ModuleConflict" {
+    
+    foreach ($moduleToTest in $script:ModulesToTest)
+    {
+        It "Should not contain any conlficting cmdlet names with '$moduleToTest'" {
+            {
+                Install-Module -Name $moduleToTest -Force
+            } | Should not throw
+        }
+    }
+}

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -1,7 +1,7 @@
 $script:DSCModuleName      = 'xNetworking'
 <#
     These integration tests ensure that exported cmdlets names do not conflict
-     with any other names that are exposed by other common resource kit modules.
+    with any other names that are exposed by other common resource kit modules.
 #>
 $script:ModulesToTest = @( 'xStorage','xCertificate','xComputerManagement','xDFS' )
 
@@ -31,9 +31,9 @@ try
         
         foreach ($moduleToTest in $script:ModulesToTest)
         {
-            It "Should not contain any conlficting cmdlet names with '$moduleToTest'" {
+            It "Should be able to install DSC Resource module '$moduleToTest'" {
                 {
-                    Install-Module -Name $moduleToTest -ErrorAction Stop
+                    Install-Module -Name $moduleToTest -Verbose -ErrorAction Stop
                 } | Should not throw
             }
         }

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -33,7 +33,7 @@ try
         {
             It "Should not contain any conlficting cmdlet names with '$moduleToTest'" {
                 {
-                    Install-Module -Name $moduleToTest -Force -ErrorAction Stop
+                    Install-Module -Name $moduleToTest -ErrorAction Stop
                 } | Should not throw
             }
         }


### PR DESCRIPTION
This resolves a high priority issue with newer versions of xNetworking, xCertificate, xStorage and xDFS conflicting with each other because the ResourceHelper cmdlets are being exported due to the way each resource imported them (using the PSD1 nested modules array).

This should be resolved in xCertificate, xStorage and xDFS as well to ensure no other conflicts.

This also contains a new integration test that will check for any further conflicts between resource modules. At some point it might be possible to move this test into the DSCResource.Tests common tests to provide more comprehensive conflict prevention. However, because the conflicts will potentially be between three different modules the number of modules compared will have to go in over time.

This fixes #213

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/214)
<!-- Reviewable:end -->
