### PR TITLE
Fix MSFT_xFirewall DisplayName incorrectly set to Name (Fixes #234)

### DIFF
--- a/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xFirewall/MSFT_xFirewall.psm1
@@ -443,7 +443,7 @@ function Set-TargetResource
                         $null = $PSBoundParameters.Remove('DisplayName')
                         if ($DisplayName -ne $FirewallRule.DisplayName)
                         {
-                            $null = $PSBoundParameters.Add('NewDisplayName',$Name)
+                            $null = $PSBoundParameters.Add('NewDisplayName',$DisplayName)
                         }
                     }
 


### PR DESCRIPTION
This seemingly fixes issue #234 where if not already in desired state the DisplayName property is incorrectly set to Name. There remains a funky thing about the verbose output mentioned in the issue, but that might be unrelated, the DisplayName is set to DisplayName bottom line.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/241)
<!-- Reviewable:end -->
