### PR TITLE
Fix MSFT_xDnsServerAddress error when setting address - Fixes #237

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -17,6 +17,11 @@
 - MSFT_xDnsClientGlobalSetting:
   - Corrected style and formatting to meet HQRM guidelines.
   - Converted exceptions to use ResourceHelper functions.
+- Updated year to 2017 in LICENSE and module manifest.
+- MSFT_xDnsServerAddress:
+  - Fix error when setting address on adapter where NameServer
+    Property does not exist in registry for interface - see
+    [issue #237](https://github.com/PowerShell/xNetworking/issues/237)
 
 ## 5.0.0.0
 

--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,6 @@
 The MIT License (MIT)
 
-Copyright (c) 2015 Microsoft Corporation.
+Copyright (c) 2017 Microsoft Corporation.
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal

--- a/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDefaultGatewayAddress/MSFT_xDefaultGatewayAddress.psm1
@@ -44,6 +44,7 @@ function Get-TargetResource
         [String]
         $AddressFamily,
 
+        [Parameter()]
         [String]
         $Address
     )

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -336,10 +336,11 @@ function Get-DnsClientServerStaticAddress
         $interfaceRegKeyPath = "HKLM:\SYSTEM\CurrentControlSet\Services\Tcpip6\Parameters\Interfaces\$interfaceGuid\"
     } # if
 
-    $nameServerAddressString = Get-ItemPropertyValue `
+
+    $interfaceInformation = Get-ItemProperty `
         -Path $interfaceRegKeyPath `
-        -Name NameServer `
         -ErrorAction SilentlyContinue
+    $nameServerAddressString = $interfaceInformation.NameServer
 
     # Are any statically assigned addresses for this adapter?
     if ([String]::IsNullOrWhiteSpace($nameServerAddressString))

--- a/Modules/xNetworking/xNetworking.psd1
+++ b/Modules/xNetworking/xNetworking.psd1
@@ -12,7 +12,7 @@ Author = 'Microsoft Corporation'
 CompanyName = 'Microsoft Corporation'
 
 # Copyright statement for this module
-Copyright = '(c) 2013 Microsoft Corporation. All rights reserved.'
+Copyright = '(c) 2017 Microsoft Corporation. All rights reserved.'
 
 # Description of the functionality provided by this module
 Description = 'Module with DSC Resources for Networking area'
@@ -75,7 +75,7 @@ PrivateData = @{
 - Updated badges in README.MD to match the layout from PSDscResources.
 - MSFT_xIPAddress:
   - BREAKING CHANGE: Adding support for multiple IP addresses being assigned.
- 
+
 '
 
     } # End of PSData hashtable

--- a/Tests/Unit/NetworkingDsc.Common.tests.ps1
+++ b/Tests/Unit/NetworkingDsc.Common.tests.ps1
@@ -532,8 +532,12 @@ try
                     -MockWith { $matchAdapter }
 
                 Mock `
-                    -CommandName Get-ItemPropertyValue `
-                    -MockWith { $noIpv4StaticAddressString }
+                    -CommandName Get-ItemProperty `
+                    -MockWith {
+                        [psobject] @{
+                            NameServer  = $noIpv4StaticAddressString
+                        }
+                    }
 
                 It 'should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
@@ -545,7 +549,34 @@ try
 
                 It 'should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-ItemPropertyValue -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
+                }
+            }
+
+            Context 'Interface Alias was found in system but IPv4 NameServer property does not exist' {
+                Mock `
+                    -CommandName Get-NetAdapter `
+                    -MockWith { $matchAdapter }
+
+                Mock `
+                    -CommandName Get-ItemProperty `
+                    -MockWith {
+                        [psobject] @{
+                            Dummy = ''
+                        }
+                    }
+
+                It 'should not throw exception' {
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
+                }
+
+                It 'should return null' {
+                    $script:result | Should BeNullOrEmpty
+                }
+
+                It 'should call expected mocks' {
+                    Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
             }
 
@@ -555,8 +586,12 @@ try
                     -MockWith { $matchAdapter }
 
                 Mock `
-                    -CommandName Get-ItemPropertyValue `
-                    -MockWith { $oneIpv4StaticAddressString }
+                    -CommandName Get-ItemProperty `
+                    -MockWith {
+                        [psobject] @{
+                            NameServer = $oneIpv4StaticAddressString
+                        }
+                    }
 
                 It 'should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
@@ -568,7 +603,7 @@ try
 
                 It 'should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-ItemPropertyValue -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
             }
 
@@ -578,8 +613,12 @@ try
                     -MockWith { $matchAdapter }
 
                 Mock `
-                    -CommandName Get-ItemPropertyValue `
-                    -MockWith { $twoIpv4StaticAddressString }
+                    -CommandName Get-ItemProperty `
+                    -MockWith {
+                        [psobject] @{
+                            NameServer = $twoIpv4StaticAddressString
+                        }
+                    }
 
                 It 'should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
@@ -592,7 +631,7 @@ try
 
                 It 'should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-ItemPropertyValue -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
             }
 
@@ -602,8 +641,12 @@ try
                     -MockWith { $matchAdapter }
 
                 Mock `
