### PR TITLE
xDNSServerAddress: Converted to HQRM - Fixes #236

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@
   - Fix error when setting address on adapter where NameServer
     Property does not exist in registry for interface - see
     [issue #237](https://github.com/PowerShell/xNetworking/issues/237).
+  - Corrected style and formatting to meet HQRM guidelines.
 - MSFT_xIPAddress:
   - Improved examples to clarify how to set IP Address prefix -
     see [issue #239](https://github.com/PowerShell/xNetworking/issues/239).

--- a/Modules/xNetworking/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDNSServerAddress/MSFT_xDNSServerAddress.psm1
@@ -44,6 +44,7 @@ function Get-TargetResource
         [String]
         $AddressFamily,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $Address
@@ -103,10 +104,12 @@ function Set-TargetResource
         [String]
         $AddressFamily,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $Address,
 
+        [Parameter()]
         [Boolean]
         $Validate = $false
     )
@@ -215,10 +218,12 @@ function Test-TargetResource
         [String]
         $AddressFamily,
 
+        [Parameter()]
         [ValidateNotNullOrEmpty()]
         [String[]]
         $Address,
 
+        [Parameter()]
         [Boolean]
         $Validate = $false
     )

--- a/Modules/xNetworking/DSCResources/MSFT_xDNSServerAddress/en-US/MSFT_xDNSServerAddress.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xDNSServerAddress/en-US/MSFT_xDNSServerAddress.strings.psd1
@@ -1,16 +1,16 @@
 # Localized resources for MSFT_xDNSServerAddress
 
 ConvertFrom-StringData @'
-    GettingDNSServerAddressesMessage = Getting the DNS server addresses.
-    ApplyingDNSServerAddressesMessage = Applying the DNS server addresses.
-    DNSServersSetCorrectlyMessage = DNS server addresses are set correctly.
-    DNSServersAlreadySetMessage = DNS server addresses are already set correctly.
-    CheckingDNSServerAddressesMessage = Checking the DNS server addresses.
-    DNSServersNotCorrectMessage = DNS server addresses are not correct. Expected "{0}", actual "{1}".
+    GettingDNSServerAddressesMessage      = Getting the DNS server addresses.
+    ApplyingDNSServerAddressesMessage     = Applying the DNS server addresses.
+    DNSServersSetCorrectlyMessage         = DNS server addresses are set correctly.
+    DNSServersAlreadySetMessage           = DNS server addresses are already set correctly.
+    CheckingDNSServerAddressesMessage     = Checking the DNS server addresses.
+    DNSServersNotCorrectMessage           = DNS server addresses are not correct. Expected "{0}", actual "{1}".
     DNSServersHaveBeenSetCorrectlyMessage = DNS server addresses were set to the desired state.
-    DNSServersHaveBeenSetToDHCPMessage = DNS server addresses were set to the desired state of DHCP.
-    InterfaceNotAvailableError = Interface "{0}" is not available. Please select a valid interface and try again.
-    AddressFormatError = Address "{0}" is not in the correct format. Please correct the Address parameter in the configuration and try again.
-    AddressIPv4MismatchError = Address "{0}" is in IPv4 format, which does not match server address family {1}. Please correct either of them in the configuration and try again.
-    AddressIPv6MismatchError = Address "{0}" is in IPv6 format, which does not match server address family {1}. Please correct either of them in the configuration and try again.
+    DNSServersHaveBeenSetToDHCPMessage    = DNS server addresses were set to the desired state of DHCP.
+    InterfaceNotAvailableError            = Interface "{0}" is not available. Please select a valid interface and try again.
+    AddressFormatError                    = Address "{0}" is not in the correct format. Please correct the Address parameter in the configuration and try again.
+    AddressIPv4MismatchError              = Address "{0}" is in IPv4 format, which does not match server address family {1}. Please correct either of them in the configuration and try again.
+    AddressIPv6MismatchError              = Address "{0}" is in IPv6 format, which does not match server address family {1}. Please correct either of them in the configuration and try again.
 '@

