### PR TITLE
MSFT_xNetBios: Corrected style and formatting to meet HQRM guidelines - Fixes #300

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,13 @@
   - Converted exceptions to use ResourceHelper functions.
   - Improved integration tests to preserve system status and run in more
     scenarios.
+- MSFT_xNetBIOS:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Updated tests to meet Pester v4 guidelines.
+  - Converted exceptions to use ResourceHelper functions.
+  - Improved integration tests to preserve system status, run in more
+    scenarios and more effectively test the resource.
+  - Changed to report back error if unable to set NetBIOS setting.
 
 ## 5.4.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.schema.mof
@@ -3,5 +3,5 @@
 class MSFT_xNetBIOS : OMI_BaseResource
 {
     [Key, Description("Specifies the alias of a network interface.")] String InterfaceAlias;
-    [Required, Description("Default - Use NetBios settings from the DHCP server. If static IP, Enable NetBIOS."), ValueMap{"Default","Enable","Disable"}, Values{"Default","Enable","Disable"}] String Setting;
+    [Required, Description("Specifies if NetBIOS should be enabled or disabled or obtained from the DHCP server (Default). If static IP, Enable NetBIOS."), ValueMap{"Default","Enable","Disable"}, Values{"Default","Enable","Disable"}] String Setting;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/en-US/MSFT_xNetBIOS.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/en-US/MSFT_xNetBIOS.strings.psd1
@@ -1,13 +1,16 @@
 # Localized resources for MSFT_xNetBIOS
 
 ConvertFrom-StringData @'
-    GettingNetBiosSetting = Getting NetBIOS Configuration for Interface {0}.
-    InterfaceDetected = Interface {0} detected with Index number: {1}.
-    CurrentNetBiosSetting = Current NetBIOS Configuration: {0}.
-    DesiredSetting = Desired NetBIOS Configuration: {0}.
-    InDesiredState = NetBIOS configuration is in desired state.
-    NotInDesiredState = NetBIOS configuration is not in desired state.
-    ResetToDefaut = NetBIOS configuration will be reset to default.
-    SetNetBIOS = NetBIOS configuration will be set to: {0}.
-    NICNotFound = Interface {0} was not found.
+    GettingNetBiosSettingMessage = Getting NetBIOS configuration for Interface '{0}'.
+    InterfaceDetectedMessage = Interface '{0}' detected with Index number {1}.
+    SettingNetBiosSettingMessage = Setting NetBIOS configuration for Interface '{0}'.
+    ResetToDefautMessage = NetBIOS configuration will be reset to default.
+    SetNetBiosMessage = NetBIOS configuration will be set to '{0}'.
+    TestingNetBiosSettingMessage = Testing NetBIOS configuration for Interface '{0}'.
+    CurrentNetBiosSettingMessage = Current NetBIOS configuration is '{0}'.
+    DesiredSettingMessage = Desired NetBIOS configuration is '{0}'.
+    InDesiredStateMessage = NetBIOS configuration is in desired state.
+    NotInDesiredStateMessage = NetBIOS configuration is not in desired state.
+    InterfaceNotFoundError = Interface '{0}' was not found.
+    FailedUpdatingNetBiosError = An error result of '{0}' was returned when attemting to set NetBIOS configuration to '{1}'.
 '@

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -421,8 +421,312 @@ function Get-IPAddressPrefix
     }
 }
 