-                    -CommandName Get-ItemPropertyValue `
-                    -MockWith { $noIpv6StaticAddressString }
+                    -CommandName Get-ItemProperty `
+                    -MockWith {
+                        [psobject] @{
+                            NameServer = $noIpv6StaticAddressString
+                        }
+                    }
 
                 It 'should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
@@ -615,7 +658,34 @@ try
 
                 It 'should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-ItemPropertyValue -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
+                }
+            }
+
+            Context 'Interface Alias was found in system but IPv6 NameServer property does not exist' {
+                Mock `
+                    -CommandName Get-NetAdapter `
+                    -MockWith { $matchAdapter }
+
+                Mock `
+                    -CommandName Get-ItemProperty `
+                    -MockWith {
+                        [psobject] @{
+                            Dummy = ''
+                        }
+                    }
+
+                It 'should not throw exception' {
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
+                }
+
+                It 'should return null' {
+                    $script:result | Should BeNullOrEmpty
+                }
+
+                It 'should call expected mocks' {
+                    Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
             }
 
@@ -625,8 +695,12 @@ try
                     -MockWith { $matchAdapter }
 
                 Mock `
-                    -CommandName Get-ItemPropertyValue `
-                    -MockWith { $oneIpv6StaticAddressString }
+                    -CommandName Get-ItemProperty `
+                    -MockWith {
+                        [psobject] @{
+                            NameServer = $oneIpv6StaticAddressString
+                        }
+                    }
 
                 It 'should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
@@ -638,7 +712,7 @@ try
 
                 It 'should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-ItemPropertyValue -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
             }
 
@@ -648,8 +722,12 @@ try
                     -MockWith { $matchAdapter }
 
                 Mock `
-                    -CommandName Get-ItemPropertyValue `
-                    -MockWith { $twoIpv6StaticAddressString }
+                    -CommandName Get-ItemProperty `
+                    -MockWith {
+                        [psobject] @{
+                            NameServer = $twoIpv6StaticAddressString
+                        }
+                    }
 
                 It 'should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
@@ -662,7 +740,7 @@ try
 
                 It 'should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
-                    Assert-MockCalled -CommandName Get-ItemPropertyValue -Exactly -Times 1
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
             }
         }

--- a/Tests/Unit/NetworkingDsc.Common.tests.ps1
+++ b/Tests/Unit/NetworkingDsc.Common.tests.ps1
@@ -517,11 +517,11 @@ try
                 $errorRecord = Get-InvalidOperationRecord `
                     -Message ($LocalizedData.InterfaceAliasNotFoundError -f $interfaceAlias)
 
-                It 'should throw exception' {
+                It 'Should throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Throw $errorRecord
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                 }
             }
@@ -539,15 +539,15 @@ try
                         }
                     }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return null' {
+                It 'Should return null' {
                     $script:result | Should BeNullOrEmpty
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
@@ -566,15 +566,15 @@ try
                         }
                     }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return null' {
+                It 'Should return null' {
                     $script:result | Should BeNullOrEmpty
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
@@ -593,15 +593,15 @@ try
                         }
                     }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected address' {
+                It 'Should return expected address' {
                     $script:result | Should Be $oneIpv4StaticAddressString
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
@@ -620,16 +620,16 @@ try
                         }
                     }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return two expected addresses' {
+                It 'Should return two expected addresses' {
                     $script:result[0] | Should Be $oneIpv4StaticAddressString
                     $script:result[1] | Should Be $secondIpv4StaticAddressString
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
@@ -648,15 +648,15 @@ try
                         }
                     }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return null' {
+                It 'Should return null' {
                     $script:result | Should BeNullOrEmpty
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
@@ -675,15 +675,15 @@ try
                         }
                     }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return null' {
+                It 'Should return null' {
                     $script:result | Should BeNullOrEmpty
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
@@ -702,15 +702,15 @@ try
                         }
                     }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return expected address' {
+                It 'Should return expected address' {
                     $script:result | Should Be $oneIpv6StaticAddressString
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }
@@ -729,16 +729,16 @@ try
                         }
                     }
 
-                It 'should not throw exception' {
+                It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
                 }
 
-                It 'should return two expected addresses' {
+                It 'Should return two expected addresses' {
                     $script:result[0] | Should Be $oneIpv6StaticAddressString
                     $script:result[1] | Should Be $secondIpv6StaticAddressString
                 }
 
-                It 'should call expected mocks' {
+                It 'Should call expected mocks' {
                     Assert-MockCalled -CommandName Get-NetAdapter -Exactly -Times 1
                     Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 1
                 }


### PR DESCRIPTION
This PR fixes issue #237.

The problem was caused by `Get-ItemPropertyValue` ignoring the `-ErrorAction SilentlyContinue` if the required property value does not exist. This causes an error to be thrown regardless of the ErrorAction setting. However, the `Get-ItemProperty` cmdlet does not ignore this.

I also corrected one missing `[Parameter()]` block in the MSFT_xDefaultGatewayAddress resource that had already been updated to HQRM - this was identified in the new PSSA rule validation (yay! :grin:).

I also updated the LICENSE and manifest with 2017 as the year.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/240)
<!-- Reviewable:end -->
