### PR TITLE
Corrected style and formatting of xNetAdapterName to meet HQRM guidelines - Fixes #296

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - MSFT_xNetAdapterLso:
   - Corrected style and formatting to meet HQRM guidelines.
+  - Updated tests to meet Pester v4 guidelines.
+- MSFT_xNetAdapterName:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Updated tests to meet Pester v4 guidelines.
 
 ## 5.4.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetAdapterName/MSFT_xNetAdapterName.psm1
@@ -2,13 +2,13 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 # Import the Networking Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
-                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+            -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
-                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+            -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -76,7 +76,7 @@ function Get-TargetResource
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('Up','Disconnected','Disabled')]
+        [ValidateSet('Up', 'Disconnected', 'Disabled')]
         [System.String]
         $Status = 'Up',
 
@@ -110,7 +110,7 @@ function Get-TargetResource
     )
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-        $($LocalizedData.GettingNetAdapterNameMessage -f $NewName)
+            $($LocalizedData.GettingNetAdapterNameMessage -f $NewName)
         ) -join '')
 
     $adapter = Find-NetworkAdapter `
@@ -120,7 +120,7 @@ function Get-TargetResource
     if (-not $adapter)
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.FindNetAdapterMessage)
+                $($LocalizedData.FindNetAdapterMessage)
             ) -join '')
 
         $null = $PSBoundParameters.Remove('NewName')
@@ -131,7 +131,7 @@ function Get-TargetResource
     }
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-        $($LocalizedData.NetAdapterNameFoundMessage -f $adapter.Name)
+            $($LocalizedData.NetAdapterNameFoundMessage -f $adapter.Name)
         ) -join '')
 
     $returnValue = @{
@@ -209,7 +209,7 @@ function Set-TargetResource
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('Up','Disconnected','Disabled')]
+        [ValidateSet('Up', 'Disconnected', 'Disabled')]
         [System.String]
         $Status = 'Up',
 
@@ -243,7 +243,7 @@ function Set-TargetResource
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-        $($LocalizedData.SettingNetAdapterNameMessage -f $NewName)
+            $($LocalizedData.SettingNetAdapterNameMessage -f $NewName)
         ) -join '')
 
     $null = $PSBoundParameters.Remove('NewName')
@@ -253,13 +253,13 @@ function Set-TargetResource
         -ErrorAction Stop
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-        $($LocalizedData.RenamingNetAdapterNameMessage -f $adapter.Name,$NewName)
+            $($LocalizedData.RenamingNetAdapterNameMessage -f $adapter.Name, $NewName)
         ) -join '')
 
     $adapter | Rename-NetAdapter -NewName $NewName
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-        $($LocalizedData.NetAdapterNameRenamedMessage -f $NewName)
+            $($LocalizedData.NetAdapterNameRenamedMessage -f $NewName)
         ) -join '')
 } # Set-TargetResource
 
@@ -324,7 +324,7 @@ function Test-TargetResource
 
         [Parameter()]
         [ValidateNotNullOrEmpty()]
-        [ValidateSet('Up','Disconnected','Disabled')]
+        [ValidateSet('Up', 'Disconnected', 'Disabled')]
         [System.String]
         $Status = 'Up',
 
@@ -358,7 +358,7 @@ function Test-TargetResource
     )
 
     Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-        $($LocalizedData.TestingNetAdapterNameMessage -f $NewName)
+            $($LocalizedData.TestingNetAdapterNameMessage -f $NewName)
         ) -join '')
 
     $null = $PSBoundParameters.Remove('NewName')
@@ -373,15 +373,16 @@ function Test-TargetResource
     {
         # An adapter was found matching the new name
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-            $($LocalizedData.NetAdapterWithNewNameExistsMessage -f $adapterWithNewName.Name)
+                $($LocalizedData.NetAdapterWithNewNameExistsMessage -f $adapterWithNewName.Name)
             ) -join '')
+
         return $true
     }
     else
     {
         # Find an adapter matching the parameters - throw if none can be found
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
-            $($LocalizedData.FindNetAdapterMessage)
+                $($LocalizedData.FindNetAdapterMessage)
             ) -join '')
 
         $adapter = Find-NetworkAdapter `
