### PR TITLE
MSFT_xDefaultGatewayAddress: Correct Style to meet HQRM and exceptions to use ResourceHelper functions - Fixes #221

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,9 @@
   - Updated example to also cover setting DNS Client to DHCP.
 - Added the VS Code PowerShell extension formatting settings that cause PowerShell
   files to be formatted as per the DSC Resource kit style guidelines.
+- MSFT_xDefaultGatewayAddress:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Converted exceptions to use ResourceHelper functions.
 
 ## 4.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -24,6 +24,7 @@
 - MSFT_xDefaultGatewayAddress:
   - Corrected style and formatting to meet HQRM guidelines.
   - Converted exceptions to use ResourceHelper functions.
+- Updated badges in README.MD to match the layout from PSDscResources.
 
 ## 4.1.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
@@ -2,13 +2,13 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 # Import the Networking Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
-                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+            -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
-                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+            -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -49,7 +49,7 @@ function Get-TargetResource
     )
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-        $($LocalizedData.GettingDefaultGatewayAddressMessage)
+            $($LocalizedData.GettingDefaultGatewayAddressMessage)
         ) -join '' )
 
     # Use $AddressFamily to select the IPv4 or IPv6 destination prefix
@@ -64,14 +64,17 @@ function Get-TargetResource
         Where-Object { $_.DestinationPrefix -eq $destinationPrefix }
 
     $returnValue = @{
-        AddressFamily = $AddressFamily
+        AddressFamily  = $AddressFamily
         InterfaceAlias = $InterfaceAlias
     }
     # If there is a Default Gateway defined for this interface/address family add it
     # to the return value.
-    if ($defaultRoutes) {
+    if ($defaultRoutes)
+    {
         $returnValue += @{ Address = $defaultRoutes.NextHop }
-    } else {
+    }
+    else
+    {
         $returnValue += @{ Address = $null }
     }
 
@@ -106,16 +109,18 @@ function Set-TargetResource
         [String]
         $AddressFamily,
 
+        [Parameter()]
         [String]
         $Address
     )
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-        $($LocalizedData.ApplyingDefaultGatewayAddressMessage)
+            $($LocalizedData.ApplyingDefaultGatewayAddressMessage)
         ) -join '' )
 
     # Use $AddressFamily to select the IPv4 or IPv6 destination prefix
     $destinationPrefix = '0.0.0.0/0'
+
     if ($AddressFamily -eq 'IPv6')
     {
         $destinationPrefix = '::/0'
@@ -123,12 +128,13 @@ function Set-TargetResource
 
     # Get all the default routes
     $defaultRoutes = @(Get-NetRoute `
-        -InterfaceAlias $InterfaceAlias `
-        -AddressFamily $AddressFamily `
-        -ErrorAction Stop).Where( { $_.DestinationPrefix -eq $destinationPrefix } )
+            -InterfaceAlias $InterfaceAlias `
+            -AddressFamily $AddressFamily `
+            -ErrorAction Stop).Where( { $_.DestinationPrefix -eq $destinationPrefix } )
 
     # Remove any existing default route
-    foreach ($defaultRoute in $defaultRoutes) {
+    foreach ($defaultRoute in $defaultRoutes)
+    {
         Remove-NetRoute `
             -DestinationPrefix $defaultRoute.DestinationPrefix `
             -NextHop $defaultRoute.NextHop `
@@ -143,21 +149,21 @@ function Set-TargetResource
         # Build parameter hash table
         $parameters = @{
             DestinationPrefix = $destinationPrefix
-            InterfaceAlias = $InterfaceAlias
-            AddressFamily = $AddressFamily
-            NextHop = $Address
+            InterfaceAlias    = $InterfaceAlias
+            AddressFamily     = $AddressFamily
+            NextHop           = $Address
         }
 
         New-NetRoute @Parameters -ErrorAction Stop
 
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-            $($LocalizedData.DefaultGatewayAddressSetToDesiredStateMessage)
+                $($LocalizedData.DefaultGatewayAddressSetToDesiredStateMessage)
             ) -join '' )
     }
     else
     {
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-            $($LocalizedData.DefaultGatewayRemovedMessage)
+                $($LocalizedData.DefaultGatewayRemovedMessage)
             ) -join '' )
     }
 }
@@ -191,6 +197,7 @@ function Test-TargetResource
         [String]
         $AddressFamily,
 
+        [Parameter()]
         [String]
         $Address
     )
