### PR TITLE
MSFT_xDnsClientGlobalSetting: Correct Style to meet HQRM and exceptions to use ResourceHelper functions - Fixes #227

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,9 @@
   - Converted badges to use branch header as used in xSQLServer.
 - Added standard .markdownlint.json to configure rules to run on
   Markdown files.
+- MSFT_xDnsClientGlobalSetting:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Converted exceptions to use ResourceHelper functions.
 
 ## 5.0.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
@@ -11,7 +11,7 @@ Import-Module -Name (Join-Path -Path $modulePath `
             -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
-$localizedData = Get-LocalizedData `
+$LocalizedData = Get-LocalizedData `
     -ResourceName 'MSFT_xDefaultGatewayAddress' `
     -ResourcePath (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDhcpClient/MSFT_xDhcpClient.psm1
@@ -11,7 +11,7 @@ Import-Module -Name (Join-Path -Path $modulePath `
             -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
-$localizedData = Get-LocalizedData `
+$LocalizedData = Get-LocalizedData `
     -ResourceName 'MSFT_xDhcpClient' `
     -ResourcePath (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
 

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.data.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.data.psd1
@@ -1,7 +1,16 @@
 @{
     ParameterList = @(
-        @{ Name = 'SuffixSearchList'; Type = 'String'  },
-        @{ Name = 'UseDevolution';    Type = 'Boolean' },
-        @{ Name = 'DevolutionLevel';  Type = 'Uint32'  }
+        @{
+            Name = 'SuffixSearchList'
+            Type = 'String'
+        },
+        @{
+            Name = 'UseDevolution'
+            Type = 'Boolean'
+        },
+        @{
+            Name = 'DevolutionLevel'
+            Type = 'Uint32'
+        }
     )
 }

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsClientGlobalSetting/MSFT_xDnsClientGlobalSetting.psm1
@@ -35,7 +35,7 @@ $script:parameterList = $resourceData.ParameterList
 function Get-TargetResource
 {
     [CmdletBinding()]
-    [OutputType([Hashtable])]
+    [OutputType([System.Collections.Hashtable])]
     param
     (
         [Parameter(Mandatory = $true)]

--- a/Modules/xNetworking/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDnsConnectionSuffix/MSFT_xDnsConnectionSuffix.psm1
@@ -11,7 +11,7 @@ Import-Module -Name (Join-Path -Path $modulePath `
             -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
-$localizedData = Get-LocalizedData `
+$LocalizedData = Get-LocalizedData `
     -ResourceName 'MSFT_xDnsConnectionSuffix' `
     -ResourcePath (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
 

--- a/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
@@ -38,7 +38,7 @@ try
             } | Should not throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
@@ -45,10 +45,10 @@ try
     $configData = @{
         AllNodes = @(
             @{
-                NodeName              = 'localhost'
-                SuffixSearchList             = 'contoso.com'
-                UseDevolution                = $True
-                DevolutionLevel              = 2
+                NodeName         = 'localhost'
+                SuffixSearchList = 'contoso.com'
+                UseDevolution    = $True
+                DevolutionLevel  = 2
             }
         )
     }
@@ -59,7 +59,7 @@ try
 
     Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
-        It 'Should compile without throwing' {
+        It 'Should compile and apply the MOF without throwing' {
             {
                 & "$($script:DSCResourceName)_Config" `
                     -OutputPath $TestDrive `
@@ -69,22 +69,22 @@ try
             } | Should not throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion
 
         # Get the DNS Client Global Settings details
-        $DnsClientGlobalSettingNew = Get-DnsClientGlobalSetting
+        $dnsClientGlobalSettingNew = Get-DnsClientGlobalSetting
 
         # Use the Parameters List to perform these tests
         foreach ($parameter in $parameterList)
         {
-            $parameterValue = (Get-Variable -Name 'DnsClientGlobalSettingNew').value.$($parameter.name)
-            $parameterNew = (Get-Variable -Name configData).Value.AllNodes[0].$($parameter.Name)
+            $parameterCurrentValue = (Get-Variable -Name 'dnsClientGlobalSettingNew').value.$($parameter.name)
+            $parameterNewValue = (Get-Variable -Name configData).Value.AllNodes[0].$($parameter.Name)
 
-            It "Should have set the '$parameterName' to '$parameterNew'" {
-                $parameterValue | Should Be $parameterNew
+            It "Should have set the '$parameterName' to '$parameterNewValue'" {
+                $parameterCurrentValue | Should Be $parameterNewValue
             }
         }
     }


### PR DESCRIPTION
MSFT_xDnsClientGlobalSetting:
- Corrected style and formatting to meet HQRM guidelines.
- Converted exceptions to use ResourceHelper functions.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/233)
<!-- Reviewable:end -->