@@ -390,8 +391,9 @@ function Test-TargetResource
 
         # An adapter was found that needs to be changed to the new name
         Write-Verbose -Message ( @("$($MyInvocation.MyCommand): "
-            $($LocalizedData.NetAdapterNameNotMatchMessage -f $adapter.Name,$NewName)
+                $($LocalizedData.NetAdapterNameNotMatchMessage -f $adapter.Name, $NewName)
             ) -join '')
+
         return $false
     } # if
 } # Test-TargetResource

--- a/Modules/xNetworking/Examples/Resources/xNetAdapterName/1-RenameNetAdapterMacAddress.ps1
+++ b/Modules/xNetworking/Examples/Resources/xNetAdapterName/1-RenameNetAdapterMacAddress.ps1
@@ -18,8 +18,8 @@ Configuration Example
     {
         xNetAdapterName RenameNetAdapterCluster
         {
-            NewName        = 'Cluster'
-            MacAddress     = '9C-D2-1E-61-B5-DA'
+            NewName    = 'Cluster'
+            MacAddress = '9C-D2-1E-61-B5-DA'
         }
 
         xDhcpClient EnableDhcpClientCluster
@@ -31,8 +31,8 @@ Configuration Example
 
         xNetAdapterName RenameNetAdapterManagement
         {
-            NewName        = 'Management'
-            MacAddress     = '9C-D2-1E-61-B5-DB'
+            NewName    = 'Management'
+            MacAddress = '9C-D2-1E-61-B5-DB'
         }
 
         xDhcpClient EnableDhcpClientManagement
@@ -44,8 +44,8 @@ Configuration Example
 
         xNetAdapterName RenameNetAdapterSMB
         {
-            NewName        = 'SMB'
-            MacAddress     = '9C-D2-1E-61-B5-DC'
+            NewName    = 'SMB'
+            MacAddress = '9C-D2-1E-61-B5-DC'
         }
 
         xDhcpClient EnableDhcpClientSMB

--- a/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterName.Integration.Tests.ps1
@@ -1,14 +1,14 @@
-$script:DSCModuleName      = 'xNetworking'
-$script:DSCResourceName    = 'MSFT_xNetAdapterName'
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xNetAdapterName'
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -60,24 +60,40 @@ try
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
 
-                Start-DscConfiguration -Path $TestDrive `
-                    -ComputerName localhost -Wait -Verbose -Force
-            } | Should Not Throw
+                Start-DscConfiguration `
+                    -Path $TestDrive `
+                    -ComputerName localhost `
+                    -Wait `
+                    -Verbose `
+                    -Force `
+                    -ErrorAction Stop
+            } | Should -Not -Throw
         }
 
-        it 'should reapply the MOF without throwing' {
-            { Start-DscConfiguration -Path $TestDrive `
-                -ComputerName localhost -Wait -Verbose -Force } | Should Not Throw
+        It 'Should reapply the MOF without throwing' {
+            {
+                Start-DscConfiguration `
+                    -Path $TestDrive `
+                    -ComputerName localhost `
+                    -Wait `
+                    -Verbose `
+                    -Force `
+                    -ErrorAction Stop
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            {
+                Get-DscConfiguration -Verbose -ErrorAction Stop
+            } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config_All"}
-            $current.Name                     | Should Be $newAdapterName
+            $current = Get-DscConfiguration | Where-Object -FilterScript {
+                $_.ConfigurationName -eq "$($script:DSCResourceName)_Config_All"
+            }
+            $current.Name | Should -Be $newAdapterName
         }
 
         AfterAll {
@@ -107,9 +123,9 @@ try
                 $configData = @{
                     AllNodes = @(
                         @{
-                            NodeName             = 'localhost'
-                            NewName              = $newAdapterName
-                            Name                 = $adapter.Name
+                            NodeName = 'localhost'
+                            NewName  = $newAdapterName
+                            Name     = $adapter.Name
                         }
                     )
                 }
@@ -118,24 +134,40 @@ try
                     -OutputPath $TestDrive `
                     -ConfigurationData $configData
 
-                Start-DscConfiguration -Path $TestDrive `
-                    -ComputerName localhost -Wait -Verbose -Force
-            } | Should Not Throw
+                Start-DscConfiguration `
+                    -Path $TestDrive `
+                    -ComputerName localhost `
+                    -Wait `
+                    -Verbose `
+                    -Force `
+                    -ErrorAction Stop
+            } | Should -Not -Throw
         }
 