@@ -199,7 +206,7 @@ function Test-TargetResource
     [Boolean] $desiredConfigurationMatch = $true
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-        $($LocalizedData.CheckingDefaultGatewayAddressMessage)
+            $($LocalizedData.CheckingDefaultGatewayAddressMessage)
         ) -join '' )
 
     Assert-ResourceProperty @PSBoundParameters
@@ -210,34 +217,36 @@ function Test-TargetResource
     {
         $destinationPrefix = '::/0'
     }
+
     # Get all the default routes
     $defaultRoutes = @(Get-NetRoute `
-        -InterfaceAlias $InterfaceAlias `
-        -AddressFamily $AddressFamily `
-        -ErrorAction Stop).Where( { $_.DestinationPrefix -eq $destinationPrefix } )
+            -InterfaceAlias $InterfaceAlias `
+            -AddressFamily $AddressFamily `
+            -ErrorAction Stop).Where( { $_.DestinationPrefix -eq $destinationPrefix } )
 
     # Test if the Default Gateway passed is equal to the current default gateway
     if ($Address)
     {
-        if ($defaultRoutes) {
+        if ($defaultRoutes)
+        {
             if (-not $defaultRoutes.Where( { $_.NextHop -eq $Address } ))
             {
                 Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-                     $($LocalizedData.DefaultGatewayNotMatchMessage) -f $Address,$defaultRoutes.NextHop
+                        $($LocalizedData.DefaultGatewayNotMatchMessage) -f $Address, $defaultRoutes.NextHop
                     ) -join '' )
                 $desiredConfigurationMatch = $false
             }
             else
             {
                 Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-                     $($LocalizedData.DefaultGatewayCorrectMessage)
+                        $($LocalizedData.DefaultGatewayCorrectMessage)
                     ) -join '' )
             }
         }
         else
         {
             Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-                $($LocalizedData.DefaultGatewayDoesNotExistMessage) -f $Address
+                    $($LocalizedData.DefaultGatewayDoesNotExistMessage) -f $Address
                 ) -join '' )
             $desiredConfigurationMatch = $false
         }
@@ -248,15 +257,15 @@ function Test-TargetResource
         if ($defaultRoutes)
         {
             Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-                $($LocalizedData.DefaultGatewayExistsButShouldNotMessage)
+                    $($LocalizedData.DefaultGatewayExistsButShouldNotMessage)
                 ) -join '' )
             $desiredConfigurationMatch = $false
         }
         else
         {
             Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-                $($LocalizedData.DefaultGatewayExistsAndShouldMessage)
-                'Default Gateway does not exist which is correct.'
+                    $($LocalizedData.DefaultGatewayExistsAndShouldMessage)
+                    'Default Gateway does not exist which is correct.'
                 ) -join '' )
         }
     }
@@ -292,64 +301,42 @@ function Assert-ResourceProperty
         [String]
         $AddressFamily = 'IPv4',
 
+        [Parameter()]
         [String]
         $Address
     )
 
     if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
     {
-        $errorId = 'InterfaceNotAvailable'
-        $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
-        $errorMessage = $($LocalizedData.InterfaceNotAvailableError) -f $InterfaceAlias
-        $exception = New-Object -TypeName System.InvalidOperationException `
-            -ArgumentList $errorMessage
-        $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-            -ArgumentList $exception, $errorId, $errorCategory, $null
-
-        $PSCmdlet.ThrowTerminatingError($errorRecord)
+        New-InvalidOperationException `
+            -Message ($LocalizedData.InterfaceNotAvailableError -f $InterfaceAlias)
     }
+
     if ($Address)
     {
         if (-not ([System.Net.IPAddress]::TryParse($Address, [ref]0)))
         {
-            $errorId = 'AddressFormatError'
-            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-            $errorMessage = $($LocalizedData.AddressFormatError) -f $Address
-            $exception = New-Object -TypeName System.InvalidOperationException `
-                -ArgumentList $errorMessage
-            $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                -ArgumentList $exception, $errorId, $errorCategory, $null
-
-            $PSCmdlet.ThrowTerminatingError($errorRecord)
+            New-InvalidArgumentException `
+                -Message ($LocalizedData.AddressFormatError -f $Address) `
+                -ArgumentName 'Address'
         }
 
         $detectedAddressFamily = ([System.Net.IPAddress]$Address).AddressFamily.ToString()
