### PR TITLE
MSFT_xDnsConnectionSuffix: Correct Style to meet HQRM and exceptions to use ResourceHelper functions - Fixes #226 

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@
 - MSFT_xDhcpClient:
   - Corrected style and formatting to meet HQRM guidelines.
   - Converted exceptions to use ResourceHelper functions.
+- README.MD:
+  - Cleaned up badges by putting them into a table.
+- MSFT_xDnsConnectionSuffix:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Converted exceptions to use ResourceHelper functions.
 
 ## 5.0.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
@@ -2,13 +2,13 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 # Import the Networking Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
-                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+            -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
-                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+            -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -51,28 +51,34 @@ function Get-TargetResource
         [System.String]
         $ConnectionSpecificSuffix,
 
+        [Parameter()]
         [System.Boolean]
         $RegisterThisConnectionsAddress = $true,
 
+        [Parameter()]
         [System.Boolean]
         $UseSuffixWhenRegistering = $false,
 
-        [ValidateSet('Present','Absent')]
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present'
     )
 
     $dnsClient = Get-DnsClient -InterfaceAlias $InterfaceAlias -ErrorAction SilentlyContinue
+
     $targetResource = @{
         InterfaceAlias                 = $dnsClient.InterfaceAlias
         ConnectionSpecificSuffix       = $dnsClient.ConnectionSpecificSuffix
         RegisterThisConnectionsAddress = $dnsClient.RegisterThisConnectionsAddress
         UseSuffixWhenRegistering       = $dnsClient.UseSuffixWhenRegistering
     }
+
     if ($Ensure -eq 'Present')
     {
-        ## Test to see if the connection-specific suffix matches
+        # Test to see if the connection-specific suffix matches
         Write-Verbose -Message ($LocalizedData.CheckingConnectionSuffix -f $ConnectionSpecificSuffix)
+
         if ($dnsClient.ConnectionSpecificSuffix -eq $ConnectionSpecificSuffix)
         {
             $Ensure = 'Present'
@@ -84,8 +90,9 @@ function Get-TargetResource
     }
     else
     {
-        ## ($Ensure -eq 'Absent'). Test to see if there is a connection-specific suffix
+        # ($Ensure -eq 'Absent'). Test to see if there is a connection-specific suffix
         Write-Verbose -Message ($LocalizedData.CheckingConnectionSuffix -f '')
+
         if ([System.String]::IsNullOrEmpty($dnsClient.ConnectionSpecificSuffix))
         {
             $Ensure = 'Absent'
@@ -95,7 +102,9 @@ function Get-TargetResource
             $Ensure = 'Present'
         }
     }
+
     $targetResource['Ensure'] = $Ensure
+
     return $targetResource
 }
 
@@ -134,34 +143,41 @@ function Set-TargetResource
         [System.String]
         $ConnectionSpecificSuffix,
 
+        [Parameter()]
         [System.Boolean]
         $RegisterThisConnectionsAddress = $true,
 
+        [Parameter()]
         [System.Boolean]
         $UseSuffixWhenRegistering = $false,
 
-        [ValidateSet('Present','Absent')]
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present'
     )
 
     $setDnsClientParams = @{
-        InterfaceAlias = $InterfaceAlias
+        InterfaceAlias                 = $InterfaceAlias
         RegisterThisConnectionsAddress = $RegisterThisConnectionsAddress
-        UseSuffixWhenRegistering = $UseSuffixWhenRegistering
+        UseSuffixWhenRegistering       = $UseSuffixWhenRegistering
     }
+
     if ($Ensure -eq 'Present')
     {
         $setDnsClientParams['ConnectionSpecificSuffix'] = $ConnectionSpecificSuffix
+
         Write-Verbose -Message ($LocalizedData.SettingConnectionSuffix `
-            -f $ConnectionSpecificSuffix, $InterfaceAlias)
+                -f $ConnectionSpecificSuffix, $InterfaceAlias)
     }
     else
     {
         $setDnsClientParams['ConnectionSpecificSuffix'] = ''
+
         Write-Verbose -Message ($LocalizedData.RemovingConnectionSuffix `
-            -f $ConnectionSpecificSuffix, $InterfaceAlias)
+                -f $ConnectionSpecificSuffix, $InterfaceAlias)
     }
