### PR TITLE
Added xWinsSetting resource - Fixes #302

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,6 +23,9 @@
   - Improved integration tests to preserve system status, run in more
     scenarios and more effectively test the resource.
   - Changed to report back error if unable to set NetBIOS setting.
+- MSFT_xWinsSetting:
+  - Created new resource for enabling/disabling LMHOSTS lookup and
+    enabling/disabling WINS name resoluton using DNS.
 
 ## 5.4.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/MSFT_xWINSSetting.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/MSFT_xWINSSetting.psm1
@@ -1,0 +1,191 @@
+$modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot -Parent) -Parent) -ChildPath 'Modules'
+
+# Import the Networking Common Modules
+Import-Module -Name (Join-Path -Path $modulePath `
+        -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+            -ChildPath 'NetworkingDsc.Common.psm1'))
+
+# Import the Networking Resource Helper Module
+Import-Module -Name (Join-Path -Path $modulePath `
+        -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+            -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
+
+# Import Localization Strings
+$LocalizedData = Get-LocalizedData `
+    -ResourceName 'MSFT_xWINSSetting' `
+    -ResourcePath (Split-Path -Parent $Script:MyInvocation.MyCommand.Path)
+
+<#
+    .SYNOPSIS
+    Returns the current WINS settings.
+
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
+#>
+function Get-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Collections.Hashtable])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance
+    )
+
+    Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($LocalizedData.GettingWinsSettingMessage)
+        ) -join '' )
+
+    # 0 equals off, 1 equals on
+    $enableLMHostsRegistryKey = Get-ItemProperty `
+        -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' `
+        -Name EnableLMHOSTS `
+        -ErrorAction SilentlyContinue
+
+    $enableLMHOSTS = ($enableLMHOSTSRegistryKey.EnableLMHOSTS -eq 1)
+
+    # 0 equals off, 1 equals on
+    $enableDnsRegistryKey = Get-ItemProperty `
+        -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' `
+        -Name EnableDNS `
+        -ErrorAction SilentlyContinue
+
+    if ($enableDnsRegistryKey)
+    {
+        $enableDNS = ($enableDnsRegistryKey.EnableDNS -eq 1)
+    }
+    else
+    {
+        # if the key does not exist, then set the default which is enabled.
+        $enableDNS = $true
+    }
+
+    return @{
+        IsSingleInstance = 'Yes'
+        EnableLMHOSTS    = $enableLMHOSTS
+        EnableDNS        = $enableDNS
+    }
+} # Get-TargetResource
+
+<#
+    .SYNOPSIS
+    Sets the current configuration for the LMHOSTS Lookup setting.
+
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
+
+    .PARAMETER EnableLMHOSTS
+    Specifies if LMHOSTS lookup should be enabled for all network
+    adapters with TCP/IP enabled.
+
+    .PARAMETER EnableDNS
+    Specifies if DNS is enabled for name resolution over WINS for
+    all network adapters with TCP/IP enabled.
+#>
+function Set-TargetResource
+{
+    [CmdletBinding()]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
+
+        [Parameter()]
+        [System.Boolean]
+        $EnableLMHOSTS,
+
+        [Parameter()]
+        [System.Boolean]
+        $EnableDNS
+    )
+
+    Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($LocalizedData.SettingWinsSettingMessage)
+        ) -join '' )
+
+    # Get the current values of the WINS settings
+    $currentState = Get-TargetResource -IsSingleInstance 'Yes'
+
+    if (-not $PSBoundParameters.ContainsKey('EnableLMHOSTS'))
+    {
+        $EnableLMHOSTS = $currentState.EnableLMHOSTS
+    }
+
+    if (-not $PSBoundParameters.ContainsKey('EnableDNS'))
+    {
+        $EnableDNS = $currentState.EnableDNS
+    }
+
+    $result = Invoke-CimMethod `
+        -ClassName Win32_NetworkAdapterConfiguration `
+        -MethodName EnableWins `
+        -Arguments @{
+            DNSEnabledForWINSResolution = $EnableDNS
+            WINSEnableLMHostsLookup     = $EnableLMHOSTS
+        }
+
+    if ($result.ReturnValue -ne 0)
+    {
+        New-InvalidOperationException `
+            -Message ($localizedData.FailedUpdatingWinsSettingError -f $result.ReturnValue)
+    }
+
+    Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($LocalizedData.WinsSettingUpdatedMessage)
+        ) -join '' )
+} # Set-TargetResource
+
+<#
+    .SYNOPSIS
+    Tests the current configuration for the LMHOSTS Lookup setting.
+
+    .PARAMETER IsSingleInstance
+    Specifies the resource is a single instance, the value must be 'Yes'.
+
+    .PARAMETER EnableLMHOSTS
+    Specifies if LMHOSTS lookup should be enabled for all network
+    adapters with TCP/IP enabled.
+
+    .PARAMETER EnableDNS
+    Specifies if DNS is enabled for name resolution over WINS for
+    all network adapters with TCP/IP enabled.
+#>
+function Test-TargetResource
+{
+    [CmdletBinding()]
+    [OutputType([System.Boolean])]
+    param
+    (
+        [Parameter(Mandatory = $true)]
+        [ValidateSet('Yes')]
+        [System.String]
+        $IsSingleInstance,
+
+        [Parameter()]
+        [System.Boolean]
+        $EnableLMHOSTS,
+
+        [Parameter()]
+        [System.Boolean]
+        $EnableDNS
+    )
+
+    Write-Verbose -Message ( @(
+            "$($MyInvocation.MyCommand): "
+            $($LocalizedData.TestingWinsSettingMessage)
+        ) -join '' )
+
+    # Get the current values of the WINS settings
+    $currentState = Get-TargetResource -IsSingleInstance 'Yes'
+
+    return Test-DscParameterState -CurrentValues $currentState -DesiredValues $PSBoundParameters
+} # Test-TargetResource
+
+Export-ModuleMember -Function *-TargetResource

--- a/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/MSFT_xWINSSetting.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/MSFT_xWINSSetting.psm1
@@ -40,12 +40,12 @@ function Get-TargetResource
         ) -join '' )
 
     # 0 equals off, 1 equals on
-    $enableLMHostsRegistryKey = Get-ItemProperty `
+    $enableLmHostsRegistryKey = Get-ItemProperty `
         -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' `
         -Name EnableLMHOSTS `
         -ErrorAction SilentlyContinue
 
-    $enableLMHOSTS = ($enableLMHOSTSRegistryKey.EnableLMHOSTS -eq 1)
+    $enableLmHosts = ($enableLmHostsRegistryKey.EnableLMHOSTS -eq 1)
 
     # 0 equals off, 1 equals on
     $enableDnsRegistryKey = Get-ItemProperty `
@@ -55,18 +55,18 @@ function Get-TargetResource
 
     if ($enableDnsRegistryKey)
     {
-        $enableDNS = ($enableDnsRegistryKey.EnableDNS -eq 1)
+        $enableDns = ($enableDnsRegistryKey.EnableDNS -eq 1)
     }
     else
     {
         # if the key does not exist, then set the default which is enabled.
-        $enableDNS = $true
+        $enableDns = $true
     }
 
     return @{
         IsSingleInstance = 'Yes'
-        EnableLMHOSTS    = $enableLMHOSTS
-        EnableDNS        = $enableDNS
+        EnableLmHosts    = $enableLmHosts
+        EnableDns        = $enableDns
     }
 } # Get-TargetResource
 
