### PR TITLE
 MSFT_xDhcpClient: Correct Style to meet HQRM and exceptions to use ResourceHelper functions - Fixes #225

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,9 @@
   - Corrected style and formatting to meet HQRM guidelines.
   - Converted exceptions to use ResourceHelper functions.
 - Updated badges in README.MD to match the layout from PSDscResources.
+- MSFT_xDhcpClient:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Converted exceptions to use ResourceHelper functions.
 
 ## 4.1.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
@@ -297,6 +297,7 @@ function Assert-ResourceProperty
         [String]
         $InterfaceAlias,
 
+        [Parameter()]
         [ValidateSet('IPv4', 'IPv6')]
         [String]
         $AddressFamily = 'IPv4',

--- a/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -35,17 +35,17 @@ function Get-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $InterfaceAlias,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
-        [String]
+        [System.String]
         $AddressFamily,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
-        [String]
+        [System.String]
         $State
     )
 
@@ -88,17 +88,17 @@ function Set-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $InterfaceAlias,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
-        [String]
+        [System.String]
         $AddressFamily,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
-        [String]
+        [System.String]
         $State
     )
 
@@ -147,22 +147,22 @@ function Test-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $InterfaceAlias,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
-        [String]
+        [System.String]
         $AddressFamily,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
-        [String]
+        [System.String]
         $State
     )
 
     # Flag to signal whether settings are correct
-    [Boolean] $desiredConfigurationMatch = $true
+    [System.Boolean] $desiredConfigurationMatch = $true
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
             $($LocalizedData.CheckingDHCPClientMessage) `
@@ -209,17 +209,17 @@ function Assert-ResourceProperty
     (
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
-        [String]
+        [System.String]
         $InterfaceAlias,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
-        [String]
+        [System.String]
         $AddressFamily,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
-        [String]
+        [System.String]
         $State
     )
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -2,13 +2,13 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 # Import the Networking Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
-                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+            -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
-                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+            -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -50,23 +50,23 @@ function Get-TargetResource
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-        $($LocalizedData.GettingDHCPClientMessage) `
-        -f $InterfaceAlias,$AddressFamily `
+            $($LocalizedData.GettingDHCPClientMessage) `
+                -f $InterfaceAlias, $AddressFamily `
         ) -join '')
 
     Assert-ResourceProperty @PSBoundParameters
 
-    $CurrentDHCPClient = Get-NetIPInterface `
+    $currentDHCPClient = Get-NetIPInterface `
         -InterfaceAlias $InterfaceAlias `
         -AddressFamily $AddressFamily
 
     $returnValue = @{
-        State          = $CurrentDHCPClient.Dhcp
+        State          = $currentDHCPClient.Dhcp
         AddressFamily  = $AddressFamily
         InterfaceAlias = $InterfaceAlias
     }
 
-    $returnValue
+    return $returnValue
 }
 
 <#
@@ -103,13 +103,13 @@ function Set-TargetResource
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-        $($LocalizedData.ApplyingDHCPClientMessage) `
-        -f $InterfaceAlias,$AddressFamily `
+            $($LocalizedData.ApplyingDHCPClientMessage) `
+                -f $InterfaceAlias, $AddressFamily `
         ) -join '')
 
     Assert-ResourceProperty @PSBoundParameters
 
-    $CurrentDHCPClient = Get-NetIPInterface `
+    $null = Get-NetIPInterface `
         -InterfaceAlias $InterfaceAlias `
         -AddressFamily $AddressFamily
 
@@ -121,8 +121,8 @@ function Set-TargetResource
         -ErrorAction Stop
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-        $($LocalizedData.DHCPClientSetStateMessage) `
-        -f $InterfaceAlias,$AddressFamily,$State `
+            $($LocalizedData.DHCPClientSetStateMessage) `
+                -f $InterfaceAlias, $AddressFamily, $State `
         ) -join '' )
 
 } # Set-TargetResource
@@ -165,22 +165,22 @@ function Test-TargetResource
     [Boolean] $desiredConfigurationMatch = $true
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-        $($LocalizedData.CheckingDHCPClientMessage) `
-        -f $InterfaceAlias,$AddressFamily `
+            $($LocalizedData.CheckingDHCPClientMessage) `
+                -f $InterfaceAlias, $AddressFamily `
         ) -join '')
 
     Assert-ResourceProperty @PSBoundParameters
 
-    $CurrentDHCPClient = Get-NetIPInterface `
+    $currentDHCPClient = Get-NetIPInterface `
         -InterfaceAlias $InterfaceAlias `
         -AddressFamily $AddressFamily
 
     # The DHCP Client is in a different state - so change it.