+<#
+    .SYNOPSIS
+        Removes common parameters from a hashtable
+
+    .DESCRIPTION
+        This function serves the purpose of removing common parameters and option common parameters from a parameter hashtable
+
+    .PARAMETER Hashtable
+        The parameter hashtable that should be pruned
+#>
+function Remove-CommonParameter
+{
+    [OutputType([System.Collections.Hashtable])]
+    [cmdletbinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Hashtable]
+        $Hashtable
+    )
+
+    $inputClone = $Hashtable.Clone()
+    $commonParameters = [System.Management.Automation.PSCmdlet]::CommonParameters
+    $commonParameters += [System.Management.Automation.PSCmdlet]::OptionalCommonParameters
+
+    $Hashtable.Keys | Where-Object { $_ -in $commonParameters } | ForEach-Object {
+        $inputClone.Remove($_)
+    }
+
+    return $inputClone
+}
+
+<#
+    .SYNOPSIS
+        Tests the status of DSC resource parameters
+
+    .DESCRIPTION
+        This function tests the parameter status of DSC resource parameters against the current values present on the system
+
+    .PARAMETER CurrentValues
+        A hashtable with the current values on the system, obtained by e.g. Get-TargetResource
+
+    .PARAMETER DesiredValues
+        The hashtable of desired values
+
+    .PARAMETER ValuesToCheck
+        The values to check if not all values should be checked
+
+    .PARAMETER TurnOffTypeChecking
+        Indicates that the type of the parameter should not be checked
+#>
+function Test-DscParameterState
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Collections.Hashtable]
+        $CurrentValues,
+
+        [Parameter(Mandatory = $true)]
+        [System.Object]
+        $DesiredValues,
+
+        [Parameter()]
+        [System.String[]]
+        $ValuesToCheck,
+
+        [Parameter()]
+        [switch]
+        $TurnOffTypeChecking
+    )
+
+    $returnValue = $true
+
+    $types = 'System.Management.Automation.PSBoundParametersDictionary', 'System.Collections.Hashtable', 'Microsoft.Management.Infrastructure.CimInstance'
+
+    if ($DesiredValues.GetType().FullName -notin $types)
+    {
+        New-InvalidArgumentException `
+            -Message ($script:localizedData.InvalidDesiredValuesError -f $DesiredValues.GetType().FullName) `
+            -ArgumentName 'DesiredValues'
+    }
+
+    if ($DesiredValues -is [Microsoft.Management.Infrastructure.CimInstance] -and -not $ValuesToCheck)
+    {
+        New-InvalidArgumentException `
+            -Message $script:localizedData.InvalidValuesToCheckError `
+            -ArgumentName 'ValuesToCheck'
+    }
+
+    $desiredValuesClean = Remove-CommonParameter -Hashtable $DesiredValues
+
+    if (-not $ValuesToCheck)
+    {
+        $keyList = $desiredValuesClean.Keys
+    }
+    else
+    {
+        $keyList = $ValuesToCheck
+    }
+
+    foreach ($key in $keyList)
+    {
+        if ($null -ne $desiredValuesClean.$key)
+        {
+            $desiredType = $desiredValuesClean.$key.GetType()
+        }
+        else
+        {
+            $desiredType = [psobject] @{
+                Name = 'Unknown'
+            }
+        }
+
+        if ($null -ne $CurrentValues.$key)
+        {
+            $currentType = $CurrentValues.$key.GetType()
+        }
+        else
+        {
+            $currentType = [psobject] @{
+                Name = 'Unknown'
+            }
+        }
+
+        if ($currentType.Name -ne 'Unknown' -and $desiredType.Name -eq 'PSCredential')
+        {
+            # This is a credential object. Compare only the user name
+            if ($currentType.Name -eq 'PSCredential' -and $CurrentValues.$key.UserName -eq $desiredValuesClean.$key.UserName)
+            {
+                Write-Verbose -Message ($script:localizedData.MatchPsCredentialUsernameMessage -f $CurrentValues.$key.UserName, $desiredValuesClean.$key.UserName)
+                continue
+            }
+            else
+            {
+                Write-Verbose -Message ($script:localizedData.NoMatchPsCredentialUsernameMessage -f $CurrentValues.$key.UserName, $desiredValuesClean.$key.UserName)
+                $returnValue = $false
+            }
+
+            # Assume the string is our username when the matching desired value is actually a credential
+            if ($currentType.Name -eq 'string' -and $CurrentValues.$key -eq $desiredValuesClean.$key.UserName)
+            {
+                Write-Verbose -Message ($script:localizedData.MatchPsCredentialUsernameMessage -f $CurrentValues.$key, $desiredValuesClean.$key.UserName)
+                continue
+            }
+            else
+            {
+                Write-Verbose -Message ($script:localizedData.NoMatchPsCredentialUsernameMessage -f $CurrentValues.$key, $desiredValuesClean.$key.UserName)
+                $returnValue = $false
+            }
+        }
+
+        if (-not $TurnOffTypeChecking)
+        {
+            if (($desiredType.Name -ne 'Unknown' -and $currentType.Name -ne 'Unknown') -and
+                $desiredType.FullName -ne $currentType.FullName)
+            {
+                Write-Verbose -Message ($script:localizedData.NoMatchTypeMismatchMessage -f $key, $currentType.Name, $desiredType.Name)
+                continue
+            }
+        }
+
+        if ($CurrentValues.$key -eq $desiredValuesClean.$key -and -not $desiredType.IsArray)
+        {
+            Write-Verbose -Message ($script:localizedData.MatchValueMessage -f $desiredType.Name, $key, $CurrentValues.$key, $desiredValuesClean.$key)
+            continue
+        }
+
+        if ($desiredValuesClean.GetType().Name -in 'HashTable', 'PSBoundParametersDictionary')
+        {
+            $checkDesiredValue = $desiredValuesClean.ContainsKey($key)
+        }
+        else
+        {
+            $checkDesiredValue = Test-DscObjectHasProperty -Object $desiredValuesClean -PropertyName $key
+        }
+
+        if (-not $checkDesiredValue)
+        {
+            Write-Verbose -Message ($script:localizedData.MatchValueMessage -f $desiredType.Name, $key, $CurrentValues.$key, $desiredValuesClean.$key)
+            continue
+        }
+
+        if ($desiredType.IsArray)
+        {
+            Write-Verbose -Message ($script:localizedData.TestDscParameterCompareMessage -f $key)
+
+            if (-not $CurrentValues.ContainsKey($key) -or -not $CurrentValues.$key)
+            {
+                Write-Verbose -Message ($script:localizedData.NoMatchValueMessage -f $desiredType.Name, $key, $CurrentValues.$key, $desiredValuesClean.$key)
+                $returnValue = $false
+                continue
+            }
+            elseif ($CurrentValues.$key.Count -ne $DesiredValues.$key.Count)
+            {
+                Write-Verbose -Message ($script:localizedData.NoMatchValueDifferentCountMessage -f $desiredType.Name, $key, $CurrentValues.$key.Count, $desiredValuesClean.$key.Count)
+                $returnValue = $false
+                continue
+            }
+            else
+            {
+                $desiredArrayValues = $DesiredValues.$key
+                $currentArrayValues = $CurrentValues.$key
+
+                for ($i = 0; $i -lt $desiredArrayValues.Count; $i++)
+                {
+                    if ($null -ne $desiredArrayValues[$i])
+                    {
+                        $desiredType = $desiredArrayValues[$i].GetType()
+                    }
+                    else
+                    {
+                        $desiredType = [psobject]@{
+                            Name = 'Unknown'
+                        }
+                    }
+
+                    if ($null -ne $currentArrayValues[$i])
+                    {
+                        $currentType = $currentArrayValues[$i].GetType()
+                    }
+                    else
+                    {
+                        $currentType = [psobject]@{
+                            Name = 'Unknown'
+                        }
+                    }
+
+                    if (-not $TurnOffTypeChecking)
+                    {
+                        if (($desiredType.Name -ne 'Unknown' -and $currentType.Name -ne 'Unknown') -and
+                            $desiredType.FullName -ne $currentType.FullName)
+                        {
+                            Write-Verbose -Message ($script:localizedData.NoMatchElementTypeMismatchMessage -f $key, $i, $currentType.Name, $desiredType.Name)
+                            $returnValue = $false
+                            continue
+                        }
+                    }
+
+                    if ($desiredArrayValues[$i] -ne $currentArrayValues[$i])
+                    {
+                        Write-Verbose -Message ($script:localizedData.NoMatchElementValueMismatchMessage -f $i, $desiredType.Name, $key, $currentArrayValues[$i], $desiredArrayValues[$i])
+                        $returnValue = $false
+                        continue
+                    }
+                    else
+                    {
+                        Write-Verbose -Message ($script:localizedData.MatchElementValueMessage -f $i, $desiredType.Name, $key, $currentArrayValues[$i], $desiredArrayValues[$i])
+                        continue
+                    }
+                }
+
+            }
+        }
+        else
+        {
+            if ($desiredValuesClean.$key -ne $CurrentValues.$key)
+            {
+                Write-Verbose -Message ($script:localizedData.NoMatchValueMessage -f $desiredType.Name, $key, $CurrentValues.$key, $desiredValuesClean.$key)
+                $returnValue = $false
+            }
+        }
+    }
+
+    Write-Verbose -Message ($script:localizedData.TestDscParameterResultMessage -f $returnValue)
+    return $returnValue
+}
+
+<#
+    .SYNOPSIS
+        Tests of an object has a property
+
+    .PARAMETER Object
+        The object to test
+
+    .PARAMETER PropertyName
+        The property name
+#>
+function Test-DscObjectHasProperty
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [System.Object]
+        $Object,
+
+        [Parameter(Mandatory = $true)]
+        [System.String]
+        $PropertyName
+    )
+
+    if ($Object.PSObject.Properties.Name -contains $PropertyName)
+    {
+        return [System.Boolean] $Object.$PropertyName
+    }
+
+    return $false
+}
+
 Export-ModuleMember -Function `
     Convert-CIDRToSubhetMask, `
