### PR TITLE
Change branch header and add markdownlint settings - Fixes #231

### DIFF
--- a/.markdownlint.json
+++ b/.markdownlint.json
@@ -1,0 +1,10 @@
+{
+    "default": true,
+    "MD029": {
+        "style": "one"
+    },
+    "MD013": true,
+    "MD024": true,
+    "MD034": true,
+    "no-hard-tabs": true
+}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@
 - MSFT_xDnsConnectionSuffix:
   - Corrected style and formatting to meet HQRM guidelines.
   - Converted exceptions to use ResourceHelper functions.
+- README.MD:
+  - Converted badges to use branch header as used in xSQLServer.
+- Added standard .markdownlint.json to configure rules to run on
+  Markdown files.
 
 ## 5.0.0.0
 
@@ -283,11 +287,12 @@
 - MSFT_xFirewall: Set-TargetResource now updates firewall rules instead of
   recreating them.
 - MSFT_xFirewall: Added message localization support.
-- MSFT_xFirewall: Removed unessesary code for handling multiple rules with same name.
-- MSFT_xDefaultGatewayAddress: Removed unessesary try/catch logic from around
+- MSFT_xFirewall: Removed unnecessary code for handling multiple rules with same
+  name.
+- MSFT_xDefaultGatewayAddress: Removed unnecessary try/catch logic from around
   networking cmdlets.
-- MSFT_xIPAddress: Removed unessesary try/catch logic from around networking cmdlets.
-- MSFT_xDNSServerAddress: Removed unessesary try/catch logic from around
+- MSFT_xIPAddress: Removed unnecessary try/catch logic from around networking cmdlets.
+- MSFT_xDNSServerAddress: Removed unnecessary try/catch logic from around
   networking cmdlets.
 - MSFT_xDefaultGatewayAddress: Refactored to add more unit tests and cleanup logic.
 - MSFT_xIPAddress: Network Connection Profile no longer forced to Private when

--- a/README.md
+++ b/README.md
@@ -1,10 +1,5 @@
 # xNetworking
 
-| Branch | Build Status | Code Coverage |
-| --- | --- | --- |
-| master | [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/master) | [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking/branch/master) |
-| dev | [![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/dev) | [![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking/branch/dev) |
-
 The **xNetworking** module contains the following resources:
 
 - **xFirewall**: Sets a node's firewall rules.
@@ -32,6 +27,24 @@ For more information see the [Code of Conduct FAQ](https://opensource.microsoft.
 or contact [opencode@microsoft.com](mailto:opencode@microsoft.com) with any
 additional questions or comments.
 
+## Branches
+
+### master
+
+[![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/master?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/master)
+[![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/master/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking/branch/master)
+
+This is the branch containing the latest release - no contributions should be made
+directly to this branch.
+
+### dev
+
+[![Build status](https://ci.appveyor.com/api/projects/status/obmudad7gy8usbx2/branch/dev?svg=true)](https://ci.appveyor.com/project/PowerShell/xNetworking/branch/dev)[![codecov](https://codecov.io/gh/PowerShell/xNetworking/branch/dev/graph/badge.svg)](https://codecov.io/gh/PowerShell/xNetworking/branch/dev)
+
+This is the development branch to which contributions should be proposed by contributors
+as pull requests. This development branch will periodically be merged to the master
+branch, and be released to [PowerShell Gallery](https://www.powershellgallery.com/).
+
 ## Contributing
 
 Please check out common DSC Resources [contributing guidelines](https://github.com/PowerShell/DscResource.Kit/blob/master/CONTRIBUTING.md).
@@ -50,7 +63,7 @@ not installed. Please ensure this update is installed if this error occurs.
     preference via -Debug switch or $DebugPreference variable, and try again.
 ````
 
-### Known Invalid Configuraiton
+### Known Invalid Configuration
 
 - The exception 'One of the port keywords is invalid' will be thrown if a rule
     is created with the LocalPort set to PlayToDiscovery and the Protocol is not


### PR DESCRIPTION
As per suggestion from @johlju, I've added the branches header copied from xSQLServer. This is so that the MD013 rule validation can be enabled.

The markdownlint rules file has also been added so that the standard rules are enforced.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/232)
<!-- Reviewable:end -->