@@ -77,11 +77,11 @@ function Get-TargetResource
     .PARAMETER IsSingleInstance
     Specifies the resource is a single instance, the value must be 'Yes'.
 
-    .PARAMETER EnableLMHOSTS
+    .PARAMETER EnableLmHosts
     Specifies if LMHOSTS lookup should be enabled for all network
     adapters with TCP/IP enabled.
 
-    .PARAMETER EnableDNS
+    .PARAMETER EnableDns
     Specifies if DNS is enabled for name resolution over WINS for
     all network adapters with TCP/IP enabled.
 #>
@@ -97,11 +97,11 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $EnableLMHOSTS,
+        $EnableLmHosts,
 
         [Parameter()]
         [System.Boolean]
-        $EnableDNS
+        $EnableDns
     )
 
     Write-Verbose -Message ( @(
@@ -112,22 +112,22 @@ function Set-TargetResource
     # Get the current values of the WINS settings
     $currentState = Get-TargetResource -IsSingleInstance 'Yes'
 
-    if (-not $PSBoundParameters.ContainsKey('EnableLMHOSTS'))
+    if (-not $PSBoundParameters.ContainsKey('EnableLmHosts'))
     {
-        $EnableLMHOSTS = $currentState.EnableLMHOSTS
+        $EnableLmHosts = $currentState.EnableLmHosts
     }
 
-    if (-not $PSBoundParameters.ContainsKey('EnableDNS'))
+    if (-not $PSBoundParameters.ContainsKey('EnableDns'))
     {
-        $EnableDNS = $currentState.EnableDNS
+        $EnableDns = $currentState.EnableDNS
     }
 
     $result = Invoke-CimMethod `
         -ClassName Win32_NetworkAdapterConfiguration `
         -MethodName EnableWins `
         -Arguments @{
-            DNSEnabledForWINSResolution = $EnableDNS
-            WINSEnableLMHostsLookup     = $EnableLMHOSTS
+            DNSEnabledForWINSResolution = $EnableDns
+            WINSEnableLMHostsLookup     = $EnableLmHosts
         }
 
     if ($result.ReturnValue -ne 0)
@@ -149,11 +149,11 @@ function Set-TargetResource
     .PARAMETER IsSingleInstance
     Specifies the resource is a single instance, the value must be 'Yes'.
 
-    .PARAMETER EnableLMHOSTS
+    .PARAMETER EnableLmHosts
     Specifies if LMHOSTS lookup should be enabled for all network
     adapters with TCP/IP enabled.
 
-    .PARAMETER EnableDNS
+    .PARAMETER EnableDns
     Specifies if DNS is enabled for name resolution over WINS for
     all network adapters with TCP/IP enabled.
 #>
@@ -170,11 +170,11 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
-        $EnableLMHOSTS,
+        $EnableLmHosts,
 
         [Parameter()]
         [System.Boolean]
-        $EnableDNS
+        $EnableDns
     )
 
     Write-Verbose -Message ( @(

--- a/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/MSFT_xWINSSetting.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/MSFT_xWINSSetting.schema.mof
@@ -1,0 +1,7 @@
+[ClassVersion("1.0.0.0"), FriendlyName("xWINSSetting")]
+class MSFT_xWINSSetting : OMI_BaseResource
+{
+    [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
+    [Write, Description("Specifies if LMHOSTS lookup should be enabled for all network adapters with TCP/IP enabled.")] Boolean EnableLMHOSTS;
+    [Write, Description("Specifies if DNS is enabled for name resolution over WINS for all network adapters with TCP/IP enabled.")] Boolean EnableDNS;
+};

--- a/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/MSFT_xWINSSetting.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/MSFT_xWINSSetting.schema.mof
@@ -2,6 +2,6 @@
 class MSFT_xWINSSetting : OMI_BaseResource
 {
     [Key, Description("Specifies the resource is a single instance, the value must be 'Yes'."), ValueMap{"Yes"}, Values{"Yes"}] String IsSingleInstance;
-    [Write, Description("Specifies if LMHOSTS lookup should be enabled for all network adapters with TCP/IP enabled.")] Boolean EnableLMHOSTS;
-    [Write, Description("Specifies if DNS is enabled for name resolution over WINS for all network adapters with TCP/IP enabled.")] Boolean EnableDNS;
+    [Write, Description("Specifies if LMHOSTS lookup should be enabled for all network adapters with TCP/IP enabled.")] Boolean EnableLmHosts;
+    [Write, Description("Specifies if DNS is enabled for name resolution over WINS for all network adapters with TCP/IP enabled.")] Boolean EnableDns;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/README.MD
+++ b/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/README.MD
@@ -1,0 +1,4 @@
+# Description
+
+This resource is used to configure the WINS settings that enable or disable
+LMHOSTS lookups and enable or disable DNS for name resolution over WINS.

--- a/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/en-US/MSFT_xWINSSetting.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/en-US/MSFT_xWINSSetting.strings.psd1
@@ -5,6 +5,5 @@ ConvertFrom-StringData @'
     SettingWinsSettingMessage = Setting WINS settings.
     WinsSettingUpdatedMessage = WINS settings updated.
     TestingWinsSettingMessage = Testing WINS settings.
-    WinsSettingParameterNeedsUpdateMessage = WINS setting is "{0}" but should be "{1}". Change required.
     FailedUpdatingWinsSettingError = An error result of '{0}' was returned when attemting to update WINS settings.
 '@

--- a/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/en-US/MSFT_xWINSSetting.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/en-US/MSFT_xWINSSetting.strings.psd1
@@ -1,0 +1,10 @@
+# Localized resources for MSFT_xWinsSetting
+
+ConvertFrom-StringData @'
+    GettingWinsSettingMessage = Getting WINS settings.
+    SettingWinsSettingMessage = Setting WINS settings.
+    WinsSettingUpdatedMessage = WINS settings updated.
+    TestingWinsSettingMessage = Testing WINS settings.
+    WinsSettingParameterNeedsUpdateMessage = WINS setting is "{0}" but should be "{1}". Change required.
+    FailedUpdatingWinsSettingError = An error result of '{0}' was returned when attemting to update WINS settings.
+'@

--- a/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/en-US/MSFT_xWINSSetting.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xWinsSetting/en-US/MSFT_xWINSSetting.strings.psd1
@@ -5,5 +5,5 @@ ConvertFrom-StringData @'
     SettingWinsSettingMessage = Setting WINS settings.
     WinsSettingUpdatedMessage = WINS settings updated.
     TestingWinsSettingMessage = Testing WINS settings.
-    FailedUpdatingWinsSettingError = An error result of '{0}' was returned when attemting to update WINS settings.
+    FailedUpdatingWinsSettingError = An error code of '{0}' was returned when attemting to update WINS settings.
 '@

--- a/Modules/xNetworking/Examples/Resources/xWinsSetting/1-ConfigureWinsSetting.ps1
+++ b/Modules/xNetworking/Examples/Resources/xWinsSetting/1-ConfigureWinsSetting.ps1
@@ -1,0 +1,25 @@
+<#
+    .EXAMPLE
+    Disable LMHOSTS lookup and disable using DNS for WINS name resolution.
+#>
+Configuration Example
+{
+    param
+    (
+        [Parameter()]
+        [System.String[]]
+        $NodeName = 'localhost'
+    )
+
+    Import-DscResource -Module xNetworking
+
+    Node $NodeName
+    {
+        xWinsSetting ConfigureWinsSettings
+        {
+            IsSingleInstance = 'Yes'
+            EnableLMHOSTS    = $false
+            EnableDNS        = $false
+        }
+    }
+}

--- a/README.md
+++ b/README.md
@@ -30,6 +30,8 @@ The **xNetworking** module contains the following resources:
 - **xWeakHostSend**: Enable or disable the Weak Host Send setting on a network adapter.
 - **xWeakHostReceive**: Enable or disable the Weak Host Receive setting
     on a network adapter.
+- **xWinsSetting**: Configure the WINS settings that enable or disable LMHOSTS lookups
+  and enable or disable DNS for name resolution over WINS.
 
 This project has adopted the [Microsoft Open Source Code of Conduct](https://opensource.microsoft.com/codeofconduct/).
 For more information see the [Code of Conduct FAQ](https://opensource.microsoft.com/codeofconduct/faq/)

--- a/Tests/Integration/MSFT_xWinsSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWinsSetting.Integration.Tests.ps1
@@ -1,0 +1,182 @@
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xWinsSetting'
+
+# Find an adapter we can test with. It needs to be enabled and have IP enabled.
+$netAdapter = $null
+$netAdapterConfig = $null
+$netAdapterEnabled = Get-CimInstance -ClassName Win32_NetworkAdapter -Filter 'NetEnabled="True"'
+if (-not $netAdapterEnabled)
+{
+    Write-Verbose -Message ('There are no enabled network adapters in this system. Integration tests will be skipped.') -Verbose
+    return
+}
+
+foreach ($netAdapter in $netAdapterEnabled)
+{
+    $netAdapterConfig = $netAdapter |
+        Get-CimAssociatedInstance -ResultClassName Win32_NetworkAdapterConfiguration |
+        Where-Object -FilterScript { $_.IPEnabled -eq $True }
+    if ($netAdapterConfig)
+    {
+        break
+    }
+}
+if (-not $netAdapterConfig)
+{
+    Write-Verbose -Message ('There are no enabled network adapters with IP enabled in this system. Integration tests will be skipped.') -Verbose
+    return
+}
+Write-Verbose -Message ('A network adapter ({0}) was found in this system that meets requirements for integration testing.' -f $netAdapter.Name) -Verbose
+
+#region HEADER
+# Integration Test Template Version: 1.1.0
+[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
+
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Integration
+#endregion
+
+# Using try/finally to always cleanup even if something awful happens.
+try
+{
+    $ConfigFile = Join-Path -Path $PSScriptRoot -ChildPath "$($script:DSCResourceName).config.ps1"
+    . $ConfigFile
+
+    # Store the current WINS settings
+    $enableDnsRegistryKey = Get-ItemProperty `
+        -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' `
+        -Name EnableDNS `
+        -ErrorAction SilentlyContinue
+
+    if ($enableDnsRegistryKey)
+    {
+        $currentEnableDNS = ($enableDnsRegistryKey.EnableDNS -eq 1)
+    }
+    else
+    {
+        # if the key does not exist, then set the default which is enabled.
+        $currentEnableDNS = $true
+    }
+
+    $enableLMHostsRegistryKey = Get-ItemProperty `
+        -Path 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' `
+        -Name EnableLMHOSTS `
+        -ErrorAction SilentlyContinue
+
+    $currentEnableLMHOSTS = ($enableLMHOSTSRegistryKey.EnableLMHOSTS -eq 1)
+
+    # Set the WINS settings to known values
+    $null = Invoke-CimMethod `
+        -ClassName Win32_NetworkAdapterConfiguration `
+        -MethodName EnableWins `
+        -Arguments @{
+            DNSEnabledForWINSResolution = $true
+            WINSEnableLMHostsLookup     = $true
+        }
+
+    Describe "$($script:DSCResourceName)_Integration" {
+        Context 'Disable all settings' {
+            $configData = @{
+                AllNodes = @(
+                    @{
+                        NodeName      = 'localhost'
+                        EnableLMHOSTS = $false
+                        EnableDNS     = $false
+                    }
+                )
+            }
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+
+                    Start-DscConfiguration `
+                        -Path $TestDrive `
+                        -ComputerName localhost `
+                        -Wait `
+                        -Verbose `
+                        -Force `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all setting should match current state' {
+                $result = Get-DscConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $result.EnableLMHOSTS | Should -Be $false
+                $result.EnableDNS | Should -Be $false
+            }
+        }
+
+        Context 'Enable all settings' {
+            $configData = @{
+                AllNodes = @(
+                    @{
+                        NodeName      = 'localhost'
+                        EnableLMHOSTS = $true
+                        EnableDNS     = $true
+                    }
+                )
+            }
+
+            It 'Should compile and apply the MOF without throwing' {
+                {
+                    & "$($script:DSCResourceName)_Config" `
+                        -OutputPath $TestDrive `
+                        -ConfigurationData $configData
+
+                    Start-DscConfiguration `
+                        -Path $TestDrive `
+                        -ComputerName localhost `
+                        -Wait `
+                        -Verbose `
+                        -Force `
+                        -ErrorAction Stop
+                } | Should -Not -Throw
+            }
+
+            It 'Should be able to call Get-DscConfiguration without throwing' {
+                { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+            }
+
+            It 'Should have set the resource and all setting should match current state' {
+                $result = Get-DscConfiguration | Where-Object -FilterScript {
+                    $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+                }
+                $result.EnableLMHOSTS | Should -Be $true
+                $result.EnableDNS | Should -Be $true
+            }
+        }
+    }
+}
+finally
+{
+    # Restore the WINS settings
+    $null = Invoke-CimMethod `
+        -ClassName Win32_NetworkAdapterConfiguration `
+        -MethodName EnableWins `
+        -Arguments @{
+            DNSEnabledForWINSResolution = $currentEnableDNS
+            WINSEnableLMHostsLookup     = $currentEnableLMHOSTS
+        }
+
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}

--- a/Tests/Integration/MSFT_xWinsSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWinsSetting.Integration.Tests.ps1
@@ -72,7 +72,7 @@ try
         -Name EnableLMHOSTS `
         -ErrorAction SilentlyContinue
 
-    $currentEnableLMHOSTS = ($enableLMHOSTSRegistryKey.EnableLMHOSTS -eq 1)
+    $currentEnableLmHosts = ($enableLMHOSTSRegistryKey.EnableLMHOSTS -eq 1)
 
     # Set the WINS settings to known values
     $null = Invoke-CimMethod `
@@ -85,12 +85,12 @@ try
 
     Describe "$($script:DSCResourceName)_Integration" {
         Context 'Disable all settings' {
-            $configData = @{
+            $configurationData = @{
                 AllNodes = @(
                     @{
                         NodeName      = 'localhost'
-                        EnableLMHOSTS = $false
-                        EnableDNS     = $false
+                        EnableLmHosts = $false
+                        EnableDns     = $false
                     }
                 )
             }
@@ -99,7 +99,7 @@ try
                 {
                     & "$($script:DSCResourceName)_Config" `
                         -OutputPath $TestDrive `
-                        -ConfigurationData $configData
+                        -ConfigurationData $configurationData
 
                     Start-DscConfiguration `
                         -Path $TestDrive `
@@ -119,18 +119,18 @@ try
                 $result = Get-DscConfiguration | Where-Object -FilterScript {
                     $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
                 }
-                $result.EnableLMHOSTS | Should -Be $false
-                $result.EnableDNS | Should -Be $false
+                $result.EnableLmHosts | Should -Be $false
+                $result.EnableDns | Should -Be $false
             }
         }
 
         Context 'Enable all settings' {
-            $configData = @{
+            $configurationData = @{
                 AllNodes = @(
                     @{
                         NodeName      = 'localhost'
-                        EnableLMHOSTS = $true
-                        EnableDNS     = $true
+                        EnableLmHosts = $true
+                        EnableDns     = $true
                     }
                 )
             }
@@ -139,7 +139,7 @@ try
                 {
                     & "$($script:DSCResourceName)_Config" `
                         -OutputPath $TestDrive `
-                        -ConfigurationData $configData
+                        -ConfigurationData $configurationData
 
                     Start-DscConfiguration `
                         -Path $TestDrive `
@@ -159,8 +159,8 @@ try
                 $result = Get-DscConfiguration | Where-Object -FilterScript {
                     $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
                 }
-                $result.EnableLMHOSTS | Should -Be $true
-                $result.EnableDNS | Should -Be $true
+                $result.EnableLmHosts | Should -Be $true
+                $result.EnableDns | Should -Be $true
             }
         }
     }
@@ -172,8 +172,8 @@ finally
         -ClassName Win32_NetworkAdapterConfiguration `
         -MethodName EnableWins `
         -Arguments @{
-            DNSEnabledForWINSResolution = $currentEnableDNS
-            WINSEnableLMHostsLookup     = $currentEnableLMHOSTS
+            DNSEnabledForWINSResolution = $currentEnableDns
+            WINSEnableLMHostsLookup     = $currentEnableLmHosts
         }
 
     #region FOOTER

--- a/Tests/Integration/MSFT_xWinsSetting.config.ps1
+++ b/Tests/Integration/MSFT_xWinsSetting.config.ps1
@@ -1,0 +1,12 @@
+Configuration MSFT_xWinsSetting_Config {
+    Import-DscResource -ModuleName xNetworking
+
+    node localhost {
+        xWinsSetting Integration_Test
+        {
+            IsSingleInstance = 'Yes'
+            EnableLMHOSTS    = $Node.EnableLMHOSTS
+            EnableDNS        = $Node.EnableDNS
+        }
+    }
+}

--- a/Tests/Integration/MSFT_xWinsSetting.config.ps1
+++ b/Tests/Integration/MSFT_xWinsSetting.config.ps1
@@ -5,8 +5,8 @@ Configuration MSFT_xWinsSetting_Config {
         xWinsSetting Integration_Test
         {
             IsSingleInstance = 'Yes'
-            EnableLMHOSTS    = $Node.EnableLMHOSTS
-            EnableDNS        = $Node.EnableDNS
+            EnableLmHosts    = $Node.EnableLmHosts
+            EnableDns        = $Node.EnableDns
         }
     }
 }

--- a/Tests/Unit/MSFT_xWinsSetting.Tests.ps1
+++ b/Tests/Unit/MSFT_xWinsSetting.Tests.ps1
@@ -1,0 +1,270 @@
+$script:DSCModuleName = 'xNetworking'
+$script:DSCResourceName = 'MSFT_xWinsSetting'
+
+#region HEADER
+# Unit Test Template Version: 1.1.0
+[string] $script:moduleRoot = Join-Path -Path $(Split-Path -Parent (Split-Path -Parent (Split-Path -Parent $Script:MyInvocation.MyCommand.Path))) -ChildPath 'Modules\xNetworking'
+if ( (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests'))) -or `
+    (-not (Test-Path -Path (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1'))) )
+{
+    & git @('clone', 'https://github.com/PowerShell/DscResource.Tests.git', (Join-Path -Path $script:moduleRoot -ChildPath '\DSCResource.Tests\'))
+}
+
+Import-Module (Join-Path -Path $script:moduleRoot -ChildPath 'DSCResource.Tests\TestHelper.psm1') -Force
+$TestEnvironment = Initialize-TestEnvironment `
+    -DSCModuleName $script:DSCModuleName `
+    -DSCResourceName $script:DSCResourceName `
+    -TestType Unit
+#endregion HEADER
+
+# Begin Testing
+try
+{
+    #region Pester Tests
+    InModuleScope $script:DSCResourceName {
+        # Create the Mock Objects that will be used for running tests
+        $mockEnabledLmHostsRegistryKey = [PSObject] @{
+            EnableLMHosts = 1
+        }
+
+        $mockDisabledLmHostsRegistryKey = [PSObject] @{
+            EnableLMHosts = 0
+        }
+
+        $mockEnabledDNSRegistryKey = [PSObject] @{
+            EnableDNS = 1
+        }
+
+        $mockDisabledDNSRegistryKey = [PSObject] @{
+            EnableDNS = 0
+        }
+
+        $mockGetTargetResourceAllEnabled = [PSObject] @{
+            IsSingleInstance = 'Yes'
+            EnableLMHOSTS    = $true
+            EnableDNS        = $true
+        }
+
+        $mockGetTargetResourceAllDisabled = [PSObject] @{
+            IsSingleInstance = 'Yes'
+            EnableLMHOSTS    = $false
+            EnableDNS        = $false
+        }
+
+        Describe 'MSFT_xWinsSetting\Get-TargetResource' {
+            Context 'EnableLMHosts is enabled and EnableDNS is enabled' {
+                Mock `
+                    -CommandName Get-ItemProperty `
+                    -ParameterFilter {
+                    $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' -and $Name -eq 'EnableLMHOSTS'
+                } `
+                    -MockWith {
+                    $mockEnabledLmHostsRegistryKey
+                }
+
+                Mock `
+                    -CommandName Get-ItemProperty `
+                    -ParameterFilter {
+                    $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' -and $Name -eq 'EnableDNS'
+                } `
+                    -MockWith {
+                    $mockEnabledDNSRegistryKey
+                }
+
+                It 'Should not throw an exception' {
+                    { $script:result = Get-TargetResource -IsSingleInstance 'Yes' -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return expected results' {
+                    $script:result.EnableLMHOSTS | Should Be $true
+                    $script:result.EnableDNS | Should Be $true
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 2
+                }
+            }
+
+            Context 'EnableLMHosts is disabled and EnableDNS is disabled' {
+                Mock `
+                    -CommandName Get-ItemProperty `
+                    -ParameterFilter {
+                    $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' -and $Name -eq 'EnableLMHOSTS'
+                } `
+                    -MockWith {
+                    $mockDisabledLmHostsRegistryKey
+                }
+
+                Mock `
+                    -CommandName Get-ItemProperty `
+                    -ParameterFilter {
+                    $Path -eq 'HKLM:\SYSTEM\CurrentControlSet\Services\NetBT\Parameters' -and $Name -eq 'EnableDNS'
+                } `
+                    -MockWith {
+                    $mockDisabledDNSRegistryKey
+                }
+
+                It 'Should not throw an exception' {
+                    { $script:result = Get-TargetResource -IsSingleInstance 'Yes' -Verbose } | Should -Not -Throw
+                }
+
+                It 'Should return expected results' {
+                    $script:result.EnableLMHOSTS | Should Be $false
+                    $script:result.EnableDNS | Should Be $false
+                }
+
+                It 'Should call the expected mocks' {
+                    Assert-MockCalled -CommandName Get-ItemProperty -Exactly -Times 2
+                }
+            }
+        }
+
+        Describe 'MSFT_xDnsClientGlobalSetting\Set-TargetResource' {
+            BeforeEach {
+                Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourceAllEnabled }
+            }
+
+            Context 'Set EnableLMHosts to enabled and EnableDNS to enabled' {
+                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 0 } }
+
+                It 'Should not throw an exception' {
+                    {
+                        Set-TargetResource -IsSingleInstance 'Yes' -EnableLMHosts $true -EnableDNS $true -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Invoke-CimMethod -Exactly -Times 1
+                }
+            }
+
+            Context 'Set EnableLMHosts to disabled and EnableDNS to disabled' {
+                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 0 } }
+
+                It 'Should not throw an exception' {
+                    {
+                        Set-TargetResource -IsSingleInstance 'Yes' -EnableLMHosts $false -EnableDNS $false -Verbose
+                    } | Should -Not -Throw
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Invoke-CimMethod -Exactly -Times 1
+                }
+            }
+
+            Context 'Set EnableLMHosts and EnableDNS but Invoke-CimMethod returns error' {
+                Mock -CommandName Invoke-CimMethod -MockWith { @{ ReturnValue = 74 } }
+
+                $errorRecord = Get-InvalidOperationRecord `
+                    -Message ($LocalizedData.FailedUpdatingWinsSettingError -f 74, 'Enable')
+
+                It 'Should throw an exception' {
+                    {
+                        Set-TargetResource -IsSingleInstance 'Yes' -EnableLMHosts $true -EnableDNS $true -Verbose
+                    } | Should -Throw $errorRecord
+                }
+
+                It 'Should call expected Mocks' {
+                    Assert-MockCalled -commandName Invoke-CimMethod -Exactly -Times 1
+                }
+            }
+        }
+
+        Describe 'MSFT_xDnsClientGlobalSetting\Test-TargetResource' {
+            Context 'EnableLMHosts is enabled and EnableDNS is enabled' {
+                Context 'Set EnableLMHosts to true and EnableDNS to true' {
+                    Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourceAllEnabled }
+
+                    It 'Should not throw an exception' {
+                        {
+                            $script:result = Test-TargetResource -IsSingleInstance 'Yes' -EnableLMHosts $true -EnableDNS $true -Verbose
+                        } | Should -Not -Throw
+                    }
+
+                    It 'Should return true' {
+                        $script:result | Should -Be $true
+                    }
+                }
+
+                Context 'Set EnableLMHosts to false' {
+                    Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourceAllEnabled }
+
+                    It 'Should not throw an exception' {
+                        {
+                            $script:result = Test-TargetResource -IsSingleInstance 'Yes' -EnableLMHosts $false -Verbose
+                        } | Should -Not -Throw
+                    }
+
+                    It 'Should return false' {
+                        $script:result | Should -Be $false
+                    }
+                }
+
+                Context 'Set EnableDNS to false' {
+                    Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourceAllEnabled }
+
+                    It 'Should not throw an exception' {
+                        {
+                            $script:result = Test-TargetResource -IsSingleInstance 'Yes' -EnableDNS $false -Verbose
+                        } | Should -Not -Throw
+                    }
+
+                    It 'Should return false' {
+                        $script:result | Should -Be $false
+                    }
+                }
+            }
+
+            Context 'EnableLMHosts is disabled and EnableDNS is disabled' {
+                Context 'Set EnableLMHosts to false and EnableDNS to false' {
+                    Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourceAllDisabled }
+
+                    It 'Should not throw an exception' {
+                        {
+                            $script:result = Test-TargetResource -IsSingleInstance 'Yes' -EnableLMHosts $false -EnableDNS $false -Verbose
+                        } | Should -Not -Throw
+                    }
+
+                    It 'Should return true' {
+                        $script:result | Should -Be $true
+                    }
+                }
+
+                Context 'Set EnableLMHosts to true' {
+                    Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourceAllDisabled }
+
+                    It 'Should not throw an exception' {
+                        {
+                            $script:result = Test-TargetResource -IsSingleInstance 'Yes' -EnableLMHosts $true -Verbose
+                        } | Should -Not -Throw
+                    }
+
+                    It 'Should return false' {
+                        $script:result | Should -Be $false
+                    }
+                }
+
+                Context 'Set EnableDNS to true' {
+                    Mock -CommandName Get-TargetResource -MockWith { $mockGetTargetResourceAllDisabled }
+
+                    It 'Should not throw an exception' {
+                        {
+                            $script:result = Test-TargetResource -IsSingleInstance 'Yes' -EnableDNS $true -Verbose
+                        } | Should -Not -Throw
+                    }
+
+                    It 'Should return false' {
+                        $script:result | Should -Be $false
+                    }
+                }
+            }
+        }
+    }
+    #endregion
+}
+finally
+{
+    #region FOOTER
+    Restore-TestEnvironment -TestEnvironment $TestEnvironment
+    #endregion
+}


### PR DESCRIPTION
**Pull Request (PR) description**
This PR adds the xWinsSetting resource for configuring global WINS settings. It specifically allows enabling of LMHOSTS lookups and enabling/disabling of DNS resolution using WINS.

**This Pull Request (PR) fixes the following issues:**
- Fixes #302 
- Relates to #199 but does not fully complete it (another resource xWinsServer is required).

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

@johlju - would you mind reviewing when you get a chance? I based this around the code you pasted in #199. I'll plan to implement a WINS server resource at some point, but to be honest it is a low priority (I'm a little bit surprised anyone is still using WINS at all :wink:).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/304)
<!-- Reviewable:end -->