-    Find-NetworkAdapter,
-    Get-DnsClientServerStaticAddress,
-    Get-IPAddressPrefix
+    Find-NetworkAdapter, `
+    Get-DnsClientServerStaticAddress, `
+    Get-IPAddressPrefix, `
+    Test-DscParameterState, `
+    Test-DscObjectHasProperty

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/en-us/NetworkingDsc.Common.strings.psd1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/en-us/NetworkingDsc.Common.strings.psd1
@@ -1,12 +1,25 @@
 ConvertFrom-StringData @'
-    FindingNetAdapterMessage = Finding network adapters matching the parameters.
-    AllNetAdaptersFoundMessage = Found all network adapters because no filter parameters provided.
-    NetAdapterFoundMessage = {0} network adapters were found matching the parameters.
-    NetAdapterNotFoundError = A network adapter matching the parameters was not found. Please correct the properties and try again.
-    InterfaceAliasNotFoundError = A network adapter with the alias '{0}' could not be found.
-    MultipleMatchingNetAdapterFound = Please adjust the parameters or specify IgnoreMultipleMatchingAdapters to only use the first and try again.
-    InvalidNetAdapterNumberError = network adapter interface number {0} was specified but only {1} was found. Please correct the interface number and try again.
+    FindingNetAdapterMessage             = Finding network adapters matching the parameters.
+    AllNetAdaptersFoundMessage           = Found all network adapters because no filter parameters provided.
+    NetAdapterFoundMessage               = {0} network adapters were found matching the parameters.
+    NetAdapterNotFoundError              = A network adapter matching the parameters was not found. Please correct the properties and try again.
+    InterfaceAliasNotFoundError          = A network adapter with the alias '{0}' could not be found.
+    MultipleMatchingNetAdapterFound      = Please adjust the parameters or specify IgnoreMultipleMatchingAdapters to only use the first and try again.
+    InvalidNetAdapterNumberError         = network adapter interface number {0} was specified but only {1} was found. Please correct the interface number and try again.
     GettingDNSServerStaticAddressMessage = Getting staticly assigned DNS server {0} address for interface alias '{1}'.
-    DNSServerStaticAddressNotSetMessage = Statically assigned DNS server {0} address for interface alias '{1}' is not set.
-    DNSServerStaticAddressFoundMessage = Statically assigned DNS server {0} address for interface alias '{1}' is '{2}'.
+    DNSServerStaticAddressNotSetMessage  = Statically assigned DNS server {0} address for interface alias '{1}' is not set.
+    DNSServerStaticAddressFoundMessage   = Statically assigned DNS server {0} address for interface alias '{1}' is '{2}'.
+    InvalidDesiredValuesError            = Property 'DesiredValues' in Test-DscParameterState must be either a Hashtable or CimInstance. Type detected was '{0}'.
+    InvalidValuesToCheckError            = If 'DesiredValues' is a CimInstance then property 'ValuesToCheck' must contain a value.
+    TestDscParameterCompareMessage       = Comparing values in property '{0}'.
+    MatchPsCredentialUsernameMessage     = MATCH: PSCredential username match. Current state is '{0}' and desired state is '{1}'.
+    NoMatchPsCredentialUsernameMessage   = NOTMATCH: PSCredential username mismatch. Current state is '{0}' and desired state is '{1}'.
+    NoMatchTypeMismatchMessage           = NOTMATCH: Type mismatch for property '{0}' Current state type is '{1}' and desired type is '{2}'.
+    MatchValueMessage                    = MATCH: Value (type '{0}') for property '{1}' does match. Current state is '{2}' and desired state is '{3}'.
+    NoMatchValueMessage                  = NOTMATCH: Value (type '{0}') for property '{1}' does not match. Current state is '{2}' and desired state is '{3}'.
+    NoMatchValueDifferentCountMessage    = NOTMATCH: Value (type '{0}') for property '{1}' does have a different count. Current state count is '{2}' and desired state count is '{3}'.
+    NoMatchElementTypeMismatchMessage    = NOTMATCH: Type mismatch for property '{0}' Current state type of element [{1}] is '{2}' and desired type is '{3}'.
+    NoMatchElementValueMismatchMessage   = NOTMATCH: Value [{0}] (type '{1}') for property '{2}' does match. Current state is '{3}' and desired state is '{4}'.
+    MatchElementValueMessage             = MATCH: Value [{0}] (type '{1}') for property '{2}' does match. Current state is '{3}' and desired state is '{4}'.
+    TestDscParameterResultMessage        = Test-DscParameter result is '{0}'.
 '@

