### PR TITLE
[xNetConnectionProfile] Enable setting only some parameters and validate parameters - Fixes #254

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,12 @@
 - Converted files with UTF8 with BOM over to UTF8 - fixes [Issue 250](https://github.com/PowerShell/xNetworking/issues/250).
 - MSFT_xFirewallProfile:
   - Created new resource configuring firewall profiles.
+- MSFT_xNetConnectionProfile:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Added validation for provided parameters.
+  - Prevent testing parameter values of connection that aren't set in resource -
+    fixes [Issue 254](https://github.com/PowerShell/xNetworking/issues/254).
+  - Improved unit test coverage for this resource.
 
 ## 5.0.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/MSFT_xNetConnectionProfile.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/MSFT_xNetConnectionProfile.schema.mof
@@ -2,7 +2,7 @@
 class MSFT_xNetConnectionProfile : OMI_BaseResource
 {
     [Key, Description("Specifies the alias for the Interface that is being changed.")] string InterfaceAlias;
-    [Write, Description("Sets the NetworkCategory for the interface."), ValueMap{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}, Values{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}] string IPv4Connectivity;
+    [Write, Description("Sets the Network Category for the interface."), ValueMap{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}, Values{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}] string IPv4Connectivity;
     [Write, Description("Specifies the IPv4 Connection Value."), ValueMap{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}, Values{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}] string IPv6Connectivity;
     [Write, Description("Specifies the IPv6 Connection Value."), ValueMap{"Public", "Private"}, Values{"Public", "Private"}] string NetworkCategory;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/en-US/MSFT_xNetConnectionProfile.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/en-US/MSFT_xNetConnectionProfile.strings.psd1
@@ -6,4 +6,6 @@ ConvertFrom-StringData @'
     TestIPv6Connectivity        = IPv6Connectivity '{0}' does not match set IPv6Connectivity '{1}'
     TestNetworkCategory         = NetworkCategory '{0}' does not match set NetworkCategory '{1}'
     SetNetConnectionProfile     = Setting NetConnectionProfile on interface '{0}'
+    InterfaceNotAvailableError  = Interface "{0}" is not available. Please select a valid interface and try again.
+    ParameterCombinationError   = At least one of the parameters IPv4Connectivity, IPv6Connectivity or NetworkCategory must be set.
 '@

--- a/Modules/xNetworking/Examples/Resources/xNetConnectionProfile/2-SetNetConnectionProfileNetworkCategory.ps1
+++ b/Modules/xNetworking/Examples/Resources/xNetConnectionProfile/2-SetNetConnectionProfileNetworkCategory.ps1
@@ -1,0 +1,25 @@
+<#
+    .EXAMPLE
+    Sets the Ethernet adapter to Private but does not change
+    IPv4 or IPv6 connectivity
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost'
+    )
+
+    Import-DscResource -Module xNetworking
+
+    Node $NodeName
+    {
+        xNetConnectionProfile Example
+        {
+            InterfaceAlias   = 'Ethernet'
+            NetworkCategory  = 'Private'
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xNetConnectionProfile.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetConnectionProfile.Integration.Tests.ps1
@@ -27,14 +27,14 @@ try
 
     Describe "$($script:DSCResourceName)_Integration" {
         #region DEFAULT TESTS
-        It 'Should compile without throwing' {
+        It 'Should compile and apply the MOF without throwing' {
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
             } | Should not throw
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
+        It 'Should be able to call Get-DscConfiguration without throwing' {
             { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
         }
         #endregion

--- a/Tests/Unit/MSFT_xNetconnectionProfile.tests.ps1
+++ b/Tests/Unit/MSFT_xNetconnectionProfile.tests.ps1
@@ -25,7 +25,7 @@ try
 
         # Create the Mock Objects that will be used for running tests
         $mockNetAdapter = [PSCustomObject] @{
-            Name = 'Ethernet'
+            Name = 'TestAdapter'
         }
 
         $mockNetConnnectionProfileAll = [PSObject] @{
@@ -86,9 +86,11 @@ try
 
         Describe 'MSFT_xNetConnectionProfile\Test-TargetResource' {
             BeforeEach {
-                Mock -CommandName Get-TargetResource {
+                Mock -CommandName Get-TargetResource -MockWith {
                     return $mockNetConnnectionProfileAll
                 }
+
+                Mock -CommandName Assert-ResourceProperty
             }
 
             Context 'NetworkCategory matches' {
@@ -131,6 +133,7 @@ try
         Describe 'MSFT_xNetConnectionProfile\Set-TargetResource' {
             It 'Should call all the mocks' {
                 Mock -CommandName Set-NetConnectionProfile
+                Mock -CommandName Assert-ResourceProperty
 
                 Set-TargetResource @testNetworkCategoryMatches
 


### PR DESCRIPTION
**Pull Request (PR) description**
Change xNetConnectionProfile so that the parameters are validated so that at least one is set. Also only compares values that were passed, enabling the resource to only set specific parameters.

Corrected xNetConnectionProfile to meet HQRM and converted exceptions to use ResourceHelper functions.

**This Pull Request (PR) fixes the following issues:**
Fixes #254 
Fixes #255

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/256)
<!-- Reviewable:end -->
