### PR TITLE
Improved Examples for xIPAddress - Fixes #239

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,9 @@
   - Fix error when setting address on adapter where NameServer
     Property does not exist in registry for interface - see
     [issue #237](https://github.com/PowerShell/xNetworking/issues/237)
+- MSFT_xIPAddress:
+  - Improved examples to clarify how to set IP Address prefix -
+    see [issue #239](https://github.com/PowerShell/xNetworking/issues/239)
 
 ## 5.0.0.0
 

--- a/Modules/xNetworking/Examples/Resources/xIPAddress/1-AddingStaticIP.ps1
+++ b/Modules/xNetworking/Examples/Resources/xIPAddress/1-AddingStaticIP.ps1
@@ -1,6 +1,7 @@
 <#
     .EXAMPLE
     Disabling DHCP and adding a static IP Address for IPv6 and IPv4
+    using default prefix lengths for the matching address classes
 #>
 Configuration Example
 {
@@ -25,7 +26,7 @@ Configuration Example
         # If no prefix is supplied IPv6 will default to /64.
         xIPAddress NewIPv6Address
         {
-            IPAddress      = '2001:4898:200:7:6c71:a102:ebd8:f482/64'
+            IPAddress      = '2001:4898:200:7:6c71:a102:ebd8:f482'
             InterfaceAlias = 'Ethernet'
             AddressFamily  = 'IPV6'
         }

--- a/Modules/xNetworking/Examples/Resources/xIPAddress/3-AddingStaticIPWithPrefix.ps1
+++ b/Modules/xNetworking/Examples/Resources/xIPAddress/3-AddingStaticIPWithPrefix.ps1
@@ -1,6 +1,7 @@
 <#
     .EXAMPLE
-    Disabling DHCP and adding multiple static IP Addresses for IPv4 and IPv6
+    Disabling DHCP and adding a static IP Address for IPv6 and IPv4
+    using specified prefixes in CIDR notation.
 #>
 Configuration Example
 {
@@ -24,14 +25,14 @@ Configuration Example
 
         xIPAddress NewIPv6Address
         {
-            IPAddress      = '2001:4898:200:7:6c71:a102:ebd8:f482/64','2001:4598:210:7:6d71:a102:ebe8:f483/64'
+            IPAddress      = '2001:4898:200:7:6c71:a102:ebd8:f482/64'
             InterfaceAlias = 'Ethernet'
             AddressFamily  = 'IPV6'
         }
 
         xIPAddress NewIPv4Address
         {
-            IPAddress      = '192.168.10.5/24','192.168.10.6/24'
+            IPAddress      = '192.168.10.5/24'
             InterfaceAlias = 'Ethernet'
             AddressFamily  = 'IPV4'
         }


### PR DESCRIPTION
This PR addresses an issue raised in #239 that came from a question in #238.

It tries to clarify how to set IP Addresses with CIDR notation.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/242)
<!-- Reviewable:end -->