--- a/Tests/Integration/MSFT_xNetBIOS.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetBIOS.Integration.Tests.ps1
@@ -1,14 +1,41 @@
-$script:DSCModuleName      = 'xNetworking'
-$script:DSCResourceName    = 'MSFT_xNetBIOS'
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xNetBIOS'
+
+# Find an adapter we can test with. It needs to be enabled and have IP enabled.
+$netAdapter = $null
+$netAdapterConfig = $null
+$netAdapterEnabled = Get-CimInstance -ClassName Win32_NetworkAdapter -Filter 'NetEnabled="True"'
+if (-not $netAdapterEnabled)
+{
+    Write-Verbose -Message ('There are no enabled network adapters in this system. Integration tests will be skipped.') -Verbose
+    return
+}
+
+foreach ($netAdapter in $netAdapterEnabled)
+{
+    $netAdapterConfig = $netAdapter |
+        Get-CimAssociatedInstance -ResultClassName Win32_NetworkAdapterConfiguration |
+        Where-Object -FilterScript { $_.IPEnabled -eq $True }
+    if ($netAdapterConfig)
+    {
+        break
+    }
+}
+if (-not $netAdapterConfig)
+{
+    Write-Verbose -Message ('There are no enabled network adapters with IP enabled in this system. Integration tests will be skipped.') -Verbose
+    return
+}
+Write-Verbose -Message ('A network adapter ({0}) was found in this system that meets requirements for integration testing.' -f $netAdapter.Name) -Verbose
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -21,34 +48,159 @@ $TestEnvironment = Initialize-TestEnvironment `
 # Using try/finally to always cleanup even if something awful happens.
 try
 {
-    #region Integration Tests
     $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
     . $ConfigFile -Verbose -ErrorAction Stop
 
+    $tcpipNetbiosOptions = $netAdapterConfig.TcpipNetbiosOptions
+
+    # Store the current Net Bios setting
+    if ($null -eq $tcpipNetbiosOptions)
+    {
+        $currentNetBiosSetting = [NetBiosSetting]::Default
+    }
+    else
+    {
+        $currentNetBiosSetting = [NetBiosSetting].GetEnumValues()[$tcpipNetbiosOptions]
+    }
+
+    # Ensure the Net Bios setting is in a known state (enabled)
+    $null = $netAdapterConfig | Invoke-CimMethod `
+        -MethodName SetTcpipNetbios `
+        -ErrorAction Stop `
+        -Arguments @{
+            TcpipNetbiosOptions = [uint32][NetBiosSetting]::Enable
+        }
+
     Describe "$($script:DSCResourceName)_Integration" {
-        #region DEFAULT TESTS
-        It 'Should compile without throwing' {
-            {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
-                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+        Context 'Disable NetBIOS over TCP/IP' {
+            $configData = @{
+                AllNodes = @(
+                    @{
+                        NodeName            = 'localhost'
+                        InterfaceAlias      = $netAdapter.Name
+                        Setting             = 'Disable'
+                    }
+                )
+            }
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+
+                    Start-DscConfiguration `
+                        -Path $TestDrive `
+                        -ComputerName localhost `
+                        -Wait `
+                        -Verbose `
+                        -Force `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all setting should match current state' {
+                $result = Get-DscConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $result.Setting | Should -Be 'Disable'
+            }
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
-        }
-        #endregion
+        Context 'Enable NetBIOS over TCP/IP' {
+            $configData = @{
+                AllNodes = @(
+                    @{
+                        NodeName            = 'localhost'
+                        InterfaceAlias      = $netAdapter.Name
+                        Setting             = 'Enable'
+                    }
+                )
+            }
 
-        It 'Should have set the resource and all setting should match current state' {
-            $Live = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
-            $Live.Setting | should be $Current #Current is defined in MSFT_NetBIOS.config.ps1
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+
+                    Start-DscConfiguration `
+                        -Path $TestDrive `
+                        -ComputerName localhost `
+                        -Wait `
+                        -Verbose `
+                        -Force `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all setting should match current state' {
+                $result = Get-DscConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $result.Setting | Should -Be 'Enable'
+            }
+        }
+
+        Context 'Default NetBIOS over TCP/IP' {
+            $configData = @{
+                AllNodes = @(
+                    @{
+                        NodeName            = 'localhost'
+                        InterfaceAlias      = $netAdapter.Name
+                        Setting             = 'Default'
+                    }
+                )
+            }
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+
+                    Start-DscConfiguration `
+                        -Path $TestDrive `
+                        -ComputerName localhost `
+                        -Wait `
+                        -Verbose `
+                        -Force `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all setting should match current state' {
+                $result = Get-DscConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $result.Setting | Should -Be 'Default'
+            }
         }
     }