+
     Set-DnsClient @setDnsClientParams
 }
 
@@ -201,37 +217,47 @@ function Test-TargetResource
         [System.String]
         $ConnectionSpecificSuffix,
 
+        [Parameter()]
         [System.Boolean]
         $RegisterThisConnectionsAddress = $true,
 
+        [Parameter()]
         [System.Boolean]
         $UseSuffixWhenRegistering = $false,
 
-        [ValidateSet('Present','Absent')]
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present'
     )
 
     $targetResource = Get-TargetResource @PSBoundParameters
     $inDesiredState = $true
+
     if ($targetResource.Ensure -ne $Ensure)
     {
         Write-Verbose -Message ($LocalizedData.PropertyMismatch `
-            -f 'Ensure', $Ensure, $targetResource.Ensure)
+                -f 'Ensure', $Ensure, $targetResource.Ensure)
+
         $inDesiredState = $false
     }
+
     if ($targetResource.RegisterThisConnectionsAddress -ne $RegisterThisConnectionsAddress)
     {
         Write-Verbose -Message ($LocalizedData.PropertyMismatch `
-            -f 'RegisterThisConnectionsAddress', $RegisterThisConnectionsAddress, $targetResource.RegisterThisConnectionsAddress)
+                -f 'RegisterThisConnectionsAddress', $RegisterThisConnectionsAddress, $targetResource.RegisterThisConnectionsAddress)
+
         $inDesiredState = $false
     }