-    if ($CurrentDHCPClient.DHCP -ne $State)
+    if ($currentDHCPClient.DHCP -ne $State)
     {
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-            $($LocalizedData.DHCPClientDoesNotMatchMessage) `
-            -f $InterfaceAlias,$AddressFamily,$State `
+                $($LocalizedData.DHCPClientDoesNotMatchMessage) `
+                    -f $InterfaceAlias, $AddressFamily, $State `
             ) -join '' )
         $desiredConfigurationMatch = $false
     }
@@ -225,15 +225,8 @@ function Assert-ResourceProperty
 
     if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
     {
-        $errorId = 'InterfaceNotAvailable'
-        $errorCategory = [System.Management.Automation.ErrorCategory]::DeviceError
-        $errorMessage = $($LocalizedData.InterfaceNotAvailableError) -f $InterfaceAlias
-        $exception = New-Object -TypeName System.InvalidOperationException `
-            -ArgumentList $errorMessage
-        $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-            -ArgumentList $exception, $errorId, $errorCategory, $null
-
-        $PSCmdlet.ThrowTerminatingError($errorRecord)
+        New-InvalidOperationException `
+            -Message ($LocalizedData.InterfaceNotAvailableError -f $InterfaceAlias)
     }
 } # Assert-ResourceProperty
 

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.config.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.config.ps1
@@ -6,7 +6,8 @@ $TestDefaultGatewayAddress = [PSObject]@{
 
 configuration MSFT_xDefaultGatewayAddress_Config {
     Import-DscResource -ModuleName xNetworking
-    node localhost {
+
+    Node localhost {
         xDefaultGatewayAddress Integration_Test
         {
             InterfaceAlias = $TestDefaultGatewayAddress.InterfaceAlias

--- a/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'xNetworking'
-$script:DSCResourceName    = 'MSFT_xDhcpClient'
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xDhcpClient'
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -31,7 +31,7 @@ try
 
     Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
-        It 'Should compile without throwing' {
+        It 'Should compile and apply the MOF without throwing' {
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force

--- a/Tests/Integration/MSFT_xDhcpClient.config.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.config.ps1
@@ -1,16 +1,18 @@
 $TestDhcpClient = [PSObject]@{
-    InterfaceAlias          = 'xNetworkingLBA'
-    AddressFamily           = 'IPv4'
-    State                   = 'Enabled'
+    InterfaceAlias = 'xNetworkingLBA'
+    AddressFamily  = 'IPv4'
+    State          = 'Enabled'
 }
 
 configuration MSFT_xDhcpClient_Config {
     Import-DscResource -ModuleName xNetworking
-    node localhost {
-        xDhcpClient Integration_Test {
-            InterfaceAlias          = $TestDhcpClient.InterfaceAlias
-            AddressFamily           = $TestDhcpClient.AddressFamily
-            State                   = $TestDhcpClient.State
+
+    Node localhost {
+        xDhcpClient Integration_Test
+        {
+            InterfaceAlias = $TestDhcpClient.InterfaceAlias
+            AddressFamily  = $TestDhcpClient.AddressFamily
+            State          = $TestDhcpClient.State
         }
     }
 }


### PR DESCRIPTION
 MSFT_xDhcpClient:
  - Corrected style and formatting to meet HQRM guidelines.
  - Converted exceptions to use ResourceHelper functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/228)
<!-- Reviewable:end -->
