### PR TITLE
xNetworkTeamInterface: Issue 248 - Fixed Test-TargetResource failing on VLANID 0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,8 @@
 
 ## Unreleased
 
+## 5.1.0.0
+
 - MSFT_xDhcpClient:
   - Corrected style and formatting to meet HQRM guidelines.
   - Converted exceptions to use ResourceHelper functions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,9 @@
 # Versions
 
 ## Unreleased
+
 - MSFT_xNetworkTeamInterface:
-  - Updated Test-TargetResource to substitute VLANID value 0 to $null for Default VLANs
+  - Updated Test-TargetResource to substitute VLANID value 0 to $null
 
 ## 5.1.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,8 @@
 # Versions
 
 ## Unreleased
+- MSFT_xNetworkTeamInterface:
+  - Updated Test-TargetResource to substitute VLANID value 0 to $null for Default VLANs
 
 ## 5.1.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
@@ -205,10 +205,13 @@ function Test-TargetResource
     Write-Verbose -Message ($LocalizedData.GetTeamNicInfo -f $Name)
     $teamNic = Get-NetLbfoTeamNic -Name $Name -Team $TeamName -ErrorAction SilentlyContinue
 
-    switch ($VlanID)
+    if ($VlanID -eq 0)
     {
-        '0' {$VLANValue = $null}
-        default {$VLANValue = $VlanID}
+        $VlanValue = $null
+    }
+    else
+    {
+        $VlanValue = $VlanID
     }
 
     if ($Ensure -eq "Present")