+
     if ($targetResource.UseSuffixWhenRegistering -ne $UseSuffixWhenRegistering)
     {
         Write-Verbose -Message ($LocalizedData.PropertyMismatch `
-            -f 'UseSuffixWhenRegistering', $UseSuffixWhenRegistering, $targetResource.UseSuffixWhenRegistering)
+                -f 'UseSuffixWhenRegistering', $UseSuffixWhenRegistering, $targetResource.UseSuffixWhenRegistering)
+
         $inDesiredState = $false
     }
+
     if ($inDesiredState)
     {
         Write-Verbose -Message $LocalizedData.ResourceInDesiredState
@@ -240,6 +266,7 @@ function Test-TargetResource
     {
         Write-Verbose -Message $LocalizedData.ResourceNotInDesiredState
     }
+
     return $inDesiredState
 }
 

--- a/README.md
+++ b/README.md
@@ -1,10 +1,9 @@
 # xNetworking
 
-master: [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/master)
-[![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking)
-
-dev: [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/dev)
-[![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking)
+| Branch | Build Status | Code Coverage |
+| --- | --- | --- |
+| master | [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/master) | [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking) |
+| dev | [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/dev) | [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking) |
 
 The **xNetworking** module contains the following resources:
 

--- a/README.md
+++ b/README.md
@@ -2,8 +2,8 @@
 
 | Branch | Build Status | Code Coverage |
 | --- | --- | --- |
-| master | [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/master) | [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking) |
-| dev | [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/dev) | [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking) |
+| master | [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/master) | [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking/branch/master) |
+| dev | [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/dev) | [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking/branch/dev) |
 
 The **xNetworking** module contains the following resources:
 

--- a/Tests/Integration/MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'xNetworking'
-$script:DSCResourceName    = 'MSFT_xDnsConnectionSuffix'
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xDnsConnectionSuffix'
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force

--- a/Tests/Unit/MSFT_xDnsConnectionSuffix.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsConnectionSuffix.Tests.ps1
@@ -1,13 +1,13 @@
-$script:DSCModuleName      = 'xNetworking'
-$script:DSCResourceName    = 'MSFT_xDnsConnectionSuffix'
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xDnsConnectionSuffix'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -23,75 +23,75 @@ try
     #region Pester Tests
     InModuleScope $script:DSCResourceName {
 
-        $testDnsSuffix = 'example.local';
-        $testInterfaceAlias = 'Ethernet';
+        $testDnsSuffix = 'example.local'
+        $testInterfaceAlias = 'Ethernet'
         $testDnsSuffixParams = @{
-            InterfaceAlias = $testInterfaceAlias;
-            ConnectionSpecificSuffix = $testDnsSuffix;
+            InterfaceAlias           = $testInterfaceAlias
+            ConnectionSpecificSuffix = $testDnsSuffix
         }
 
         $fakeDnsSuffixPresent = @{
-            InterfaceAlias = $testInterfaceAlias;
-            ConnectionSpecificSuffix = $testDnsSuffix;
-            RegisterThisConnectionsAddress = $true;
-            UseSuffixWhenRegistering = $false;
+            InterfaceAlias                 = $testInterfaceAlias
+            ConnectionSpecificSuffix       = $testDnsSuffix
+            RegisterThisConnectionsAddress = $true
+            UseSuffixWhenRegistering       = $false
         }
 
-        $fakeDnsSuffixMismatch = $fakeDnsSuffixPresent.Clone();
-        $fakeDnsSuffixMismatch['ConnectionSpecificSuffix'] = 'mismatch.local';
+        $fakeDnsSuffixMismatch = $fakeDnsSuffixPresent.Clone()
+        $fakeDnsSuffixMismatch['ConnectionSpecificSuffix'] = 'mismatch.local'
 
-        $fakeDnsSuffixAbsent = $fakeDnsSuffixPresent.Clone();
-        $fakeDnsSuffixAbsent['ConnectionSpecificSuffix'] = '';
+        $fakeDnsSuffixAbsent = $fakeDnsSuffixPresent.Clone()
+        $fakeDnsSuffixAbsent['ConnectionSpecificSuffix'] = ''
 
 
-       Describe "MSFT_xDnsConnectionSuffix\Get-TargetResource" {
+        Describe "MSFT_xDnsConnectionSuffix\Get-TargetResource" {
             Context 'Validates "Get-TargetResource" method' {
-                It 'Returns a "System.Collections.Hashtable" object type' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
+                It 'Should return a "System.Collections.Hashtable" object type' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
 
-                    $targetResource = Get-TargetResource @testDnsSuffixParams;
+                    $targetResource = Get-TargetResource @testDnsSuffixParams
 
-                    $targetResource -is [System.Collections.Hashtable] | Should Be $true;
+                    $targetResource -is [System.Collections.Hashtable] | Should Be $true
                 }
 
-                It 'Returns "Present" when DNS suffix matches and "Ensure" = "Present"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
+                It 'Should return "Present" when DNS suffix matches and "Ensure" = "Present"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
 
-                    $targetResource = Get-TargetResource @testDnsSuffixParams;
+                    $targetResource = Get-TargetResource @testDnsSuffixParams
 
-                    $targetResource.Ensure | Should Be 'Present';
+                    $targetResource.Ensure | Should Be 'Present'
                 }
 
-                It 'Returns "Absent" when DNS suffix does not match and "Ensure" = "Present"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixMismatch; }
+                It 'Should return "Absent" when DNS suffix does not match and "Ensure" = "Present"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixMismatch }
 
-                    $targetResource = Get-TargetResource @testDnsSuffixParams;
+                    $targetResource = Get-TargetResource @testDnsSuffixParams
 
-                    $targetResource.Ensure | Should Be 'Absent';
+                    $targetResource.Ensure | Should Be 'Absent'
                 }
 
-                It 'Returns "Absent" when no DNS suffix is defined and "Ensure" = "Present"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent; }
+                It 'Should return "Absent" when no DNS suffix is defined and "Ensure" = "Present"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent }
 
-                    $targetResource = Get-TargetResource @testDnsSuffixParams;
+                    $targetResource = Get-TargetResource @testDnsSuffixParams
 
-                    $targetResource.Ensure | Should Be 'Absent';
+                    $targetResource.Ensure | Should Be 'Absent'
                 }
 
-                It 'Returns "Absent" when no DNS suffix is defined and "Ensure" = "Absent"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent; }
+                It 'Should return "Absent" when no DNS suffix is defined and "Ensure" = "Absent"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent }
 
-                    $targetResource = Get-TargetResource @testDnsSuffixParams -Ensure Absent;
+                    $targetResource = Get-TargetResource @testDnsSuffixParams -Ensure Absent
 
-                    $targetResource.Ensure | Should Be 'Absent';
+                    $targetResource.Ensure | Should Be 'Absent'
                 }
 
-                It 'Returns "Present" when DNS suffix is defined and "Ensure" = "Absent"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
+                It 'Should return "Present" when DNS suffix is defined and "Ensure" = "Absent"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
 
-                    $targetResource = Get-TargetResource @testDnsSuffixParams -Ensure Absent;
+                    $targetResource = Get-TargetResource @testDnsSuffixParams -Ensure Absent
 
-                    $targetResource.Ensure | Should Be 'Present';
+                    $targetResource.Ensure | Should Be 'Present'
                 }
 
             } #end Context 'Validates "Get-TargetResource" method'
@@ -99,89 +99,97 @@ try
 
         Describe "MSFT_xDnsConnectionSuffix\Test-TargetResource" {
             Context 'Validates "Test-TargetResource" method' {
+                It 'Should pass when all properties match and "Ensure" = "Present"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
 
-                It 'Passes when all properties match and "Ensure" = "Present"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
+                    $targetResource = Test-TargetResource @testDnsSuffixParams
 
-                    $targetResource = Test-TargetResource @testDnsSuffixParams;
-
-                    $targetResource | Should Be $true;
-                }
-                It 'Passes when no DNS suffix is registered and "Ensure" = "Absent"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent; }
-
-                    $targetResource = Test-TargetResource @testDnsSuffixParams -Ensure Absent;
-
-                    $targetResource | Should Be $true;
-                }
-                It 'Passes when "RegisterThisConnectionsAddress" setting is correct' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-
-                    $targetResource = Test-TargetResource @testDnsSuffixParams -RegisterThisConnectionsAddress $true;
-
-                    $targetResource | Should Be $true;
-                }
-                It 'Passes when "UseSuffixWhenRegistering" setting is correct' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
-
-                    $targetResource = Test-TargetResource @testDnsSuffixParams -UseSuffixWhenRegistering $false;
-
-                    $targetResource | Should Be $true;
+                    $targetResource | Should Be $true
                 }
 
-                It 'Fails when no DNS suffix is registered and "Ensure" = "Present"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent; }
+                It 'Should pass when no DNS suffix is registered and "Ensure" = "Absent"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent }
 
-                    $targetResource = Test-TargetResource @testDnsSuffixParams;
+                    $targetResource = Test-TargetResource @testDnsSuffixParams -Ensure Absent
 
-                    $targetResource | Should Be $false;
+                    $targetResource | Should Be $true
                 }
-                It 'Fails when the registered DNS suffix is incorrect and "Ensure" = "Present"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixMismatch; }
 
-                    $targetResource = Test-TargetResource @testDnsSuffixParams;
+                It 'Should pass when "RegisterThisConnectionsAddress" setting is correct' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
 
-                    $targetResource | Should Be $false;
+                    $targetResource = Test-TargetResource @testDnsSuffixParams -RegisterThisConnectionsAddress $true
+
+                    $targetResource | Should Be $true
                 }
-                It 'Fails when a DNS suffix is registered and "Ensure" = "Absent"' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
 
-                    $targetResource = Test-TargetResource @testDnsSuffixParams -Ensure Absent;
+                It 'Should pass when "UseSuffixWhenRegistering" setting is correct' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
 
-                    $targetResource | Should Be $false;
+                    $targetResource = Test-TargetResource @testDnsSuffixParams -UseSuffixWhenRegistering $false
+
+                    $targetResource | Should Be $true
                 }
-                It 'Fails when "RegisterThisConnectionsAddress" setting is incorrect' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
 
-                    $targetResource = Test-TargetResource @testDnsSuffixParams -RegisterThisConnectionsAddress $false;
 
-                    $targetResource | Should Be $false;
+                It 'Should fail when no DNS suffix is registered and "Ensure" = "Present"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixAbsent }
+
+                    $targetResource = Test-TargetResource @testDnsSuffixParams
+
+                    $targetResource | Should Be $false
                 }
-                It 'Fails when "UseSuffixWhenRegistering" setting is incorrect' {
-                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent; }
 
-                    $targetResource = Test-TargetResource @testDnsSuffixParams -UseSuffixWhenRegistering $true;
+                It 'Should fail when the registered DNS suffix is incorrect and "Ensure" = "Present"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixMismatch }
 
-                    $targetResource | Should Be $false;
+                    $targetResource = Test-TargetResource @testDnsSuffixParams
+
+                    $targetResource | Should Be $false
+                }
+
+                It 'Should fail when a DNS suffix is registered and "Ensure" = "Absent"' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
+
+                    $targetResource = Test-TargetResource @testDnsSuffixParams -Ensure Absent
+
+                    $targetResource | Should Be $false
+                }
+
+                It 'Should fail when "RegisterThisConnectionsAddress" setting is incorrect' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
+
+                    $targetResource = Test-TargetResource @testDnsSuffixParams -RegisterThisConnectionsAddress $false
+
+                    $targetResource | Should Be $false
+                }
+
+                It 'Should fail when "UseSuffixWhenRegistering" setting is incorrect' {
+                    Mock Get-DnsClient { return [PSCustomObject] $fakeDnsSuffixPresent }
+
+                    $targetResource = Test-TargetResource @testDnsSuffixParams -UseSuffixWhenRegistering $true
+
+                    $targetResource | Should Be $false
                 }
             } #end Context 'Validates "Test-TargetResource" method'
         }
 
         Describe "MSFT_xDnsConnectionSuffix\Test-TargetResource" {
             Context 'Validates "Set-TargetResource" method' {
-                It 'Calls "Set-DnsClient" with specified DNS suffix when "Ensure" = "Present"' {
+                It 'Should call "Set-DnsClient" with specified DNS suffix when "Ensure" = "Present"' {
                     Mock Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq $testDnsSuffix } { }
 
-                    Set-TargetResource @testDnsSuffixParams;
+                    Set-TargetResource @testDnsSuffixParams
 
-                    Assert-MockCalled Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq $testDnsSuffix } -Scope It;
+                    Assert-MockCalled Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq $testDnsSuffix } -Scope It
                 }
-                It 'Calls "Set-DnsClient" with no DNS suffix when "Ensure" = "Absent"' {
+
+                It 'Should call "Set-DnsClient" with no DNS suffix when "Ensure" = "Absent"' {
                     Mock Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq '' } { }
 
-                    Set-TargetResource @testDnsSuffixParams -Ensure Absent;
+                    Set-TargetResource @testDnsSuffixParams -Ensure Absent
 
-                    Assert-MockCalled Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq '' } -Scope It;
+                    Assert-MockCalled Set-DnsClient -ParameterFilter { $InterfaceAlias -eq $testInterfaceAlias -and $ConnectionSpecificSuffix -eq '' } -Scope It
                 }
             } #end Context 'Validates "Set-TargetResource" method'
         }


### PR DESCRIPTION


MSFT_xDnsConnectionSuffix:
- Corrected style and formatting to meet HQRM guidelines.
- Converted exceptions to use ResourceHelper functions.

<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/230)
<!-- Reviewable:end -->