-        it 'should reapply the MOF without throwing' {
-            { Start-DscConfiguration -Path $TestDrive `
-                -ComputerName localhost -Wait -Verbose -Force } | Should Not Throw
+        It 'Should reapply the MOF without throwing' {
+            {
+                Start-DscConfiguration `
+                    -Path $TestDrive `
+                    -ComputerName localhost `
+                    -Wait `
+                    -Verbose `
+                    -Force `
+                    -ErrorAction Stop
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            {
+                Get-DscConfiguration -Verbose -ErrorAction Stop
+            } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
-            $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config_NameOnly"}
-            $current.Name                     | Should Be $newAdapterName
+            $current = Get-DscConfiguration | Where-Object -FilterScript {
+                $_.ConfigurationName -eq "$($script:DSCResourceName)_Config_NameOnly"
+            }
+            $current.Name | Should -Be $newAdapterName
         }
 
         AfterAll {

--- a/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -153,7 +153,7 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @testTargetResourceParameters | Should Be $True
+                    Test-TargetResource @testTargetResourceParameters | Should Be $true
                 }
             }
 
@@ -207,7 +207,7 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @testTargetResourceParameters | Should Be $True
+                    Test-TargetResource @testTargetResourceParameters | Should Be $true
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
+++ b/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
@@ -182,7 +182,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceDisabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testNetIPInterfaceDisabled | Should Be $True
+                    Test-TargetResource @testNetIPInterfaceDisabled | Should Be $true
                 }
 
                 It 'Should call expected mocks' {
@@ -195,7 +195,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceEnabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testNetIPInterfaceEnabled | Should Be $True
+                    Test-TargetResource @testNetIPInterfaceEnabled | Should Be $true
                 }
 
                 It 'Should call expected mocks' {

--- a/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
@@ -27,13 +27,13 @@ try
         $dnsClientGlobalSettings = [PSObject]@{
             SuffixSearchList = 'contoso.com'
             DevolutionLevel  = 1
-            UseDevolution    = $True
+            UseDevolution    = $true
         }
 
         $dnsClientGlobalMultiSuffixSettings = [PSObject]@{
             SuffixSearchList = @('fabrikam.com', 'fourthcoffee.com')
             DevolutionLevel  = 1
-            UseDevolution    = $True
+            UseDevolution    = $true
         }
 
         $dnsClientGlobalSettingsSplat = [PSObject]@{
@@ -167,7 +167,7 @@ try
                 Context 'DNS Client Global Settings all parameters are the same' {
                     It 'Should return true' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
-                        Test-TargetResource @testTargetResourceParameters | Should Be $True
+                        Test-TargetResource @testTargetResourceParameters | Should Be $true
                     }
 
                     It 'Should call expected Mocks' {
@@ -233,7 +233,7 @@ try
                     It 'Should return true' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $testTargetResourceParameters.SuffixSearchList = @('fabrikam.com', 'fourthcoffee.com')
-                        Test-TargetResource @testTargetResourceParameters | Should Be $True
+                        Test-TargetResource @testTargetResourceParameters | Should Be $true
                     }
 
                     It 'Should call expected Mocks' {

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -748,7 +748,7 @@ try
 
                 It "Should return True on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $True
+                    $result | Should be $true
                 }
             }
 

--- a/Tests/Unit/MSFT_xFirewallProfile.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewallProfile.Tests.ps1
@@ -237,7 +237,7 @@ try
             Context 'Firewall Profile all parameters are the same' {
                 It 'Should return true' {
                     $testTargetResourceParameters = $firewallProfileSplat.Clone()
-                    Test-TargetResource @testTargetResourceParameters | Should Be $True
+                    Test-TargetResource @testTargetResourceParameters | Should Be $true
                 }
 
                 It 'Should call expected Mocks' {

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -47,7 +47,7 @@ try
         $mockBindingEnabled = @{
             InterfaceAlias = 'Ethernet'
             ComponentId    = 'ms_tcpip63'
-            Enabled        = $True
+            Enabled        = $true
         }
 
         $mockBindingDisabled = @{
@@ -65,7 +65,7 @@ try
             @{
                 InterfaceAlias = 'Ethernet2'
                 ComponentId    = 'ms_tcpip63'
-                Enabled        = $True
+                Enabled        = $true
             }
         )
 
@@ -183,7 +183,7 @@ try
                 Mock -CommandName Get-Binding -MockWith { $mockBindingEnabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testBindingEnabled | Should Be $True
+                    Test-TargetResource @testBindingEnabled | Should Be $true
                 }
 
                 It 'Should call all the mocks' {
@@ -195,7 +195,7 @@ try
                 Mock -CommandName Get-Binding -MockWith { $mockBindingDisabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testBindingDisabled | Should Be $True
+                    Test-TargetResource @testBindingDisabled | Should Be $true
                 }
 
                 It 'Should call all the mocks' {

--- a/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
@@ -191,11 +191,11 @@ try
                 Mock `
                     -CommandName Find-NetworkAdapter `
                     -MockWith { $script:mockAdapter } `
-                    -ParameterFilter {$Name -and $Name -eq $script:AdapterName}
+                    -ParameterFilter { $Name -and $Name -eq $script:AdapterName }
 
                 Mock `
                     -CommandName Find-NetworkAdapter `
-                    -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
+                    -ParameterFilter { $Name -and $Name -eq $script:newAdapterName }
 
                 It 'Should not throw exception' {
                     { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should -Not -Throw
@@ -208,11 +208,11 @@ try
                 It 'Should call all the mocks' {
                     Assert-MockCalled `
                         -CommandName Find-NetworkAdapter -Exactly -Times 1 `
-                        -ParameterFilter {$Name -and $Name -eq $script:AdapterName}
+                        -ParameterFilter { $Name -and $Name -eq $script:AdapterName }
 
                     Assert-MockCalled `
                         -CommandName Find-NetworkAdapter -Exactly -Times 1 `
-                        -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
+                        -ParameterFilter { $Name -and $Name -eq $script:newAdapterName }
                 }
             }
 
@@ -220,20 +220,20 @@ try
                 Mock `
                     -CommandName Find-NetworkAdapter `
                     -MockWith { $script:mockRenamedAdapter } `
-                    -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
+                    -ParameterFilter { $Name -and $Name -eq $script:newAdapterName }
 
                 It 'Should not throw exception' {
                     { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:result | Should -Be $True
+                    $script:result | Should -Be $true
                 }
 
                 It 'Should call all the mocks' {
                     Assert-MockCalled `
                         -CommandName Find-NetworkAdapter -Exactly -Times 1 `
-                        -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
+                        -ParameterFilter { $Name -and $Name -eq $script:newAdapterName }
                 }
             }
         }

--- a/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterName.Tests.ps1
@@ -1,13 +1,13 @@
-﻿$script:DSCModuleName      = 'xNetworking'
-$script:DSCResourceName    = 'MSFT_xNetAdapterName'
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xNetAdapterName'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -21,7 +21,6 @@ $TestEnvironment = Initialize-TestEnvironment `
 try
 {
     InModuleScope $script:DSCResourceName {
-
         # Generate the adapter data to be used for Mocking
         $script:adapterName = 'Adapter'
         $script:newAdapterName = 'NewAdapter'
@@ -32,6 +31,7 @@ try
         $script:adapterInterfaceIndex = 2
         $script:adapterInterfaceGuid = '75670D9B-5879-4DBA-BC99-86CDD33EB66A'
         $script:adapterDriverDescription = 'Hyper-V Virtual Ethernet Adapter'
+
         $script:adapterParameters = [PSObject]@{
             Name                 = $script:adapterName
             NewName              = $script:newAdapterName
@@ -43,6 +43,7 @@ try
             InterfaceGuid        = $script:adapterInterfaceGuid
             DriverDescription    = $script:adapterDriverDescription
         }
+
         $script:mockAdapter = [PSObject]@{
             Name                 = $script:adapterName
             PhysicalMediaType    = $script:adapterPhysicalMediaType
@@ -53,6 +54,7 @@ try
             InterfaceGuid        = $script:adapterInterfaceGuid
             DriverDescription    = $script:adapterDriverDescription
         }
+
         $script:mockRenamedAdapter = [PSObject]@{
             Name                 = $script:newAdapterName
             PhysicalMediaType    = $script:adapterPhysicalMediaType
@@ -64,105 +66,120 @@ try
             DriverDescription    = $script:adapterDriverDescription
         }
 
-        function Rename-NetAdapter {
+        function Rename-NetAdapter
+        {
             [CmdletBinding()]
             param (
-                [Parameter(ValueFromPipeline)]
+                [Parameter(ValueFromPipeline = $true)]
                 $InputObject,
 
+                [Parameter()]
                 [System.String]
                 $NewName
             )
         }
 
-        Describe "MSFT_xNetAdapterName\Get-TargetResource" {
+        Describe 'MSFT_xNetAdapterName\Get-TargetResource' {
             Context 'Renamed adapter can be found' {
-                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter } `
+                Mock `
+                    -CommandName Find-NetworkAdapter `
+                    -MockWith { $script:mockRenamedAdapter } `
                     -ParameterFilter { $Name -eq $script:newAdapterName }
 
                 It 'Should not throw' {
-                    { $script:result = Get-TargetResource @adapterParameters -Verbose } | Should Not Throw
+                    { $script:result = Get-TargetResource @adapterParameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return existing adapter' {
-                    $script:result.Name                 | Should Be $script:mockRenamedAdapter.Name
-                    $script:result.PhysicalMediaType    | Should Be $script:mockRenamedAdapter.PhysicalMediaType
-                    $script:result.Status               | Should Be $script:mockRenamedAdapter.Status
-                    $script:result.MacAddress           | Should Be $script:mockRenamedAdapter.MacAddress
-                    $script:result.InterfaceDescription | Should Be $script:mockRenamedAdapter.InterfaceDescription
-                    $script:result.InterfaceIndex       | Should Be $script:mockRenamedAdapter.InterfaceIndex
-                    $script:result.InterfaceGuid        | Should Be $script:mockRenamedAdapter.InterfaceGuid
-                    $script:result.DriverDescription    | Should Be $script:mockRenamedAdapter.DriverDescription
+                    $script:result.Name                 | Should -Be $script:mockRenamedAdapter.Name
+                    $script:result.PhysicalMediaType    | Should -Be $script:mockRenamedAdapter.PhysicalMediaType
+                    $script:result.Status               | Should -Be $script:mockRenamedAdapter.Status
+                    $script:result.MacAddress           | Should -Be $script:mockRenamedAdapter.MacAddress
+                    $script:result.InterfaceDescription | Should -Be $script:mockRenamedAdapter.InterfaceDescription
+                    $script:result.InterfaceIndex       | Should -Be $script:mockRenamedAdapter.InterfaceIndex
+                    $script:result.InterfaceGuid        | Should -Be $script:mockRenamedAdapter.InterfaceGuid
+                    $script:result.DriverDescription    | Should -Be $script:mockRenamedAdapter.DriverDescription
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
+                    Assert-MockCalled `
+                        -CommandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter { $Name -eq $script:newAdapterName }
                 }
             }
 
             Context 'Renamed adapter not found but matching adapter can be found' {
-                Mock -CommandName Find-NetworkAdapter `
+                Mock `
+                    -CommandName Find-NetworkAdapter `
                     -ParameterFilter { $Name -eq $script:newAdapterName }
-                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter } `
+
+                Mock `
+                    -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter } `
                     -ParameterFilter { $Name -eq $script:adapterName }
 
-                It 'Should not throw' {
-                    { $script:result = Get-TargetResource -Name $script:adapterName -NewName $script:newAdapterName -Verbose } | Should Not Throw
+                It 'Should not throw exception' {
+                    { $script:result = Get-TargetResource -Name $script:adapterName -NewName $script:newAdapterName -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return existing adapter' {
-                    $script:result.Name                 | Should Be $script:mockAdapter.Name
-                    $script:result.PhysicalMediaType    | Should Be $script:mockAdapter.PhysicalMediaType
-                    $script:result.Status               | Should Be $script:mockAdapter.Status
-                    $script:result.MacAddress           | Should Be $script:mockAdapter.MacAddress
-                    $script:result.InterfaceDescription | Should Be $script:mockAdapter.InterfaceDescription
-                    $script:result.InterfaceIndex       | Should Be $script:mockAdapter.InterfaceIndex
-                    $script:result.InterfaceGuid        | Should Be $script:mockAdapter.InterfaceGuid
-                    $script:result.DriverDescription    | Should Be $script:mockAdapter.DriverDescription
+                    $script:result.Name                 | Should -Be $script:mockAdapter.Name
+                    $script:result.PhysicalMediaType    | Should -Be $script:mockAdapter.PhysicalMediaType
+                    $script:result.Status               | Should -Be $script:mockAdapter.Status
+                    $script:result.MacAddress           | Should -Be $script:mockAdapter.MacAddress
+                    $script:result.InterfaceDescription | Should -Be $script:mockAdapter.InterfaceDescription
+                    $script:result.InterfaceIndex       | Should -Be $script:mockAdapter.InterfaceIndex
+                    $script:result.InterfaceGuid        | Should -Be $script:mockAdapter.InterfaceGuid
+                    $script:result.DriverDescription    | Should -Be $script:mockAdapter.DriverDescription
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
+                    Assert-MockCalled `
+                        -CommandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter { $Name -eq $script:adapterName }
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
+
+                    Assert-MockCalled `
+                        -CommandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter { $Name -eq $script:newAdapterName }
                 }
             }
         }
 
-        Describe "MSFT_xNetAdapterName\Set-TargetResource" {
+        Describe 'MSFT_xNetAdapterName\Set-TargetResource' {
             Context 'Matching adapter can be found' {
-                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter }
+                Mock `
+                    -CommandName Find-NetworkAdapter `
+                    -MockWith { $script:mockAdapter }
+
                 Mock `
                     -CommandName Rename-NetAdapter `
                     -ParameterFilter { $NewName -eq $script:newAdapterName } `
                     -MockWith { $script:mockRenamedAdapter }
 
-                It 'Should not throw' {
-                    { Set-TargetResource @adapterParameters -Verbose } | Should Not Throw
+                It 'Should not throw exception' {
+                    { Set-TargetResource @adapterParameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1
                     Assert-MockCalled `
-                        -commandName Rename-NetAdapter `
-                        -ParameterFilter { $NewName -eq $script:newAdapterName } `
-                        -Exactly -Times 1
+                        -CommandName Find-NetworkAdapter -Exactly -Times 1
+
+                    Assert-MockCalled `
+                        -CommandName Rename-NetAdapter -Exactly -Times 1 `
+                        -ParameterFilter { $NewName -eq $script:newAdapterName }
                 }
             }
         }
 
-        Describe "MSFT_xNetAdapterName\Test-TargetResource" {
+        Describe 'MSFT_xNetAdapterName\Test-TargetResource' {
             Context 'Matching adapter can be found and has correct Name' {
                 Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter }
 
-                It 'Should not throw' {
-                    { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
+                It 'Should not throw exception' {
+                    { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:result                      | Should Be $true
+                    $script:result | Should -Be $true
                 }
 
                 It 'Should call all the mocks' {
@@ -171,41 +188,51 @@ try
             }
 
             Context 'Renamed adapter does not exist, but matching adapter can be found and has wrong Name' {
-                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockAdapter } `
+                Mock `
+                    -CommandName Find-NetworkAdapter `
+                    -MockWith { $script:mockAdapter } `
                     -ParameterFilter {$Name -and $Name -eq $script:AdapterName}
-                Mock -CommandName Find-NetworkAdapter -MockWith { } `
+
+                Mock `
+                    -CommandName Find-NetworkAdapter `
                     -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
 
-                It 'Should not throw' {
-                    { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
+                It 'Should not throw exception' {
+                    { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:result                      | Should Be $false
+                    $script:result  | Should -Be $false
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
+                    Assert-MockCalled `
+                        -CommandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter {$Name -and $Name -eq $script:AdapterName}
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
+
+                    Assert-MockCalled `
+                        -CommandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
                 }
             }
 
             Context 'Adapter name changed by Set-TargetResource' {
-                Mock -CommandName Find-NetworkAdapter -MockWith { $script:mockRenamedAdapter } `
+                Mock `
+                    -CommandName Find-NetworkAdapter `
+                    -MockWith { $script:mockRenamedAdapter } `
                     -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
 
-                It 'Should not throw' {
-                    { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should Not Throw
+                It 'Should not throw exception' {
+                    { $script:result = Test-TargetResource @adapterParameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:result                      | Should Be $True
+                    $script:result | Should -Be $True
                 }
 
                 It 'Should call all the mocks' {
-                    Assert-MockCalled -commandName Find-NetworkAdapter -Exactly -Times 1 `
+                    Assert-MockCalled `
+                        -CommandName Find-NetworkAdapter -Exactly -Times 1 `
                         -ParameterFilter {$Name -and $Name -eq $script:newAdapterName}
                 }
             }


### PR DESCRIPTION
**Pull Request (PR) description**
Corrected style and formatting to meet HQRM guidelines for xNetAdapterName. Updated tests for xNetAdapterName to Pester v4 standard.

**This Pull Request (PR) fixes the following issues:**
#296

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/297)
<!-- Reviewable:end -->