-        if (($detectedAddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork.ToString()) `
-            -and ($AddressFamily -ne 'IPv4'))
-        {
-            $errorId = 'AddressMismatchError'
-            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-            $errorMessage = $($LocalizedData.AddressIPv4MismatchError) -f $Address,$AddressFamily
-            $exception = New-Object -TypeName System.InvalidOperationException `
-                -ArgumentList $errorMessage
-            $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                -ArgumentList $exception, $errorId, $errorCategory, $null
 
-            $PSCmdlet.ThrowTerminatingError($errorRecord)
+        if (($detectedAddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetwork.ToString()) `
+                -and ($AddressFamily -ne 'IPv4'))
+        {
+            New-InvalidArgumentException `
+                -Message ($LocalizedData.AddressIPv4MismatchError -f $Address, $AddressFamily) `
+                -ArgumentName 'AddressFamily'
         }
 
         if (($detectedAddressFamily -eq [System.Net.Sockets.AddressFamily]::InterNetworkV6.ToString()) `
-            -and ($AddressFamily -ne 'IPv6'))
+                -and ($AddressFamily -ne 'IPv6'))
         {
-            $errorId = 'AddressMismatchError'
-            $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-            $errorMessage = $($LocalizedData.AddressIPv6MismatchError) -f $Address,$AddressFamily
-            $exception = New-Object -TypeName System.InvalidOperationException `
-                -ArgumentList $errorMessage
-            $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                -ArgumentList $exception, $errorId, $errorCategory, $null
-
-            $PSCmdlet.ThrowTerminatingError($errorRecord)
+            New-InvalidArgumentException `
+                -Message ($LocalizedData.AddressIPv6MismatchError -f $Address, $AddressFamily) `
+                -ArgumentName 'AddressFamily'
         }
     }
 } # Assert-ResourceProperty

--- a/README.md
+++ b/README.md
@@ -1,7 +1,10 @@
 # xNetworking
 
-[![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xnetworking/branch/master)
+master: [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/master)
 [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking)
+
+dev: [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/dev)
+[![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking)
 
 The **xNetworking** module contains the following resources:
 

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'xNetworking'
-$script:DSCResourceName    = 'MSFT_xDefaultGatewayAddress'
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xDefaultGatewayAddress'
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -32,14 +32,14 @@ try
 
     Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
-        It 'Should compile without throwing' {
+        It 'Should compile and apply the MOF without throwing' {
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.config.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.config.ps1
@@ -1,16 +1,17 @@
 $TestDefaultGatewayAddress = [PSObject]@{
-    InterfaceAlias          = 'xNetworkingLBA'
-    AddressFamily           = 'IPv4'
-    Address                 = '10.0.0.0'
+    InterfaceAlias = 'xNetworkingLBA'
+    AddressFamily  = 'IPv4'
+    Address        = '10.0.0.0'
 }
 
 configuration MSFT_xDefaultGatewayAddress_Config {
     Import-DscResource -ModuleName xNetworking
     node localhost {
-        xDefaultGatewayAddress Integration_Test {
-            InterfaceAlias          = $TestDefaultGatewayAddress.InterfaceAlias
-            AddressFamily           = $TestDefaultGatewayAddress.AddressFamily
-            Address                 = $TestDefaultGatewayAddress.Address
+        xDefaultGatewayAddress Integration_Test
+        {
+            InterfaceAlias = $TestDefaultGatewayAddress.InterfaceAlias
+            AddressFamily  = $TestDefaultGatewayAddress.AddressFamily
+            Address        = $TestDefaultGatewayAddress.Address
         }
     }
 }

--- a/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -1,6 +1,8 @@
 $script:DSCModuleName      = 'xNetworking'
 $script:DSCResourceName    = 'MSFT_xDefaultGatewayAddress'
 
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
+
 #region HEADER
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
@@ -21,9 +23,7 @@ try
 {
     #region Pester Tests
     InModuleScope $script:DSCResourceName {
-
-        Describe "MSFT_xDefaultGatewayAddress\Get-TargetResource" {
-
+        Describe 'MSFT_xDefaultGatewayAddress\Get-TargetResource' {
             #region Mocks
             Mock Get-NetRoute -MockWith {
                 [PSCustomObject]@{
@@ -36,15 +36,16 @@ try
             }
             #endregion
 
-            Context 'checking return with default gateway' {
-                It 'should return current default gateway' {
-
-                    $Splat = @{
+            Context 'Checking return with default gateway' {
+                It 'Should return current default gateway' {
+                    $splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    $Result = Get-TargetResource @Splat
-                    $Result.Address | Should Be '192.168.0.1'
+
+                    $result = Get-TargetResource @splat
+
+                    $result.Address | Should Be '192.168.0.1'
                 }
             }
 
@@ -52,21 +53,21 @@ try
             Mock Get-NetRoute -MockWith {}
             #endregion
 
-            Context 'checking return with no default gateway' {
-                It 'should return no default gateway' {
-
-                    $Splat = @{
+            Context 'Checking return with no default gateway' {
+                It 'Should return no default gateway' {
+                    $splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    $Result = Get-TargetResource @Splat
-                    $Result.Address | Should BeNullOrEmpty
+
+                    $result = Get-TargetResource @splat
+
+                    $result.Address | Should BeNullOrEmpty
                 }
             }
         }
 
-        Describe "MSFT_xDefaultGatewayAddress\Set-TargetResource" {
-
+        Describe 'MSFT_xDefaultGatewayAddress\Set-TargetResource' {
             #region Mocks
             Mock Get-NetRoute -MockWith {
                 [PSCustomObject]@{
@@ -83,35 +84,39 @@ try
             Mock New-NetRoute
             #endregion
 
-            Context 'invoking with no Default Gateway Address' {
-                It 'should return $null' {
-                    $Splat = @{
+            Context 'Invoking with no Default Gateway Address' {
+                It 'Should return $null' {
+                    $splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    { $Result = Set-TargetResource @Splat } | Should Not Throw
-                    $Result | Should BeNullOrEmpty
+
+                    { $result = Set-TargetResource @splat } | Should Not Throw
+
+                    $result | Should BeNullOrEmpty
                 }
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                     Assert-MockCalled -commandName Remove-NetRoute -Exactly 1
                     Assert-MockCalled -commandName New-NetRoute -Exactly 0
                 }
             }
 
-            Context 'invoking with valid Default Gateway Address' {
-                It 'should return $null' {
-                    $Splat = @{
+            Context 'Invoking with valid Default Gateway Address' {
+                It 'Should return $null' {
+                    $splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    { $Result = Set-TargetResource @Splat } | Should Not Throw
-                    $Result | Should BeNullOrEmpty
+
+                    { $result = Set-TargetResource @splat } | Should Not Throw
+
+                    $result | Should BeNullOrEmpty
                 }
 
-                It 'should call all the mocks' {
+                It 'Should call all the mocks' {
                     Assert-MockCalled -commandName Get-NetRoute -Exactly 1
                     Assert-MockCalled -commandName Remove-NetRoute -Exactly 1
                     Assert-MockCalled -commandName New-NetRoute -Exactly 1
@@ -119,8 +124,7 @@ try
             }
         }
 
-        Describe "MSFT_xDefaultGatewayAddress\Test-TargetResource" {
-
+        Describe 'MSFT_xDefaultGatewayAddress\Test-TargetResource' {
             #region Mocks
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
 
@@ -135,26 +139,26 @@ try
             }
             #endregion
 
-            Context 'checking return with default gateway that matches currently set one' {
-                It 'should return true' {
-
-                    $Splat = @{
+            Context 'Checking return with default gateway that matches currently set one' {
+                It 'Should return true' {
+                    $splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    Test-TargetResource @Splat | Should Be $True
+
+                    Test-TargetResource @splat | Should Be $True
                 }
             }
 
-            Context 'checking return with no gateway but one is currently set' {
-                It 'should return false' {
-
-                    $Splat = @{
+            Context 'Checking return with no gateway but one is currently set' {
+                It 'Should return false' {
+                    $splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    Test-TargetResource @Splat | Should Be $False
+
+                    Test-TargetResource @splat | Should Be $False
                 }
             }
 
@@ -162,135 +166,118 @@ try
             Mock Get-NetRoute -MockWith {}
             #endregion
 
-            Context 'checking return with default gateway but none are currently set' {
-                It 'should return false' {
-
-                    $Splat = @{
+            Context 'Checking return with default gateway but none are currently set' {
+                It 'Should return false' {
+                    $splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    Test-TargetResource @Splat | Should Be $False
+
+                    Test-TargetResource @splat | Should Be $False
                 }
             }
 
-            Context 'checking return with no gateway and none are currently set' {
-                It 'should return true' {
-
-                    $Splat = @{
+            Context 'Checking return with no gateway and none are currently set' {
+                It 'Should return true' {
+                    $splat = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    Test-TargetResource @Splat | Should Be $True
+
+                    Test-TargetResource @splat | Should Be $True
                 }
             }
         }
 
-        Describe "MSFT_xDefaultGatewayAddress\Assert-ResourceProperty" {
+        Describe 'MSFT_xDefaultGatewayAddress\Assert-ResourceProperty' {
 
             Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
 
-            Context 'invoking with bad interface alias' {
-
-                It 'should throw an InterfaceNotAvailable error' {
-                    $Splat = @{
+            Context 'Invoking with bad interface alias' {
+                It 'Should throw an InterfaceNotAvailable error' {
+                    $splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'NotReal'
                         AddressFamily = 'IPv4'
                     }
-                    $errorId = 'InterfaceNotAvailable'
-                    $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
-                    $errorMessage = $($LocalizedData.InterfaceNotAvailableError) -f $Splat.InterfaceAlias
-                    $exception = New-Object -TypeName System.InvalidOperationException `
-                        -ArgumentList $errorMessage
-                    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                        -ArgumentList $exception, $errorId, $errorCategory, $null
 
-                    { Assert-ResourceProperty @Splat } | Should Throw $ErrorRecord
+                    $errorRecord = Get-InvalidOperationRecord `
+                        -Message ($LocalizedData.InterfaceNotAvailableError -f $splat.InterfaceAlias)
+
+                    { Assert-ResourceProperty @splat } | Should Throw $ErrorRecord
                 }
             }
 
-            Context 'invoking with invalid IP Address' {
-
-                It 'should throw an AddressFormatError error' {
-                    $Splat = @{
+            Context 'Invoking with invalid IP Address' {
+                It 'Should throw an AddressFormatError error' {
+                    $splat = @{
                         Address = 'NotReal'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    $errorId = 'AddressFormatError'
-                    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                    $errorMessage = $($LocalizedData.AddressFormatError) -f $Splat.Address
-                    $exception = New-Object -TypeName System.InvalidOperationException `
-                        -ArgumentList $errorMessage
-                    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                        -ArgumentList $exception, $errorId, $errorCategory, $null
 
-                    { Assert-ResourceProperty @Splat } | Should Throw $ErrorRecord
+                    $errorRecord = Get-InvalidArgumentRecord `
+                        -Message ($LocalizedData.AddressFormatError -f $splat.Address) `
+                        -ArgumentName 'Address'
+
+                    { Assert-ResourceProperty @splat } | Should Throw $ErrorRecord
                 }
             }
 