@@ -216,7 +219,7 @@ function Test-TargetResource
         if ($teamNic)
         {
             Write-Verbose -Message ($LocalizedData.FoundTeamNic -f $Name)
-            if ($teamNic.VlanID -eq $VLANValue)
+            if ($teamNic.VlanID -eq $VlanValue)
             {
                 Write-Verbose -Message ($LocalizedData.TeamNicExistsNoAction -f $Name)
                 return $true

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
@@ -205,6 +205,11 @@ function Test-TargetResource
     Write-Verbose -Message ($LocalizedData.GetTeamNicInfo -f $Name)
     $teamNic = Get-NetLbfoTeamNic -Name $Name -Team $TeamName -ErrorAction SilentlyContinue
 
+    if ($VlanID -eq '0')
+    {
+        $VlanID = $null
+    }
+
     if ($Ensure -eq "Present")
     {
         if ($teamNic)

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
@@ -205,9 +205,10 @@ function Test-TargetResource
     Write-Verbose -Message ($LocalizedData.GetTeamNicInfo -f $Name)
     $teamNic = Get-NetLbfoTeamNic -Name $Name -Team $TeamName -ErrorAction SilentlyContinue
 
-    if ($VlanID -eq '0')
+    switch ($VlanID)
     {
-        $VlanID = $null
+        '0' {$VLANValue = $null}
+        default {$VLANValue = $VlanID}
     }
 
     if ($Ensure -eq "Present")
@@ -215,7 +216,7 @@ function Test-TargetResource
         if ($teamNic)
         {
             Write-Verbose -Message ($LocalizedData.FoundTeamNic -f $Name)
-            if ($teamNic.VlanID -eq $VlanID)
+            if ($teamNic.VlanID -eq $VLANValue)
             {
                 Write-Verbose -Message ($LocalizedData.TeamNicExistsNoAction -f $Name)
                 return $true

--- a/Modules/xNetworking/xNetworking.psd1
+++ b/Modules/xNetworking/xNetworking.psd1
@@ -1,6 +1,6 @@
 @{
 # Version number of this module.
-ModuleVersion = '5.0.0.0'
+ModuleVersion = '5.1.0.0'
 
 # ID used to uniquely identify this module
 GUID = 'e6647cc3-ce9c-4c86-9eb8-2ee8919bf358'
@@ -50,31 +50,49 @@ PrivateData = @{
         # IconUri = ''
 
         # ReleaseNotes of this module
-        ReleaseNotes = '- Find-NetworkAdapter:
-  - Fixed to return null if exception thrown.
-  - Allowed passing no selection parameters.
-- MSFT_xNetAdapterName:
-  - Fixed bug in Get-TargetResource when Name is the only adapter selector parameter.
-  - Improved verbose logging.
-  - More improvements to verbose logging.
-- Added Get-DnsClientServerStaticAddress to NetworkingDsc.Common to return statically
-  assigned DNS server addresses to support fix for [issue 113](https://github.com/PowerShell/xNetworking/issues/113).
-- MSFT_xDNSserverAddress:
-  - Added support for setting DNS Client to DHCP for [issue 113](https://github.com/PowerShell/xNetworking/issues/113).
-  - Added new examples to show how to enable DHCP on DNS Client.
-  - Improved integration test coverage to enable testing of multiple addresses and
-    DHCP.
-  - Converted exception creation to use common exception functions.
-- MSFT_xDhcpClient:
-  - Updated example to also cover setting DNS Client to DHCP.
-- Added the VS Code PowerShell extension formatting settings that cause PowerShell
-  files to be formatted as per the DSC Resource kit style guidelines.
-- MSFT_xDefaultGatewayAddress:
+        ReleaseNotes = '- MSFT_xDhcpClient:
   - Corrected style and formatting to meet HQRM guidelines.
   - Converted exceptions to use ResourceHelper functions.
-- Updated badges in README.MD to match the layout from PSDscResources.
+- README.MD:
+  - Cleaned up badges by putting them into a table.
+- MSFT_xDnsConnectionSuffix:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Converted exceptions to use ResourceHelper functions.
+- README.MD:
+  - Converted badges to use branch header as used in xSQLServer.
+- Added standard .markdownlint.json to configure rules to run on
+  Markdown files.
+- MSFT_xDnsClientGlobalSetting:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Converted exceptions to use ResourceHelper functions.
+- Updated year to 2017 in LICENSE and module manifest.
+- MSFT_xDnsServerAddress:
+  - Fix error when setting address on adapter where NameServer
+    Property does not exist in registry for interface - see
+    [issue 237](https://github.com/PowerShell/xNetworking/issues/237).
+  - Corrected style and formatting to meet HQRM guidelines.
 - MSFT_xIPAddress:
-  - BREAKING CHANGE: Adding support for multiple IP addresses being assigned.
+  - Improved examples to clarify how to set IP Address prefix -
+    see [issue 239](https://github.com/PowerShell/xNetworking/issues/239).
+- MSFT_xFirewall:
+  - Fixed bug with DisplayName not being set correctly in some
+    situations - see [issue 234](https://github.com/PowerShell/xNetworking/issues/234).
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Converted exceptions to use ResourceHelper functions.
+- Added .github support files:
+  - CONTRIBUTING.md
+  - ISSUE_TEMPLATE.md
+  - PULL_REQUEST_TEMPLATE.md
+- Opted into Common Tests "Validate Module Files" and "Validate Script Files".
+- Converted files with UTF8 with BOM over to UTF8 - fixes [Issue 250](https://github.com/PowerShell/xNetworking/issues/250).
+- MSFT_xFirewallProfile:
+  - Created new resource configuring firewall profiles.
+- MSFT_xNetConnectionProfile:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Added validation for provided parameters.
+  - Prevent testing parameter values of connection that aren"t set in resource -
+    fixes [Issue 254](https://github.com/PowerShell/xNetworking/issues/254).
+  - Improved unit test coverage for this resource.
 
 '
 
@@ -82,6 +100,7 @@ PrivateData = @{
 
 } # End of PrivateData hashtable
 }
+
 
 
 

--- a/Tests/Unit/MSFT_xNetworkTeamInterface.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetworkTeamInterface.Tests.ps1
@@ -39,6 +39,12 @@ try
             VlanID              = 100
         }
 
+        $MockTeamNicDefaultVLAN = [PSObject] @{
+            Name                = $TestTeamNic.Name
+            Team                = $TestTeamNic.TeamName
+            VlanID              = $null
+        }
+
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
 
             Context 'Team Interface does not exist' {
@@ -197,6 +203,19 @@ try
                     $updateTeamNic = $newTeamNic.Clone()
                     $updateTeamNic.Ensure = 'Absent'
                     Test-TargetResource @updateTeamNic | Should Be $true
+                }
+                It 'should call expected Mocks' {
+                    Assert-MockCalled -commandName Get-NetLbfoTeamNic -Exactly 1
+                }
+            }
+
+            Context 'Team Interface exists on the default 0 VLAN' {
+                Mock Get-NetLbfoTeamNic -MockWith { $MockTeamNicDefaultVLAN }
+
+                It 'should return true' {
+                    $TeamNicOnDefaultVLAN = $newTeamNic.Clone()
+                    $TeamNicOnDefaultVLAN.VlanID = 0
+                    Test-TargetResource @TeamNicOnDefaultVLAN | Should Be $true
                 }
                 It 'should call expected Mocks' {
                     Assert-MockCalled -commandName Get-NetLbfoTeamNic -Exactly 1


### PR DESCRIPTION
This is my first DSC Resource contribution, hopefully I covered everything.

The Test method currently fails when using a default VLANID value of 0 because the cmdlet returns $null for that property. My update to Test-TargetResource ensures that if 0 is used for the VLAN ID, it is substituted for a $null to compare to the output of Get-NetLBFOTeamNic.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/262)
<!-- Reviewable:end -->