--- a/Modules/xNetworking/Examples/Resources/xDnsServerAddress/3-xDnsServerAddress_EnableDHCP.ps1
+++ b/Modules/xNetworking/Examples/Resources/xDnsServerAddress/3-xDnsServerAddress_EnableDHCP.ps1
@@ -27,6 +27,6 @@ Configuration Example
             InterfaceAlias = 'Ethernet'
             AddressFamily  = 'IPv4'
         }
-        
+
     }
 }

--- a/Tests/Integration/MSFT_xDNSServerAddress_DHCP.config.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress_DHCP.config.ps1
@@ -2,8 +2,8 @@ configuration MSFT_xDNSServerAddress_Config_DHCP {
     Import-DscResource -ModuleName xNetworking
     node localhost {
         xDNSServerAddress Integration_Test {
-            InterfaceAlias          = $Node.InterfaceAlias
-            AddressFamily           = $Node.AddressFamily
+            InterfaceAlias = $Node.InterfaceAlias
+            AddressFamily  = $Node.AddressFamily
         }
     }
 }

--- a/Tests/Integration/MSFT_xDNSServerAddress_Static.config.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress_Static.config.ps1
@@ -2,10 +2,10 @@ configuration MSFT_xDNSServerAddress_Config_Static {
     Import-DscResource -ModuleName xNetworking
     node localhost {
         xDNSServerAddress Integration_Test {
-            InterfaceAlias          = $Node.InterfaceAlias
-            AddressFamily           = $Node.AddressFamily
-            Address                 = $Node.Address
-            Validate                = $Node.Validate
+            InterfaceAlias = $Node.InterfaceAlias
+            AddressFamily  = $Node.AddressFamily
+            Address        = $Node.Address
+            Validate       = $Node.Validate
         }
     }
 }

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -24,568 +24,554 @@ try
 {
     #region Pester Tests
     InModuleScope $script:DSCResourceName {
-        Describe "MSFT_xDNSServerAddress\Get-TargetResource" {
-            # Test IPv4
+        Describe 'MSFT_xDNSServerAddress\Get-TargetResource' {
+            Context 'Test IPv4' {
+                Context 'Invoking with an IPv4 address and one address is currently set' {
+                    Mock Get-DnsClientServerStaticAddress -MockWith { '192.168.0.1' }
 
-            #region Mocks
-            Mock Get-DnsClientServerStaticAddress -MockWith { '192.168.0.1' }
-            #endregion
+                    It 'Should return true' {
+                        $getTargetResourceSplat = @{
+                            Address        = '192.168.0.1'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with an IPv4 address and one address is currently set' {
-                It 'Should return true' {
-                    $getTargetResourceSplat = @{
-                        Address        = '192.168.0.1'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        $Result = Get-TargetResource @getTargetResourceSplat
+                        $Result.Address | Should Be '192.168.0.1'
                     }
 
-                    $Result = Get-TargetResource @getTargetResourceSplat
-                    $Result.Address | Should Be '192.168.0.1'
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
                 }
             }
 
-            # Test IPv6
+            Context 'Test IPv6' {
+                Context 'Invoking with an IPv6 address and one address is currently set' {
+                    Mock Get-DnsClientServerStaticAddress -MockWith { 'fe80:ab04:30F5:002b::1' }
 
-            #region Mocks
-            Mock Get-DnsClientServerStaticAddress -MockWith { 'fe80:ab04:30F5:002b::1' }
-            #endregion
+                    It 'Should return true' {
+                        $getTargetResourceSplat = @{
+                            Address        = 'fe80:ab04:30F5:002b::1'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with an IPv6 address and one address is currently set' {
-                It 'Should return true' {
-                    $getTargetResourceSplat = @{
-                        Address        = 'fe80:ab04:30F5:002b::1'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
+                        $Result = Get-TargetResource @getTargetResourceSplat
+                        $Result.Address | Should Be 'fe80:ab04:30F5:002b::1'
                     }
 
-                    $Result = Get-TargetResource @getTargetResourceSplat
-                    $Result.Address | Should Be 'fe80:ab04:30F5:002b::1'
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
                 }
             }
 
-            # Test DHCP
+            Context 'Test DHCP' {
+                Context 'Invoking with an IPv4 address and DHCP is currently set' {
+                    Mock Get-DnsClientServerStaticAddress -MockWith { $null }
 
-            #region Mocks
-            Mock Get-DnsClientServerStaticAddress -MockWith { $null }
-            #endregion
+                    It 'Should return true' {
+                        $getTargetResourceSplat = @{
+                            Address        = '192.168.0.1'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with an IPv4 address and DHCP is currently set' {
-                It 'Should return true' {
-                    $getTargetResourceSplat = @{
-                        Address        = '192.168.0.1'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        $Result = Get-TargetResource @getTargetResourceSplat
+                        $Result.Address | Should BeNullOrEmpty
                     }
 
-                    $Result = Get-TargetResource @getTargetResourceSplat
-                    $Result.Address | Should BeNullOrEmpty
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
                 }
             }
         }
 
-        Describe "MSFT_xDNSServerAddress\Set-TargetResource" {
-            # Test IPv4
-
-            #region Mocks
-            Mock Get-DnsClientServerStaticAddress -MockWith { '192.168.0.1' }
-            Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
-            Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
-            Mock Set-DnsClientServerAddress -ParameterFilter { $ResetServerAddresses -eq $true }
-            #endregion
-
-            Context 'Invoking with single IPv4 server address that is the same as current' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = '192.168.0.1'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
-                    }
-
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+        Describe 'MSFT_xDNSServerAddress\Set-TargetResource' {
+            Context 'Test IPv4' {
+                BeforeEach {
+                    Mock Get-DnsClientServerStaticAddress -MockWith { '192.168.0.1' }
+                    Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
+                    Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
+                    Mock Set-DnsClientServerAddress -ParameterFilter { $ResetServerAddresses -eq $true }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                Context 'Invoking with single IPv4 server address that is the same as current' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = '192.168.0.1'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
+                }
+
+                Context 'Invoking with single IPv4 server address that is different to current' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = '192.168.0.99'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
+                }
+
+                Context 'Invoking with single IPv4 server address that is different to current and validate true' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = '192.168.0.99'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Validate       = $true
+                            Verbose        = $true
+                        }
+
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
+                }
+
+                Context 'Invoking with multiple IPv4 server addresses that are different to current' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = @( '192.168.0.99','192.168.0.100' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
+                }
+
+                Context 'Invoking with IPv4 server addresses set to DHCP but one address is currently assigned' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
+                }
+
+                Context 'Invoking with multiple IPv4 server addresses when there are different ones currently assigned' {
+                    Mock -commandName Get-DnsClientServerStaticAddress -MockWith { @( '192.168.0.1','192.168.0.2' ) }
+
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = @( '192.168.0.3','192.168.0.4' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
+                }
+
+                Context 'Invoking with multiple IPv4 server addresses when DHCP is currently set' {
+                    Mock -commandName Get-DnsClientServerStaticAddress -MockWith { $null }
+
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = @( '192.168.0.2','192.168.0.3' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
                 }
             }
 
-            Context 'Invoking with single IPv4 server address that is different to current' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = '192.168.0.99'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+            Context 'Test IPv6' {
+                BeforeEach {
+                    Mock Get-DnsClientServerStaticAddress -MockWith { 'fe80:ab04:30F5:002b::1' }
+                    Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
+                    Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
+                    Mock Set-DnsClientServerAddress -ParameterFilter { $ResetServerAddresses -eq $true }
+                }
+
+                Context 'Invoking with single IPv6 server address that is the same as current' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = 'fe80:ab04:30F5:002b::1'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
+
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
                     }
 
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
+                Context 'Invoking with single IPv6 server address that is different to current' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = 'fe80:ab04:30F5:002b::2'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with single IPv4 server address that is different to current and validate true' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = '192.168.0.99'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Validate       = $true
-                        Verbose        = $true
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
                     }
 
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
+                Context 'Invoking with single IPv6 server address that is different to current and validate true' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = 'fe80:ab04:30F5:002b::2'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Validate       = $true
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with multiple IPv4 server addresses that are different to current' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = @( '192.168.0.99','192.168.0.100' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
                     }
 
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
+                Context 'Invoking with multiple IPv6 server addresses that are different to current' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = @( 'fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with IPv4 server addresses set to DHCP but one address is currently assigned' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
                     }
 
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
+                Context 'Invoking with IPv6 server addresses set to DHCP but one address is currently assigned' {
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            #region Mocks
-            Mock Get-DnsClientServerStaticAddress -MockWith { @( '192.168.0.1','192.168.0.2' ) }
-            #endregion
-
-            Context 'Invoking with multiple IPv4 server addresses when there are different ones currently assigned' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = @( '192.168.0.3','192.168.0.4' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
                     }
 
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $ResetServerAddresses -eq $true }
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
+                Context 'Invoking with multiple IPv6 server addresses when DHCP is currently set' {
+                    Mock Get-DnsClientServerStaticAddress -MockWith { $null }
 
-            #region Mocks
-            Mock Get-DnsClientServerStaticAddress -MockWith { $null }
-            #endregion
+                    It 'Should not throw an exception' {
+                        $setTargetResourceSplat = @{
+                            Address        = @( 'fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::1' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with multiple IPv4 server addresses when DHCP is currently set' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = @( '192.168.0.2','192.168.0.3' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
                     }
 
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
-
-            # Test IPv6
-
-            #region Mocks
-            Mock Get-DnsClientServerStaticAddress -MockWith { 'fe80:ab04:30F5:002b::1' }
-            Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $true }
-            Mock Set-DnsClientServerAddress -ParameterFilter { $Validate -eq $false }
-            Mock Set-DnsClientServerAddress -ParameterFilter { $ResetServerAddresses -eq $true }
-            #endregion
-
-            Context 'Invoking with single IPv6 server address that is the same as current' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = 'fe80:ab04:30F5:002b::1'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
+                        Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
                     }
-
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
-
-            Context 'Invoking with single IPv6 server address that is different to current' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = 'fe80:ab04:30F5:002b::2'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
-                    }
-
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
-
-            Context 'Invoking with single IPv6 server address that is different to current and validate true' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = 'fe80:ab04:30F5:002b::2'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Validate       = $true
-                        Verbose        = $true
-                    }
-
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
-
-            Context 'Invoking with multiple IPv6 server addresses that are different to current' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = @( 'fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
-                    }
-
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
-
-            Context 'Invoking with IPv6 server addresses set to DHCP but one address is currently assigned' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
-                    }
-
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $ResetServerAddresses -eq $true }
-                }
-            }
-
-            #region Mocks
-            Mock Get-DnsClientServerStaticAddress -MockWith { $null }
-            #endregion
-
-            Context 'Invoking with multiple IPv6 server addresses when DHCP is currently set' {
-                It 'Should not throw an exception' {
-                    $setTargetResourceSplat = @{
-                        Address        = @( 'fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::1' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
-                    }
-
-                    { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $Validate -eq $true }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 1 -ParameterFilter { $Validate -eq $false }
-                    Assert-MockCalled -commandName Set-DnsClientServerAddress -Exactly 0 -ParameterFilter { $ResetServerAddresses -eq $true }
                 }
             }
         }
 
-        Describe "MSFT_xDNSServerAddress\Test-TargetResource" {
-            # Test IPv4
-
-            #region Mocks
-            Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-            Mock Get-DnsClientServerStaticAddress -MockWith { '192.168.0.1' }
-            #endregion
-
-            Context 'Invoking with single IPv4 server address that is the same as current' {
-                It 'Should return true' {
-                    $testTargetResourceSplat = @{
-                        Address        = '192.168.0.1'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
-                    }
-
-                    Test-TargetResource @testTargetResourceSplat | Should Be $true
+        Describe 'MSFT_xDNSServerAddress\Test-TargetResource' {
+            Context 'Test IPv4' {
+                BeforeEach {
+                    Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+                    Mock Get-DnsClientServerStaticAddress -MockWith { '192.168.0.1' }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                Context 'Invoking with single IPv4 server address that is the same as current' {
+                    It 'Should return true' {
+                        $testTargetResourceSplat = @{
+                            Address        = '192.168.0.1'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        Test-TargetResource @testTargetResourceSplat | Should Be $true
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
+                }
+
+                Context 'Invoking with single IPv4 server address that is different to current' {
+                    It 'Should return false' {
+                        $testTargetResourceSplat = @{
+                            Address        = '192.168.0.2'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
+                }
+
+                Context 'Invoking with multiple IPv4 server addresses that are different to current' {
+                    It 'Should return false' {
+                        $testTargetResourceSplat = @{
+                            Address        = @( '192.168.0.2','192.168.0.3' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
+                }
+
+                Context 'Invoking with IPv4 server addresses set to DHCP but one address is currently assigned' {
+                    It 'Should return false' {
+                        $testTargetResourceSplat = @{
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
+                }
+
+                Context 'Invoking with multiple IPv4 server addresses but DHCP is currently enabled' {
+                    Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+                    Mock Get-DnsClientServerStaticAddress -MockWith { $null }
+
+                    It 'Should return false' {
+                        $testTargetResourceSplat = @{
+                            Address        = @( '192.168.0.2','192.168.0.3' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv4'
+                            Verbose        = $true
+                        }
+
+                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                    }
+
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
                 }
             }
 
-            Context 'Invoking with single IPv4 server address that is different to current' {
-                It 'Should return false' {
-                    $testTargetResourceSplat = @{
-                        Address        = '192.168.0.2'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+            Context 'Test IPv6' {
+                BeforeEach {
+                    Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+                    Mock Get-DnsClientServerStaticAddress -MockWith { 'fe80:ab04:30F5:002b::1' }
+                }
+
+                Context 'Invoking with single IPv6 server address that is the same as current' {
+                    It 'Should return true' {
+                        $testTargetResourceSplat = @{
+                            Address        = 'fe80:ab04:30F5:002b::1'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
+
+                        Test-TargetResource @testTargetResourceSplat | Should Be $true
                     }
 
-                    Test-TargetResource @testTargetResourceSplat | Should Be $False
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                }
-            }
+                Context 'Invoking with single IPv6 server address that is different to current' {
+                    It 'Should return false' {
+                        $testTargetResourceSplat = @{
+                            Address        = 'fe80:ab04:30F5:002b::2'
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with multiple IPv4 server addresses that are different to current' {
-                It 'Should return false' {
-                    $testTargetResourceSplat = @{
-                        Address        = @( '192.168.0.2','192.168.0.3' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        Test-TargetResource @testTargetResourceSplat | Should Be $False
                     }
 
-                    Test-TargetResource @testTargetResourceSplat | Should Be $False
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                }
-            }
+                Context 'Invoking with multiple IPv6 server addresses that are different to current' {
+                    It 'Should return false' {
+                        $testTargetResourceSplat = @{
+                            Address        = @( 'fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            Context 'Invoking with IPv4 server addresses set to DHCP but one address is currently assigned' {
-                It 'Should return false' {
-                    $testTargetResourceSplat = @{
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        Test-TargetResource @testTargetResourceSplat | Should Be $False
                     }
 
-                    Test-TargetResource @testTargetResourceSplat | Should Be $False
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                }
-            }
+                Context 'Invoking with IPv6 server addresses set to DHCP but one address is currently assigned' {
+                    It 'Should return false' {
+                        $testTargetResourceSplat = @{
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            #region Mocks
-            Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-            Mock Get-DnsClientServerStaticAddress -MockWith { $null }
-            #endregion
-
-            Context 'Invoking with multiple IPv4 server addresses but DHCP is currently enabled' {
-                It 'Should return false' {
-                    $testTargetResourceSplat = @{
-                        Address        = @( '192.168.0.2','192.168.0.3' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv4'
-                        Verbose        = $true
+                        Test-TargetResource @testTargetResourceSplat | Should Be $False
                     }
 
-                    Test-TargetResource @testTargetResourceSplat | Should Be $False
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
+                    }
                 }
 
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                }
-            }
+                Context 'Invoking with multiple IPv6 server addresses but DHCP is currently enabled' {
+                    Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+                    Mock Get-DnsClientServerStaticAddress -MockWith { $null }
 
-            # Test IPv6
+                    It 'Should return false' {
+                        $testTargetResourceSplat = @{
+                            Address        = @( 'fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2' )
+                            InterfaceAlias = 'Ethernet'
+                            AddressFamily  = 'IPv6'
+                            Verbose        = $true
+                        }
 
-            #region Mocks
-            Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-            Mock Get-DnsClientServerStaticAddress -MockWith { 'fe80:ab04:30F5:002b::1' }
-            #endregion
-
-            Context 'Invoking with single IPv6 server address that is the same as current' {
-                It 'Should return true' {
-                    $testTargetResourceSplat = @{
-                        Address        = 'fe80:ab04:30F5:002b::1'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
+                        Test-TargetResource @testTargetResourceSplat | Should Be $False
                     }
 
-                    Test-TargetResource @testTargetResourceSplat | Should Be $true
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                }
-            }
-
-            Context 'Invoking with single IPv6 server address that is different to current' {
-                It 'Should return false' {
-                    $testTargetResourceSplat = @{
-                        Address        = 'fe80:ab04:30F5:002b::2'
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
+                    It 'Should call all the mocks' {
+                        Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
                     }
-
-                    Test-TargetResource @testTargetResourceSplat | Should Be $False
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                }
-            }
-
-            Context 'Invoking with multiple IPv6 server addresses that are different to current' {
-                It 'Should return false' {
-                    $testTargetResourceSplat = @{
-                        Address        = @( 'fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
-                    }
-
-                    Test-TargetResource @testTargetResourceSplat | Should Be $False
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                }
-            }
-
-            Context 'Invoking with IPv6 server addresses set to DHCP but one address is currently assigned' {
-                It 'Should return false' {
-                    $testTargetResourceSplat = @{
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
-                    }
-
-                    Test-TargetResource @testTargetResourceSplat | Should Be $False
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
-                }
-            }
-
-            #region Mocks
-            Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
-            Mock Get-DnsClientServerStaticAddress -MockWith { $null }
-            #endregion
-
-            Context 'Invoking with multiple IPv6 server addresses but DHCP is currently enabled' {
-                It 'Should return false' {
-                    $testTargetResourceSplat = @{
-                        Address        = @( 'fe80:ab04:30F5:002b::1','fe80:ab04:30F5:002b::2' )
-                        InterfaceAlias = 'Ethernet'
-                        AddressFamily  = 'IPv6'
-                        Verbose        = $true
-                    }
-
-                    Test-TargetResource @testTargetResourceSplat | Should Be $False
-                }
-
-                It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Get-DnsClientServerStaticAddress -Exactly 1
                 }
             }
         }
 
-        Describe "MSFT_xDNSServerAddress\Assert-ResourceProperty" {
-            Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+        Describe 'MSFT_xDNSServerAddress\Assert-ResourceProperty' {
+            BeforeEach {
+                Mock Get-NetAdapter -MockWith { [PSObject]@{ Name = 'Ethernet' } }
+            }
 
             Context 'Invoking with bad interface alias' {
                 It 'Should throw the expected exception' {


### PR DESCRIPTION
<!--
Thanks for submitting a Pull Request (PR) to this project. Your contribution to this project is greatly appreciated!

Please prefix the PR title with the resource name, i.e. 'xIPAddress: My short description'
If this is a breaking change, then also prefix the PR title with 'BREAKING CHANGE:', i.e. 'BREAKING CHANGE: xIPAddress: My short description'

To aid community reviewers in reviewing and merging your PR, please take the time to run through the below checklist.
Change to [x] for each task in the task list that applies to this PR.
-->
**Pull Request (PR) description**
Updated xDNSServerAddress to meet HQRM guidelines. Unit tests now can run in any order.

**This Pull Request (PR) fixes the following issues:**
Fixes #236

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/247)
<!-- Reviewable:end -->