-    #endregion
 }
 finally
 {
     #region FOOTER
+    # Restore the Net Bios setting
+    $null = $netAdapterConfig | Invoke-CimMethod `
+        -MethodName SetTcpipNetbios `
+        -ErrorAction Stop `
+        -Arguments @{
+            TcpipNetbiosOptions = $currentNetBiosSetting
+        }
+
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion
 }

--- a/Tests/Integration/MSFT_xNetBIOS.config.ps1
+++ b/Tests/Integration/MSFT_xNetBIOS.config.ps1
@@ -1,36 +1,10 @@
-try 
-{
-    [void][reflection.assembly]::GetAssembly([NetBIOSSetting])
-}
-catch
-{
-    Add-Type -TypeDefinition @'
-    public enum NetBiosSetting
-    {
-       Default,
-       Enable,
-       Disable
-    }
-'@
-}
-
-$adapter = (
-    Get-CimInstance -ClassName Win32_NetworkAdapter `
-        -Filter 'NetEnabled="True"'
-)[0]
-
-$Current = [NETBIOSSetting].GetEnumValues()[(
-    $adapter |
-    Get-CimAssociatedInstance `
-        -ResultClassName Win32_NetworkAdapterConfiguration
-).TcpipNetbiosOptions]
-
 configuration MSFT_xNetBIOS_Config {
     Import-DscResource -ModuleName xNetworking
+
     node localhost {
         xNetBIOS Integration_Test {
-            InterfaceAlias   = $adapter.NetConnectionID
-            Setting = $Current
+            InterfaceAlias      = $Node.InterfaceAlias
+            Setting             = $Node.Setting
         }
     }
 }

--- a/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
@@ -224,7 +224,6 @@ try
                 }
 
                 It 'Should call "Invoke-CimMethod" instead of "Set-ItemProperty"' {
-
                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly -Times 0
                     Assert-MockCalled -CommandName Invoke-CimMethod -Exactly -Times 1
                 }

--- a/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
@@ -1,13 +1,13 @@
-$script:DSCModuleName   = 'xNetworking'
+$script:DSCModuleName = 'xNetworking'
 $script:DSCResourceName = 'MSFT_xNetBIOS'
 
 #region HEADER
 # Unit Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -22,111 +22,264 @@ try
 {
     #region Pester Tests
     InModuleScope $script:DSCResourceName {
+        $interfaceAlias = 'Test Adapter'
 
-        $InterfaceAlias = (Get-NetAdapter -Physical | Select-Object -First 1).Name
+        $mockNetadapter = New-Object `
+            -TypeName CimInstance `
+            -ArgumentList 'Win32_NetworkAdapter' |
+            Add-Member `
+            -MemberType NoteProperty `
+            -Name Name `
+            -Value $interfaceAlias `
+            -PassThru
 
-        $MockNetadapterSettingsDefault = New-Object -TypeName CimInstance -ArgumentList 'Win32_NetworkAdapterConfiguration' | Add-Member -MemberType NoteProperty -Name TcpipNetbiosOptions -Value 0 -PassThru
-        $MockNetadapterSettingsEnable = New-Object -TypeName CimInstance -ArgumentList 'Win32_NetworkAdapterConfiguration' | Add-Member -MemberType NoteProperty -Name TcpipNetbiosOptions -Value 1 -PassThru
-        $MockNetadapterSettingsDisable = New-Object -TypeName CimInstance -ArgumentList 'Win32_NetworkAdapterConfiguration' | Add-Member -MemberType NoteProperty -Name TcpipNetbiosOptions -Value 2 -PassThru
+        $mockNetadapterSettingsDefault = New-Object `
+            -TypeName CimInstance `
+            -ArgumentList 'Win32_NetworkAdapterConfiguration' |
+            Add-Member `
+            -MemberType NoteProperty `
+            -Name TcpipNetbiosOptions `
+            -Value 0 `
+            -PassThru
+
+        $mockNetadapterSettingsEnable = New-Object `
+            -TypeName CimInstance `
+            -ArgumentList 'Win32_NetworkAdapterConfiguration' |
+            Add-Member `
+            -MemberType NoteProperty `
+            -Name TcpipNetbiosOptions `
+            -Value 1 `
+            -PassThru
+
+        $mockNetadapterSettingsDisable = New-Object `
+            -TypeName CimInstance `
+            -ArgumentList 'Win32_NetworkAdapterConfiguration' |
+            Add-Member `
+            -MemberType NoteProperty `
+            -Name TcpipNetbiosOptions `
+            -Value 2 `
+            -PassThru
 
         #region Function Get-TargetResource
-        Describe "MSFT_xNetBIOS\Get-TargetResource" {
+        Describe 'MSFT_xNetBIOS\Get-TargetResource' {
+            Context 'NetBIOS over TCP/IP is set to "Default"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDefault}
 
-            Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsDefault}
+                It 'Should not throw exception' {
+                    {
+                        $script:result = Get-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Default' -Verbose
+                    } | Should -Not -Throw
+                }
 
-            It 'Returns a hashtable' {
-                $targetResource = Get-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Default'
-                $targetResource -is [System.Collections.Hashtable] | Should Be $true
+                It 'Returns a hashtable' {
+                    $script:result -is [System.Collections.Hashtable] | Should -Be $true
+                }
+
+                It 'Setting should return "Default"' {
+                    $script:result.Setting | Should -Be 'Default'
+                }
             }
 
-            It 'NetBIOS over TCP/IP numerical setting "0" should translate to "Default"' {
-                $Result = Get-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Default'
-                $Result.Setting | should be 'Default'
+            Context 'NetBIOS over TCP/IP is set to "Enable"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsEnable }
+
+                It 'Should not throw exception' {
+                    {
+                        $script:result = Get-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Default' -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Returns a hashtable' {
+                    $script:result -is [System.Collections.Hashtable] | Should -Be $true
+                }
+
+                It 'Setting should return "Enable"' {
+                    $script:result.Setting | Should -Be 'Enable'
+                }
             }
 
-            It 'NetBIOS over TCP/IP setting should return real value "Default", not parameter value "Enable"' {
-                $Result = Get-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Enable'
-                $Result.Setting | should be 'Default'
+            Context 'NetBIOS over TCP/IP is set to "Disable"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
+
+                It 'Should not throw exception' {
+                    {
+                        $script:result = Get-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Default' -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Returns a hashtable' {
+                    $script:result -is [System.Collections.Hashtable] | Should -Be $true
+                }
+
+                It 'Setting should return "Disable"' {
+                    $script:result.Setting | Should -Be 'Disable'
+                }
+            }
+
+            Context 'Interface does not exist' {
+                Mock -CommandName Get-CimInstance -MockWith { }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
+
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message ($LocalizedData.InterfaceNotFoundError -f $interfaceAlias)
+
+                It 'Should throw expected exception' {
+                    {
+                        $script:result = Get-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Default' -Verbose
+                    } | Should -Throw $errorRecord
+                }
             }
         }
         #endregion
 
-
         #region Function Test-TargetResource
-        Describe "MSFT_xNetBIOS\Test-TargetResource" {
-            Context 'invoking with NetBIOS over TCP/IP set to default' {
+        Describe 'MSFT_xNetBIOS\Test-TargetResource' {
+            Context 'NetBIOS over TCP/IP is set to "Default"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDefault }
 
-                Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsDefault}
-
-                It 'should return true when value "Default" is set' {
-                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Default' | Should Be $true
+                It 'Should return true when value "Default" is set' {
+                    Test-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Default' -Verbose | Should -Be $true
                 }
-                It 'should return false when value "Disable" is set' {
-                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Disable' | Should Be $false
-                }
-            }
 
-            Context 'invoking with NetBIOS over TCP/IP set to Disable' {
-
-                Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsDisable}
-
-                It 'should return true when value "Disable" is set' {
-                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Disable' | Should Be $true
-                }
-                It 'should return false when value "Enable" is set' {
-                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Enable' | Should Be $false
+                It 'Should return false when value "Disable" is set' {
+                    Test-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Disable' -Verbose | Should -Be $false
                 }
             }
 
-            Context 'invoking with NetBIOS over TCP/IP set to Enable' {
+            Context 'NetBIOS over TCP/IP is set to "Disable"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
 
-                Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsEnable}
-
-                It 'should return true when value "Enable" is set' {
-                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Enable' | Should Be $true
+                It 'Should return true when value "Disable" is set' {
+                    Test-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Disable' -Verbose | Should -Be $true
                 }
-                It 'should return false when value "Disable" is set' {
-                    Test-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Disable' | Should Be $false
+
+                It 'Should return false when value "Enable" is set' {
+                    Test-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Enable' -Verbose | Should -Be $false
                 }
             }
 
-            Context 'Invoking with NonExisting Network Adapter' {
-                Mock -CommandName Get-CimAssociatedInstance -MockWith { }
-                $errorMessage = ($LocalizedData.NICNotFound -f 'BogusAdapter')
-                It 'should throw ObjectNotFound exception' {
-                    {Test-TargetResource -InterfaceAlias 'BogusAdapter' -Setting 'Enable'} | Should Throw $errorMessage
+            Context 'NetBIOS over TCP/IP is set to "Enable"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsEnable }
+
+                It 'Should return true when value "Enable" is set' {
+                    Test-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Enable' -Verbose | Should -Be $true
+                }
+
+                It 'Should return false when value "Disable" is set' {
+                    Test-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Disable' -Verbose | Should -Be $false
+                }
+            }
+
+            Context 'Interface does not exist' {
+                Mock -CommandName Get-CimInstance -MockWith { }
+
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message ($LocalizedData.InterfaceNotFoundError -f $interfaceAlias)
+
+                It 'Should throw expected exception' {
+                    {
+                        Test-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Enable' -Verbose
+                    } | Should -Throw $errorRecord
                 }
             }
         }
         #endregion
 
         #region Function Set-TargetResource
-        Describe "MSFT_xNetBIOS\Set-TargetResource" {
-            Mock Set-ItemProperty
-            Mock Invoke-CimMethod
+        Describe 'MSFT_xNetBIOS\Set-TargetResource' {
+            Context 'NetBIOS over TCP/IP should be set to "Default"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsEnable }
+                Mock -CommandName Set-ItemProperty
+                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 0 } }
 
-            Context '"Setting" is "Default"' {
-
-                Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsEnable}
+                It 'Should not throw exception' {
+                    {
+                        Set-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Default' -Verbose
+                    } | Should -Not -Throw
+                }
 
                 It 'Should call "Set-ItemProperty" instead of "Invoke-CimMethod"' {
-                    $Null = Set-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Default'
-
                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly -Times 1
                     Assert-MockCalled -CommandName Invoke-CimMethod -Exactly -Times 0
                 }
             }
 
-            Context '"Setting" is "Disable"' {
+            Context 'NetBIOS over TCP/IP should be set to "Disable"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsEnable }
+                Mock -CommandName Set-ItemProperty
+                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 0 } }
+
+                It 'Should not throw exception' {
+                    {
+                        Set-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Disable' -Verbose
+                    } | Should -Not -Throw
+                }
 
                 It 'Should call "Invoke-CimMethod" instead of "Set-ItemProperty"' {
-                    Mock -CommandName Get-CimAssociatedInstance -MockWith {return $MockNetadapterSettingsEnable}
-                    Mock Invoke-CimMethod
-
-                    $Null = Set-TargetResource -InterfaceAlias $InterfaceAlias -Setting 'Disable'
 
                     Assert-MockCalled -CommandName Set-ItemProperty -Exactly -Times 0
                     Assert-MockCalled -CommandName Invoke-CimMethod -Exactly -Times 1
+                }
+            }
+
+            Context 'NetBIOS over TCP/IP should be set to "Enable"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
+                Mock -CommandName Set-ItemProperty
+                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 0 } }
+
+                It 'Should not throw exception' {
+                    {
+                        Set-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Enable' -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should call "Invoke-CimMethod" instead of "Set-ItemProperty"' {
+
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly -Times 0
+                    Assert-MockCalled -CommandName Invoke-CimMethod -Exactly -Times 1
+                }
+            }
+
+            Context 'NetBIOS over TCP/IP should be set to "Enable" but error returned from "Invoke-CimMethod"' {
+                Mock -CommandName Get-CimInstance -MockWith { $mockNetadapter }
+                Mock -CommandName Get-CimAssociatedInstance -MockWith { $mockNetadapterSettingsDisable }
+                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 74 } }
+                Mock -CommandName Set-ItemProperty
+
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message ($LocalizedData.FailedUpdatingNetBiosError -f 74, 'Enable')
+
+                It 'Should throw expected exception' {
+                    {
+                        Set-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Enable' -Verbose
+                    } | Should -Throw $errorRecord
+                }
+
+                It 'Should call "Invoke-CimMethod" instead of "Set-ItemProperty"' {
+                    Assert-MockCalled -CommandName Set-ItemProperty -Exactly -Times 0
+                    Assert-MockCalled -CommandName Invoke-CimMethod -Exactly -Times 1
+                }
+            }
+
+            Context 'Interface does not exist' {
+                Mock -CommandName Get-CimInstance -MockWith { }
+
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message ($LocalizedData.InterfaceNotFoundError -f $interfaceAlias)
+
+                It 'Should throw expected exception' {
+                    {
+                        Set-TargetResource -InterfaceAlias $interfaceAlias -Setting 'Enable' -Verbose
+                    } | Should -Throw $errorRecord
                 }
             }
         }

--- a/Tests/Unit/NetworkingDsc.Common.tests.ps1
+++ b/Tests/Unit/NetworkingDsc.Common.tests.ps1
@@ -6,9 +6,9 @@ Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot 
 # Unit Test Template Version: 1.1.0
 [string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
 if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
-     (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
 {
-    & git @('clone','https://github.com/PowerShell/DscResource.Tests.git',(Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
 }
 
 Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
@@ -47,7 +47,7 @@ try
             }
         }
         Context 'Multiple Notations Used "192.168.0.0/16,10.0.0.24/255.255.255.0"' {
-            $Result = Convert-CIDRToSubhetMask -Address @('192.168.0.0/16','10.0.0.24/255.255.255.0')
+            $Result = Convert-CIDRToSubhetMask -Address @('192.168.0.0/16', '10.0.0.24/255.255.255.0')
             It 'Should Return "192.168.0.0/255.255.0.0,10.0.0.0/255.255.255.0"' {
                 $Result[0] | Should Be '192.168.0.0/255.255.0.0'
                 $Result[1] | Should Be '10.0.0.0/255.255.255.0'
@@ -462,7 +462,7 @@ try
                     -MockWith { $multipleMatchingAdapterArray }
 
                 $errorRecord = Get-InvalidOperationRecord `
-                    -Message ($LocalizedData.InvalidNetAdapterNumberError -f 2,3)
+                    -Message ($LocalizedData.InvalidNetAdapterNumberError -f 2, 3)
 
                 It 'Should throw the correct exception' {
                     { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -IgnoreMultipleMatchingAdapters:$true -InterfaceNumber 3 -Verbose } | Should Throw $errorRecord
@@ -483,14 +483,14 @@ try
         an exception because the GetAdapter module has no manifest
     #>
     InModuleScope $script:ModuleName {
-        Describe "NetworkingDsc.Common\Get-DnsClientServerStaticAddress" {
+        Describe 'NetworkingDsc.Common\Get-DnsClientServerStaticAddress' {
 
             # Generate the adapter data to be used for Mocking
             $interfaceAlias = 'Adapter'
             $interfaceGuid = [Guid]::NewGuid().ToString()
             $nomatchAdapter = $null
             $matchAdapter = [PSObject]@{
-                InterfaceGuid        = $interfaceGuid
+                InterfaceGuid = $interfaceGuid
             }
             $ipv4Parameters = @{
                 InterfaceAlias = $interfaceAlias
@@ -534,10 +534,10 @@ try
                 Mock `
                     -CommandName Get-ItemProperty `
                     -MockWith {
-                        [psobject] @{
-                            NameServer  = $noIpv4StaticAddressString
-                        }
+                    [psobject] @{
+                        NameServer = $noIpv4StaticAddressString
                     }
+                }
 
                 It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
@@ -561,10 +561,10 @@ try
                 Mock `
                     -CommandName Get-ItemProperty `
                     -MockWith {
-                        [psobject] @{
-                            Dummy = ''
-                        }
+                    [psobject] @{
+                        Dummy = ''
                     }
+                }
 
                 It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
@@ -588,10 +588,10 @@ try
                 Mock `
                     -CommandName Get-ItemProperty `
                     -MockWith {
-                        [psobject] @{
-                            NameServer = $oneIpv4StaticAddressString
-                        }
+                    [psobject] @{
+                        NameServer = $oneIpv4StaticAddressString
                     }
+                }
 
                 It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
@@ -615,10 +615,10 @@ try
                 Mock `
                     -CommandName Get-ItemProperty `
                     -MockWith {
-                        [psobject] @{
-                            NameServer = $twoIpv4StaticAddressString
-                        }
+                    [psobject] @{
+                        NameServer = $twoIpv4StaticAddressString
                     }
+                }
 
                 It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
@@ -643,10 +643,10 @@ try
                 Mock `
                     -CommandName Get-ItemProperty `
                     -MockWith {
-                        [psobject] @{
-                            NameServer = $noIpv6StaticAddressString
-                        }
+                    [psobject] @{
+                        NameServer = $noIpv6StaticAddressString
                     }
+                }
 
                 It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
@@ -670,10 +670,10 @@ try
                 Mock `
                     -CommandName Get-ItemProperty `
                     -MockWith {
-                        [psobject] @{
-                            Dummy = ''
-                        }
+                    [psobject] @{
+                        Dummy = ''
                     }
+                }
 
                 It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
@@ -697,10 +697,10 @@ try
                 Mock `
                     -CommandName Get-ItemProperty `
                     -MockWith {
-                        [psobject] @{
-                            NameServer = $oneIpv6StaticAddressString
-                        }
+                    [psobject] @{
+                        NameServer = $oneIpv6StaticAddressString
                     }
+                }
 
                 It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
@@ -724,10 +724,10 @@ try
                 Mock `
                     -CommandName Get-ItemProperty `
                     -MockWith {
-                        [psobject] @{
-                            NameServer = $twoIpv6StaticAddressString
-                        }
+                    [psobject] @{
+                        NameServer = $twoIpv6StaticAddressString
                     }
+                }
 
                 It 'Should not throw exception' {
                     { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
@@ -748,7 +748,7 @@ try
     #endregion
 
     #region Function Get-IPAddressPrefix
-    Describe "NetworkingDsc.Common\Get-IPAddressPrefix" {
+    Describe 'NetworkingDsc.Common\Get-IPAddressPrefix' {
         Context 'IPv4 CIDR notation provided' {
             it 'Should return the provided IP and prefix as separate properties' {
                 $IPaddress = Get-IPAddressPrefix -IPAddress '192.168.10.0/24'
@@ -800,6 +800,431 @@ try
 
                 $IPaddress.IPaddress | Should be 'FF12::12::123'
                 $IPaddress.PrefixLength | Should be 64
+            }
+        }
+    }
+
+    InModuleScope $script:ModuleName {
+        Describe 'NetworkingDsc.Common\Remove-CommonParameter' {
+            $removeCommonParameter = @{
+                Parameter1          = 'value1'
+                Parameter2          = 'value2'
+                Verbose             = $true
+                Debug               = $true
+                ErrorAction         = 'Stop'
+                WarningAction       = 'Stop'
+                InformationAction   = 'Stop'
+                ErrorVariable       = 'errorVariable'
+                WarningVariable     = 'warningVariable'
+                OutVariable         = 'outVariable'
+                OutBuffer           = 'outBuffer'
+                PipelineVariable    = 'pipelineVariable'
+                InformationVariable = 'informationVariable'
+                WhatIf              = $true
+                Confirm             = $true
+                UseTransaction      = $true
+            }
+
+            Context 'Hashtable contains all common parameters' {
+                It 'Should not throw exception' {
+                    { $script:result = Remove-CommonParameter -Hashtable $removeCommonParameter -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should have retained parameters in the hashtable' {
+                    $script:result.Contains('Parameter1') | Should -Be $true
+                    $script:result.Contains('Parameter2') | Should -Be $true
+                }
+
+                It 'Should have removed the common parameters from the hashtable' {
+                    $script:result.Contains('Verbose') | Should -Be $false
+                    $script:result.Contains('Debug') | Should -Be $false
+                    $script:result.Contains('ErrorAction') | Should -Be $false
+                    $script:result.Contains('WarningAction') | Should -Be $false
+                    $script:result.Contains('InformationAction') | Should -Be $false
+                    $script:result.Contains('ErrorVariable') | Should -Be $false
+                    $script:result.Contains('WarningVariable') | Should -Be $false
+                    $script:result.Contains('OutVariable') | Should -Be $false
+                    $script:result.Contains('OutBuffer') | Should -Be $false
+                    $script:result.Contains('PipelineVariable') | Should -Be $false
+                    $script:result.Contains('InformationVariable') | Should -Be $false
+                    $script:result.Contains('WhatIf') | Should -Be $false
+                    $script:result.Contains('Confirm') | Should -Be $false
+                    $script:result.Contains('UseTransaction') | Should -Be $false
+                }
+            }
+        }
+
+        Describe 'NetworkingDsc.Common\Test-DscParameterState' {
+            Context 'All current parameters match desired parameters' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $true' {
+                    $script:result | Should -Be $true
+                }
+            }
+
+            Context 'The current parameters do not match desired parameters because a string mismatches' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'different string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -Be $false
+                }
+            }
+
+            Context 'The current parameters do not match desired parameters because a boolean mismatches' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'a string'
+                    parameterBool   = $false
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -Be $false
+                }
+            }
+
+            Context 'The current parameters do not match desired parameters because a int mismatches' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 1
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -Be $false
+                }
+            }
+
+            Context 'The current parameters do not match desired parameters because an array is missing a value' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 1
+                    parameterArray  = @( 'a', 'b' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -Be $false
+                }
+            }
+
+            Context 'The current parameters do not match desired parameters because an array has an additional value' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 1
+                    parameterArray  = @( 'a', 'b', 'c', 'd' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -Be $false
+                }
+            }
+
+            Context 'The current parameters do not match desired parameters because an array has a different value' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 1
+                    parameterArray  = @( 'a', 'd', 'c' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -Be $false
+                }
+            }
+
+            Context 'The current parameters do not match desired parameters because an array has a different type' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 1
+                    parameterArray  = @( 'a', 1, 'c' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -Be $false
+                }
+            }
+
+            Context 'The current parameters do not match desired parameters because a parameter has a different type' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = $false
+                    parameterBool   = $true
+                    parameterInt    = 1
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                    'parameterBool'
+                    'ParameterInt'
+                    'ParameterArray'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $false' {
+                    $script:result | Should -Be $false
+                }
+            }
+
+            Context 'Some of the current parameters do not match desired parameters but only matching parameter is compared' {
+                $currentValues = @{
+                    parameterString = 'a string'
+                    parameterBool   = $true
+                    parameterInt    = 99
+                    parameterArray  = @( 'a', 'b', 'c' )
+                }
+
+                $desiredValues = [PSObject] @{
+                    parameterString = 'a string'
+                    parameterBool   = $false
+                    parameterInt    = 1
+                    parameterArray  = @( 'a', 'b' )
+                }
+
+                $valuesToCheck = @(
+                    'parameterString'
+                )
+
+                It 'Should not throw exception' {
+                    { $script:result = Test-DscParameterState `
+                            -CurrentValues $currentValues `
+                            -DesiredValues $desiredValues `
+                            -ValuesToCheck $valuesToCheck `
+                            -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return $true' {
+                    $script:result | Should -Be $true
+                }
+            }
+
+            Describe 'NetworkingDsc.Common\Test-DscObjectHasProperty' {
+                # Use the Get-Verb cmdlet to just get a simple object fast
+                $testDscObject = (Get-Verb)[0]
+
+                Context 'The object contains the expected property' {
+                    It 'Should not throw exception' {
+                        { $script:result = Test-DscObjectHasProperty -Object $testDscObject -PropertyName 'Verb' -Verbose } | Should -Not -Throw
+                    }
+
+                    It 'Should return $true' {
+                        $script:result | Should -Be $true
+                    }
+                }
+
+                Context 'The object does not contain the expected property' {
+                    It 'Should not throw exception' {
+                        { $script:result = Test-DscObjectHasProperty -Object $testDscObject -PropertyName 'Missing' -Verbose } | Should -Not -Throw
+                    }
+
+                    It 'Should return $false' {
+                        $script:result | Should -Be $false
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
**Pull Request (PR) description**
Convert xNetBios to meet HQRM guidelines and improve integration testing and test coverage.

  - Corrected style and formatting to meet HQRM guidelines.
  - Updated tests to meet Pester v4 guidelines.
  - Converted exceptions to use ResourceHelper functions.
  - Improved integration tests to preserve system status, run in more
    scenarios and more effectively test the resource.
  - Changed to report back error if unable to set NetBIOS setting.

**This Pull Request (PR) fixes the following issues:**
- #300

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@Johlju - if you get time, would you mind reviewing this one for me? Unless @tysonjhayes gets a moment?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/303)
<!-- Reviewable:end -->