-            Context 'invoking with IPv4 Address and family mismatch' {
-
-                It 'should throw an AddressMismatchError error' {
-                    $Splat = @{
+            Context 'Invoking with IPv4 Address and family mismatch' {
+                It 'Should throw an AddressMismatchError error' {
+                    $splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv6'
                     }
-                    $errorId = 'AddressMismatchError'
-                    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                    $errorMessage = $($LocalizedData.AddressIPv4MismatchError) -f $Splat.Address,$Splat.AddressFamily
-                    $exception = New-Object -TypeName System.InvalidOperationException `
-                        -ArgumentList $errorMessage
-                    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                        -ArgumentList $exception, $errorId, $errorCategory, $null
 
-                    { Assert-ResourceProperty @Splat } | Should Throw $ErrorRecord
+                    $errorRecord = Get-InvalidArgumentRecord `
+                        -Message ($LocalizedData.AddressIPv4MismatchError -f $splat.Address,$splat.AddressFamily) `
+                        -ArgumentName 'AddressFamily'
+
+                    { Assert-ResourceProperty @splat } | Should Throw $ErrorRecord
                 }
             }
 
-            Context 'invoking with IPv6 Address and family mismatch' {
-
-                It 'should throw an AddressMismatchError error' {
-                    $Splat = @{
+            Context 'Invoking with IPv6 Address and family mismatch' {
+                It 'Should throw an AddressMismatchError error' {
+                    $splat = @{
                         Address = 'fe80::'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    $errorId = 'AddressMismatchError'
-                    $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidArgument
-                    $errorMessage = $($LocalizedData.AddressIPv6MismatchError) -f $Splat.Address,$Splat.AddressFamily
-                    $exception = New-Object -TypeName System.InvalidOperationException `
-                        -ArgumentList $errorMessage
-                    $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                        -ArgumentList $exception, $errorId, $errorCategory, $null
 
-                    { Assert-ResourceProperty @Splat } | Should Throw $ErrorRecord
+                    $errorRecord = Get-InvalidArgumentRecord `
+                        -Message ($LocalizedData.AddressIPv6MismatchError -f $splat.Address,$splat.AddressFamily) `
+                        -ArgumentName 'AddressFamily'
+
+                    { Assert-ResourceProperty @splat } | Should Throw $ErrorRecord
                 }
             }
 
-            Context 'invoking with valid IPv4 Address' {
-
-                It 'should not throw an error' {
-                    $Splat = @{
+            Context 'Invoking with valid IPv4 Address' {
+                It 'Should not throw an error' {
+                    $splat = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
-                    { Assert-ResourceProperty @Splat } | Should Not Throw
+
+                    { Assert-ResourceProperty @splat } | Should Not Throw
                 }
             }
 
-            Context 'invoking with valid IPv6 Address' {
-
-                It 'should not throw an error' {
-                    $Splat = @{
+            Context 'Invoking with valid IPv6 Address' {
+                It 'Should not throw an error' {
+                    $splat = @{
                         Address = 'fe80:ab04:30F5:002b::1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv6'
                     }
-                    { Assert-ResourceProperty @Splat } | Should Not Throw
+
+                    { Assert-ResourceProperty @splat } | Should Not Throw
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -24,43 +24,43 @@ try
     #region Pester Tests
     InModuleScope $script:DSCResourceName {
         Describe 'MSFT_xDefaultGatewayAddress\Get-TargetResource' {
-            #region Mocks
-            Mock Get-NetRoute -MockWith {
-                [PSCustomObject]@{
-                    NextHop = '192.168.0.1'
-                    DestinationPrefix = '0.0.0.0/0'
-                    InterfaceAlias = 'Ethernet'
-                    InterfaceIndex = 1
-                    AddressFamily = 'IPv4'
-                }
-            }
-            #endregion
-
             Context 'Checking return with default gateway' {
+                #region Mocks
+                Mock Get-NetRoute -MockWith {
+                    [PSCustomObject]@{
+                        NextHop = '192.168.0.1'
+                        DestinationPrefix = '0.0.0.0/0'
+                        InterfaceAlias = 'Ethernet'
+                        InterfaceIndex = 1
+                        AddressFamily = 'IPv4'
+                    }
+                }
+                #endregion
+
                 It 'Should return current default gateway' {
-                    $splat = @{
+                    $getTargetResourceParameters = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    $result = Get-TargetResource @splat
+                    $result = Get-TargetResource @getTargetResourceParameters
 
                     $result.Address | Should Be '192.168.0.1'
                 }
             }
 
-            #region Mocks
-            Mock Get-NetRoute -MockWith {}
-            #endregion
-
             Context 'Checking return with no default gateway' {
+                #region Mocks
+                Mock Get-NetRoute -MockWith {}
+                #endregion
+
                 It 'Should return no default gateway' {
-                    $splat = @{
+                    $getTargetResourceParameters = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    $result = Get-TargetResource @splat
+                    $result = Get-TargetResource @getTargetResourceParameters
 
                     $result.Address | Should BeNullOrEmpty
                 }
@@ -68,30 +68,32 @@ try
         }
 
         Describe 'MSFT_xDefaultGatewayAddress\Set-TargetResource' {
-            #region Mocks
-            Mock Get-NetRoute -MockWith {
-                [PSCustomObject]@{
-                    NextHop = '192.168.0.1'
-                    DestinationPrefix = '0.0.0.0/0'
-                    InterfaceAlias = 'Ethernet'
-                    InterfaceIndex = 1
-                    AddressFamily = 'IPv4'
+            BeforeEach {
+                #region Mocks
+                Mock Get-NetRoute -MockWith {
+                    [PSCustomObject]@{
+                        NextHop = '192.168.0.1'
+                        DestinationPrefix = '0.0.0.0/0'
+                        InterfaceAlias = 'Ethernet'
+                        InterfaceIndex = 1
+                        AddressFamily = 'IPv4'
+                    }
                 }
+
+                Mock Remove-NetRoute
+
+                Mock New-NetRoute
+                #endregion
             }
-
-            Mock Remove-NetRoute
-
-            Mock New-NetRoute
-            #endregion
 
             Context 'Invoking with no Default Gateway Address' {
                 It 'Should return $null' {
-                    $splat = @{
+                    $setTargetResourceParameters = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    { $result = Set-TargetResource @splat } | Should Not Throw
+                    { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     $result | Should BeNullOrEmpty
                 }
@@ -105,13 +107,13 @@ try
 
             Context 'Invoking with valid Default Gateway Address' {
                 It 'Should return $null' {
-                    $splat = @{
+                    $setTargetResourceParameters = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    { $result = Set-TargetResource @splat } | Should Not Throw
+                    { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
 
                     $result | Should BeNullOrEmpty
                 }
@@ -125,159 +127,178 @@ try
         }
 
         Describe 'MSFT_xDefaultGatewayAddress\Test-TargetResource' {
-            #region Mocks
-            Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-
-            Mock Get-NetRoute -MockWith {
-                [PSCustomObject]@{
-                    NextHop = '192.168.0.1'
-                    DestinationPrefix = '0.0.0.0/0'
-                    InterfaceAlias = 'Ethernet'
-                    InterfaceIndex = 1
-                    AddressFamily = 'IPv4'
-                }
-            }
-            #endregion
-
             Context 'Checking return with default gateway that matches currently set one' {
+                #region Mocks
+                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+
+                Mock Get-NetRoute -MockWith {
+                    [PSCustomObject]@{
+                        NextHop = '192.168.0.1'
+                        DestinationPrefix = '0.0.0.0/0'
+                        InterfaceAlias = 'Ethernet'
+                        InterfaceIndex = 1
+                        AddressFamily = 'IPv4'
+                    }
+                }
+                #endregion
+
                 It 'Should return true' {
-                    $splat = @{
+                    $testTargetResourceParameters = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @splat | Should Be $True
+                    Test-TargetResource @testTargetResourceParameters | Should Be $True
                 }
             }
 
             Context 'Checking return with no gateway but one is currently set' {
+                #region Mocks
+                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+
+                Mock Get-NetRoute -MockWith {
+                    [PSCustomObject]@{
+                        NextHop = '192.168.0.1'
+                        DestinationPrefix = '0.0.0.0/0'
+                        InterfaceAlias = 'Ethernet'
+                        InterfaceIndex = 1
+                        AddressFamily = 'IPv4'
+                    }
+                }
+                #endregion
+
                 It 'Should return false' {
-                    $splat = @{
+                    $testTargetResourceParameters = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @splat | Should Be $False
+                    Test-TargetResource @testTargetResourceParameters | Should Be $False
                 }
             }
 
-            #region Mocks
-            Mock Get-NetRoute -MockWith {}
-            #endregion
-
             Context 'Checking return with default gateway but none are currently set' {
+                #region Mocks
+                Mock Get-NetRoute -MockWith {}
+                #endregion
+
                 It 'Should return false' {
-                    $splat = @{
+                    $testTargetResourceParameters = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @splat | Should Be $False
+                    Test-TargetResource @testTargetResourceParameters | Should Be $False
                 }
             }
 
             Context 'Checking return with no gateway and none are currently set' {
+                #region Mocks
+                Mock Get-NetRoute -MockWith {}
+                #endregion
+
                 It 'Should return true' {
-                    $splat = @{
+                    $testTargetResourceParameters = @{
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @splat | Should Be $True
+                    Test-TargetResource @testTargetResourceParameters | Should Be $True
                 }
             }
         }
 
         Describe 'MSFT_xDefaultGatewayAddress\Assert-ResourceProperty' {
-
-            Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+            BeforeEach {
+                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+            }
 
             Context 'Invoking with bad interface alias' {
                 It 'Should throw an InterfaceNotAvailable error' {
-                    $splat = @{
+                    $assertResourcePropertyParameters = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'NotReal'
                         AddressFamily = 'IPv4'
                     }
 
                     $errorRecord = Get-InvalidOperationRecord `
-                        -Message ($LocalizedData.InterfaceNotAvailableError -f $splat.InterfaceAlias)
+                        -Message ($LocalizedData.InterfaceNotAvailableError -f $assertResourcePropertyParameters.InterfaceAlias)
 
-                    { Assert-ResourceProperty @splat } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'Invoking with invalid IP Address' {
                 It 'Should throw an AddressFormatError error' {
-                    $splat = @{
+                    $assertResourcePropertyParameters = @{
                         Address = 'NotReal'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
                     $errorRecord = Get-InvalidArgumentRecord `
-                        -Message ($LocalizedData.AddressFormatError -f $splat.Address) `
+                        -Message ($LocalizedData.AddressFormatError -f $assertResourcePropertyParameters.Address) `
                         -ArgumentName 'Address'
 
-                    { Assert-ResourceProperty @splat } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'Invoking with IPv4 Address and family mismatch' {
                 It 'Should throw an AddressMismatchError error' {
-                    $splat = @{
+                    $assertResourcePropertyParameters = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv6'
                     }
 
                     $errorRecord = Get-InvalidArgumentRecord `
-                        -Message ($LocalizedData.AddressIPv4MismatchError -f $splat.Address,$splat.AddressFamily) `
+                        -Message ($LocalizedData.AddressIPv4MismatchError -f $assertResourcePropertyParameters.Address,$assertResourcePropertyParameters.AddressFamily) `
                         -ArgumentName 'AddressFamily'
 
-                    { Assert-ResourceProperty @splat } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'Invoking with IPv6 Address and family mismatch' {
                 It 'Should throw an AddressMismatchError error' {
-                    $splat = @{
+                    $assertResourcePropertyParameters = @{
                         Address = 'fe80::'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
                     $errorRecord = Get-InvalidArgumentRecord `
-                        -Message ($LocalizedData.AddressIPv6MismatchError -f $splat.Address,$splat.AddressFamily) `
+                        -Message ($LocalizedData.AddressIPv6MismatchError -f $assertResourcePropertyParameters.Address,$assertResourcePropertyParameters.AddressFamily) `
                         -ArgumentName 'AddressFamily'
 
-                    { Assert-ResourceProperty @splat } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $ErrorRecord
                 }
             }
 
             Context 'Invoking with valid IPv4 Address' {
                 It 'Should not throw an error' {
-                    $splat = @{
+                    $assertResourcePropertyParameters = @{
                         Address = '192.168.0.1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv4'
                     }
 
-                    { Assert-ResourceProperty @splat } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Not Throw
                 }
             }
 
             Context 'Invoking with valid IPv6 Address' {
                 It 'Should not throw an error' {
-                    $splat = @{
+                    $assertResourcePropertyParameters = @{
                         Address = 'fe80:ab04:30F5:002b::1'
                         InterfaceAlias = 'Ethernet'
                         AddressFamily = 'IPv6'
                     }
 
-                    { Assert-ResourceProperty @splat } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Not Throw
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -127,10 +127,14 @@ try
         }
 
         Describe 'MSFT_xDefaultGatewayAddress\Test-TargetResource' {
-            Context 'Checking return with default gateway that matches currently set one' {
+            BeforeEach {
                 #region Mocks
                 Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+                #endregion
+            }
 
+            Context 'Checking return with default gateway that matches currently set one' {
+                #region Mocks
                 Mock Get-NetRoute -MockWith {
                     [PSCustomObject]@{
                         NextHop = '192.168.0.1'
@@ -155,8 +159,6 @@ try
 
             Context 'Checking return with no gateway but one is currently set' {
                 #region Mocks
-                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-
                 Mock Get-NetRoute -MockWith {
                     [PSCustomObject]@{
                         NextHop = '192.168.0.1'
@@ -180,8 +182,6 @@ try
 
             Context 'Checking return with default gateway but none are currently set' {
                 #region Mocks
-                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-
                 Mock Get-NetRoute -MockWith {}
                 #endregion
 
@@ -198,8 +198,6 @@ try
 
             Context 'Checking return with no gateway and none are currently set' {
                 #region Mocks
-                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-
                 Mock Get-NetRoute -MockWith {}
                 #endregion
 

--- a/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -180,6 +180,8 @@ try
 
             Context 'Checking return with default gateway but none are currently set' {
                 #region Mocks
+                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+
                 Mock Get-NetRoute -MockWith {}
                 #endregion
 
@@ -196,6 +198,8 @@ try
 
             Context 'Checking return with no gateway and none are currently set' {
                 #region Mocks
+                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+
                 Mock Get-NetRoute -MockWith {}
                 #endregion
 


### PR DESCRIPTION
- MSFT_xDefaultGatewayAddress: 
 - Corrected style and formatting to meet HQRM guidelines.
  - Converted exceptions to use ResourceHelper functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/222)
<!-- Reviewable:end -->
