### PR TITLE
Updated xNetworkTeam to meet HQRM guidelines - Fixes #306

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,9 +10,12 @@
   - Converted exceptions to use ResourceHelper functions.
 - MSFT_xNetBIOS:
   - Corrected style and formatting to meet HQRM guidelines.
+  - Ensured CommonTestHelper.psm1 is loaded before running unit tests.
 - MSFT_xNetworkTeam:
   - Corrected style and formatting to meet HQRM guidelines.
   - Added missing default from MOF description of Ensure parameter.
+- MSFT_xNetConnectionProfile:
+  - Corrected style and formatting to meet HQRM guidelines.
 
 ## 5.5.0.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,15 @@
   - Corrected style and formatting to meet HQRM guidelines.
   - Updated tests to meet Pester v4 guidelines.
   - Converted exceptions to use ResourceHelper functions.
+  - Changed unit tests to output Verbose logs.
 - MSFT_xNetBIOS:
   - Corrected style and formatting to meet HQRM guidelines.
   - Ensured CommonTestHelper.psm1 is loaded before running unit tests.
 - MSFT_xNetworkTeam:
   - Corrected style and formatting to meet HQRM guidelines.
   - Added missing default from MOF description of Ensure parameter.
+  - Fixed `Get-TargetResource` to always output Ensure parameter.
+  - Changed unit tests to output Verbose logs.
 - MSFT_xNetConnectionProfile:
   - Corrected style and formatting to meet HQRM guidelines.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,15 @@
 
 - Reordered resource list in README.MD to be alphabetical and added
   missing resource xNetAdapterAdvancedProperty - Fixes [issue #309](https://github.com/PowerShell/xNetworking/issues/309).
+- MSFT_xNetworkTeamInterface:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Updated tests to meet Pester v4 guidelines.
+  - Converted exceptions to use ResourceHelper functions.
+- MSFT_xNetBIOS:
+  - Corrected style and formatting to meet HQRM guidelines.
+- MSFT_xNetworkTeam:
+  - Corrected style and formatting to meet HQRM guidelines.
+  - Added missing default from MOF description of Ensure parameter.
 
 ## 5.5.0.0
 

--- a/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.psm1
@@ -52,11 +52,11 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("Default", "Enable", "Disable")]
         [System.String]
         $Setting
@@ -114,11 +114,11 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("Default", "Enable", "Disable")]
         [System.String]
         $Setting
@@ -193,11 +193,11 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [ValidateSet("Default", "Enable", "Disable")]
         [System.String]
         $Setting

--- a/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/MSFT_xNetConnectionProfile.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetConnectionProfile/MSFT_xNetConnectionProfile.psm1
@@ -29,7 +29,7 @@ function Get-TargetResource
     param
     (
         [Parameter(Position = 0, Mandatory = $true)]
-        [string]
+        [System.String]
         $InterfaceAlias
     )
 
@@ -69,19 +69,22 @@ function Set-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [string]
+        [System.String]
         $InterfaceAlias,
 
+        [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
-        [string]
+        [System.String]
         $IPv4Connectivity,
 
+        [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
-        [string]
+        [System.String]
         $IPv6Connectivity,
 
+        [Parameter()]
         [ValidateSet('Public', 'Private')]
-        [string]
+        [System.String]
         $NetworkCategory
     )
 
@@ -117,22 +120,22 @@ function Test-TargetResource
     param
     (
         [Parameter(Mandatory = $true)]
-        [string]
+        [System.String]
         $InterfaceAlias,
 
         [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
-        [string]
+        [System.String]
         $IPv4Connectivity,
 
         [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
-        [string]
+        [System.String]
         $IPv6Connectivity,
 
         [Parameter()]
         [ValidateSet('Public', 'Private')]
-        [string]
+        [System.String]
         $NetworkCategory
     )
 
@@ -140,7 +143,7 @@ function Test-TargetResource
 
     $current = Get-TargetResource -InterfaceAlias $InterfaceAlias
 
-    if (-not [String]::IsNullOrEmpty($IPv4Connectivity) -and `
+    if (-not [System.String]::IsNullOrEmpty($IPv4Connectivity) -and `
         ($IPv4Connectivity -ne $current.IPv4Connectivity))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -150,7 +153,7 @@ function Test-TargetResource
         return $false
     }
 
-    if (-not [String]::IsNullOrEmpty($IPv6Connectivity) -and `
+    if (-not [System.String]::IsNullOrEmpty($IPv6Connectivity) -and `
         ($IPv6Connectivity -ne $current.IPv6Connectivity))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -160,7 +163,7 @@ function Test-TargetResource
         return $false
     }
 
-    if (-not [String]::IsNullOrEmpty($NetworkCategory) -and `
+    if (-not [System.String]::IsNullOrEmpty($NetworkCategory) -and `
         ($NetworkCategory -ne $current.NetworkCategory))
     {
         Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -197,22 +200,22 @@ function Assert-ResourceProperty
     param
     (
         [Parameter(Mandatory = $true)]
-        [string]
+        [System.String]
         $InterfaceAlias,
 
         [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
-        [string]
+        [System.String]
         $IPv4Connectivity,
 
         [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
-        [string]
+        [System.String]
         $IPv6Connectivity,
 
         [Parameter()]
         [ValidateSet('Public', 'Private')]
-        [string]
+        [System.String]
         $NetworkCategory
     )
 
@@ -222,9 +225,9 @@ function Assert-ResourceProperty
             -Message ($LocalizedData.InterfaceNotAvailableError -f $InterfaceAlias)
     }
 
-    if ([String]::IsNullOrEmpty($IPv4Connectivity) -and `
-        [String]::IsNullOrEmpty($IPv6Connectivity) -and `
-        [String]::IsNullOrEmpty($NetworkCategory))
+    if ([System.String]::IsNullOrEmpty($IPv4Connectivity) -and `
+        [System.String]::IsNullOrEmpty($IPv6Connectivity) -and `
+        [System.String]::IsNullOrEmpty($NetworkCategory))
     {
         New-InvalidOperationException `
             -Message ($LocalizedData.ParameterCombinationError)

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.psm1
@@ -44,6 +44,7 @@ Function Get-TargetResource
     $configuration = @{
         Name        = $Name
         TeamMembers = $TeamMembers
+        Ensure      = 'Absent'
     }
 
     Write-Verbose -Message ($localizedData.GetTeamInfo -f $Name)
@@ -52,18 +53,22 @@ Function Get-TargetResource
     if ($networkTeam)
     {
         Write-Verbose -Message ($localizedData.FoundTeam -f $Name)
+        $configuration.Add('LoadBalancingAlgorithm', $networkTeam.LoadBalancingAlgorithm)
+        $configuration.Add('TeamingMode', $networkTeam.TeamingMode)
+
         if ($null -eq (Compare-Object -ReferenceObject $TeamMembers -DifferenceObject $networkTeam.Members))
         {
-            Write-Verbose -Message ($localizedData.TeamMembersExist -f $Name)
-            $configuration.Add('LoadBalancingAlgorithm', $networkTeam.loadBalancingAlgorithm)
-            $configuration.Add('TeamingMode', $networkTeam.teamingMode)
-            $configuration.Add('Ensure', 'Present')
+            Write-Verbose -Message ($localizedData.TeamMembersMatch -f $Name)
+            $configuration.Ensure = 'Present'
+        }
+        else
+        {
+            Write-Verbose -Message ($localizedData.TeamMembersNotMatch -f $Name)
         }
     }
     else
     {
         Write-Verbose -Message ($localizedData.TeamNotFound -f $Name)
-        $configuration.Add('Ensure', 'Absent')
     }
 
     return $configuration

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.psm1
@@ -112,6 +112,7 @@ Function Set-TargetResource
         [System.String]
         $LoadBalancingAlgorithm = 'HyperVPort',
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present'
@@ -267,6 +268,7 @@ Function Test-TargetResource
         [System.String]
         $LoadBalancingAlgorithm = 'HyperVPort',
 
+        [Parameter()]
         [ValidateSet('Present', 'Absent')]
         [System.String]
         $Ensure = 'Present'

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.schema.mof
@@ -5,5 +5,5 @@ class MSFT_xNetworkTeam : OMI_BaseResource
     [Required, Description("Specifies the network interfaces that should be a part of the network team. This is a comma-separated list.")] String TeamMembers[];
     [Write, Description("Specifies the teaming mode configuration."), ValueMap{"SwitchIndependent","LACP","Static"}, Values{"SwitchIndependent","LACP","Static"}] String TeamingMode;
     [Write, Description("Specifies the load balancing algorithm for the network team."), ValueMap{"Dynamic","HyperVPort","IPAddresses","MacAddresses","TransportPorts"}, Values{"Dynamic","HyperVPort","IPAddresses","MacAddresses","TransportPorts"}] String LoadBalancingAlgorithm;
-    [Write, Description("Specifies if the network team should be created or deleted. Defaults to Present.), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies if the network team should be created or deleted. Defaults to 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.schema.mof
@@ -5,5 +5,5 @@ class MSFT_xNetworkTeam : OMI_BaseResource
     [Required, Description("Specifies the network interfaces that should be a part of the network team. This is a comma-separated list.")] String TeamMembers[];
     [Write, Description("Specifies the teaming mode configuration."), ValueMap{"SwitchIndependent","LACP","Static"}, Values{"SwitchIndependent","LACP","Static"}] String TeamingMode;
     [Write, Description("Specifies the load balancing algorithm for the network team."), ValueMap{"Dynamic","HyperVPort","IPAddresses","MacAddresses","TransportPorts"}, Values{"Dynamic","HyperVPort","IPAddresses","MacAddresses","TransportPorts"}] String LoadBalancingAlgorithm;
-    [Write, Description("Specifies if the network team should be created or deleted. Defaults to 'Present'.), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies if the network team should be created or deleted. Defaults to Present.), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/MSFT_xNetworkTeam.schema.mof
@@ -5,5 +5,5 @@ class MSFT_xNetworkTeam : OMI_BaseResource
     [Required, Description("Specifies the network interfaces that should be a part of the network team. This is a comma-separated list.")] String TeamMembers[];
     [Write, Description("Specifies the teaming mode configuration."), ValueMap{"SwitchIndependent","LACP","Static"}, Values{"SwitchIndependent","LACP","Static"}] String TeamingMode;
     [Write, Description("Specifies the load balancing algorithm for the network team."), ValueMap{"Dynamic","HyperVPort","IPAddresses","MacAddresses","TransportPorts"}, Values{"Dynamic","HyperVPort","IPAddresses","MacAddresses","TransportPorts"}] String LoadBalancingAlgorithm;
-    [Write, Description("Specifies if the network team should be created or deleted."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies if the network team should be created or deleted. Defaults to 'Present'.), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/en-US/MSFT_xNetworkTeam.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeam/en-US/MSFT_xNetworkTeam.strings.psd1
@@ -3,7 +3,8 @@
 ConvertFrom-StringData @'
     GetTeamInfo = Getting network team information for '{0}'.
     FoundTeam = Found a network team with name '{0}'.
-    TeamMembersExist = Members in the network team '{0}' exist as per the configuration.
+    TeamMembersMatch = Members in the network team '{0}' exist as per the configuration.
+    TeamMembersNotMatch = Members in the network team '{0}' do not match configuration.
     TeamNotFound = Network team with name '{0}' not found.
     LoadBalancingAlgorithmDifferent = Load Balancing algorithm is different from the requested '{0}' algorithm.
     TeamingModeDifferent = Teaming mode is different from the requested '{0}' mode.

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
@@ -47,12 +47,12 @@ function Get-TargetResource
 
     Write-Verbose -Message ($localizedData.GetTeamNicInfo -f $Name)
 
-    $getNetLbfoTeamNic_parameters = @{
+    $getNetLbfoTeamNicParameters = @{
         Name        = $Name
         Team        = $TeamName
         ErrorAction = 'SilentlyContinue'
     }
-    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNic_parameters
+    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNicParameters
 
     if ($teamNic)
     {
@@ -112,12 +112,12 @@ function Set-TargetResource
 
     Write-Verbose -Message ($LocalizedData.GetTeamNicInfo -f $Name)
 
-    $getNetLbfoTeamNic_parameters = @{
+    $getNetLbfoTeamNicParameters = @{
         Name        = $Name
         Team        = $TeamName
         ErrorAction = 'SilentlyContinue'
     }
-    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNic_parameters
+    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNicParameters
 
     if ($Ensure -eq 'Present')
     {
@@ -138,14 +138,14 @@ function Set-TargetResource
 
                 if ($VlanId -eq 0)
                 {
-                    $setNetLbfoTeamNic_parameters = @{
+                    $setNetLbfoTeamNicParameters = @{
                         Name        = $Name
                         Team        = $TeamName
                         Default     = $true
                         ErrorAction = 'Stop'
                         Confirm     = $false
                     }
-                    Set-NetLbfoTeamNic @setNetLbfoTeamNic_parameters
+                    Set-NetLbfoTeamNic @setNetLbfoTeamNicParameters
                 }
                 else
                 {
@@ -153,20 +153,20 @@ function Set-TargetResource
                         Required in case of primary interface, whose name gets changed
                         to include VLAN ID, if specified
                     #>
-                    $setNetLbfoTeamNic_parameters = @{
+                    $setNetLbfoTeamNicParameters = @{
                         Name        = $Name
                         Team        = $TeamName
                         VlanId      = $VlanId
                         ErrorAction = 'Stop'
                         Confirm     = $false
                     }
-                    $renameNetAdapter_parameters = @{
+                    $renameNetAdapterParameters = @{
                         NewName     = $Name
                         ErrorAction = 'SilentlyContinue'
                         Confirm     = $false
                     }
-                    $null = Set-NetLbfoTeamNic @setNetLbfoTeamNic_parameters |
-                        Rename-NetAdapter @renameNetAdapter_parameters
+                    $null = Set-NetLbfoTeamNic @setNetLbfoTeamNicParameters |
+                        Rename-NetAdapter @renameNetAdapterParameters
                 }
             }
         }
@@ -176,14 +176,14 @@ function Set-TargetResource
 
             if ($VlanId -ne 0)
             {
-                $addNetLbfoTeamNic_parameters = @{
+                $addNetLbfoTeamNicParameters = @{
                     Name        = $Name
                     Team        = $TeamName
                     VlanId      = $VlanId
                     ErrorAction = 'Stop'
                     Confirm     = $false
                 }
-                $null = Add-NetLbfoTeamNic @addNetLbfoTeamNic_parameters
+                $null = Add-NetLbfoTeamNic @addNetLbfoTeamNicParameters
 
                 Write-Verbose -Message ($LocalizedData.CreatedNetTeamNic -f $Name)
             }
@@ -198,13 +198,13 @@ function Set-TargetResource
     {
         Write-Verbose -Message ($LocalizedData.RemoveTeamNic -f $Name)
 
-        $removeNetLbfoTeamNic_parameters = @{
+        $removeNetLbfoTeamNicParameters = @{
             Team        = $teamNic.Team
             VlanId      = $teamNic.VlanId
             ErrorAction = 'Stop'
             Confirm     = $false
         }
-        $null = Remove-NetLbfoTeamNic @removeNetLbfoTeamNic_parameters
+        $null = Remove-NetLbfoTeamNic @removeNetLbfoTeamNicParameters
     }
 }
 
@@ -250,12 +250,12 @@ function Test-TargetResource
 
     Write-Verbose -Message ($LocalizedData.GetTeamNicInfo -f $Name)
 
-    $getNetLbfoTeamNic_parameters = @{
+    $getNetLbfoTeamNicParameters = @{
         Name        = $Name
         Team        = $TeamName
         ErrorAction = 'SilentlyContinue'
     }
-    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNic_parameters
+    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNicParameters
 
     if ($VlanId -eq 0)
     {

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.psm1
@@ -2,13 +2,13 @@ $modulePath = Join-Path -Path (Split-Path -Path (Split-Path -Path $PSScriptRoot 
 
 # Import the Networking Common Modules
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
-                                                     -ChildPath 'NetworkingDsc.Common.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.Common' `
+            -ChildPath 'NetworkingDsc.Common.psm1'))
 
 # Import the Networking Resource Helper Module
 Import-Module -Name (Join-Path -Path $modulePath `
-                               -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
-                                                     -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
+        -ChildPath (Join-Path -Path 'NetworkingDsc.ResourceHelper' `
+            -ChildPath 'NetworkingDsc.ResourceHelper.psm1'))
 
 # Import Localization Strings
 $localizedData = Get-LocalizedData `
@@ -17,7 +17,7 @@ $localizedData = Get-LocalizedData `
 
 <#
     .SYNOPSIS
-    Returns the current state of a Network Team Interface in a Network Team.
+    Returns the current state of a network team interface in a Network Team.
 
     .PARAMETER Name
     Specifies the name of the network team interface to create.
@@ -31,33 +31,41 @@ function Get-TargetResource
     [OutputType([System.Collections.Hashtable])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $TeamName
     )
 
     $configuration = @{
-        name     = $Name
-        teamName = $TeamName
+        Name     = $Name
+        TeamName = $TeamName
     }
 
     Write-Verbose -Message ($localizedData.GetTeamNicInfo -f $Name)
-    $teamNic = Get-NetLbfoTeamNic -Name $Name -Team $TeamName -ErrorAction SilentlyContinue
+
+    $getNetLbfoTeamNic_parameters = @{
+        Name        = $Name
+        Team        = $TeamName
+        ErrorAction = 'SilentlyContinue'
+    }
+    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNic_parameters
 
     if ($teamNic)
     {
         Write-Verbose -Message ($localizedData.FoundTeamNic -f $Name)
-        $configuration.Add("vlanID", $teamNic.VlanID)
-        $configuration.Add("ensure", "Present")
+
+        $configuration.Add('VlanId', $teamNic.VlanId)
+        $configuration.Add('Ensure', 'Present')
     }
     else
     {
         Write-Verbose -Message ($localizedData.TeamNicNotFound -f $Name)
-        $configuration.Add("ensure", "Absent")
+
+        $configuration.Add('Ensure', 'Absent')
     }
 
     return $configuration
@@ -65,7 +73,7 @@ function Get-TargetResource
 
 <#
     .SYNOPSIS
-    Adds, updates or removes a Network Team Interface from a Network Team.
+    Adds, updates or removes a network team interface from a Network Team.
 
     .PARAMETER Name
     Specifies the name of the network team interface to create.
@@ -73,8 +81,8 @@ function Get-TargetResource
     .PARAMETER TeamName
     Specifies the name of the network team on which this particular interface should exist.
 
-    .PARAMETER VlanID
-    Specifies VlanID to be set on network team interface.
+    .PARAMETER VlanId
+    Specifies VlanId to be set on network team interface.
 
     .PARAMETER Ensure
     Specifies if the network team interface should be created or deleted.
@@ -84,83 +92,119 @@ function Set-TargetResource
     [CmdletBinding()]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $TeamName,
 
+        [Parameter()]
         [System.UInt32]
-        $VlanID,
+        $VlanId,
 
-        [ValidateSet("Present","Absent")]
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure = "Present"
+        $Ensure = 'Present'
     )
 
     Write-Verbose -Message ($LocalizedData.GetTeamNicInfo -f $Name)
-    $teamNic = Get-NetLbfoTeamNic -Name $Name -Team $TeamName -ErrorAction SilentlyContinue
 
-    if ($Ensure -eq "Present")
+    $getNetLbfoTeamNic_parameters = @{
+        Name        = $Name
+        Team        = $TeamName
+        ErrorAction = 'SilentlyContinue'
+    }
+    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNic_parameters
+
+    if ($Ensure -eq 'Present')
     {
         if ($teamNic)
         {
             Write-Verbose -Message ($LocalizedData.FoundTeamNic -f $Name)
-            if ($teamNic.VlanID -ne $VlanID)
+
+            if ($teamNic.VlanId -ne $VlanId)
             {
-                Write-Verbose -Message ($LocalizedData.TeamNicVlanMismatch -f $VlanID)
+                Write-Verbose -Message ($LocalizedData.TeamNicVlanMismatch -f $VlanId)
+
                 $isNetModifyRequired = $true
             }
 
             if ($isNetModifyRequired)
             {
                 Write-Verbose -Message ($LocalizedData.ModifyTeamNic -f $Name)
-                if ($VlanID -eq 0)
+
+                if ($VlanId -eq 0)
                 {
-                    Set-NetLbfoTeamNic -Name $Name -Team $TeamName -Default `
-                                       -ErrorAction Stop -Confirm:$false
+                    $setNetLbfoTeamNic_parameters = @{
+                        Name        = $Name
+                        Team        = $TeamName
+                        Default     = $true
+                        ErrorAction = 'Stop'
+                        Confirm     = $false
+                    }
+                    Set-NetLbfoTeamNic @setNetLbfoTeamNic_parameters
                 }
                 else
                 {
-                    # Required in case of primary interface, whose name gets changed
-                    # to include VLAN ID, if specified
-                    Set-NetLbfoTeamNic -Name $Name -Team $TeamName -VlanID $VlanID `
-                                       -ErrorAction Stop -Confirm:$false -PassThru `
-                                       | Rename-NetAdapter -NewName $Name `
-                                                           -ErrorAction SilentlyContinue `
-                                                           -Confirm:$false
+                    <#
+                        Required in case of primary interface, whose name gets changed
+                        to include VLAN ID, if specified
+                    #>
+                    $setNetLbfoTeamNic_parameters = @{
+                        Name        = $Name
+                        Team        = $TeamName
+                        VlanId      = $VlanId
+                        ErrorAction = 'Stop'
+                        Confirm     = $false
+                    }
+                    $renameNetAdapter_parameters = @{
+                        NewName     = $Name
+                        ErrorAction = 'SilentlyContinue'
+                        Confirm     = $false
+                    }
+                    $null = Set-NetLbfoTeamNic @setNetLbfoTeamNic_parameters |
+                        Rename-NetAdapter @renameNetAdapter_parameters
                 }
             }
         }
         else
         {
             Write-Verbose -Message ($LocalizedData.CreateTeamNic -f $Name)
-            if ($VlanID -ne 0)
+
+            if ($VlanId -ne 0)
             {
-                $null = Add-NetLbfoTeamNic -Name $Name -Team $TeamName -VlanID $VlanID `
-                                           -ErrorAction Stop -Confirm:$false
+                $addNetLbfoTeamNic_parameters = @{
+                    Name        = $Name
+                    Team        = $TeamName
+                    VlanId      = $VlanId
+                    ErrorAction = 'Stop'
+                    Confirm     = $false
+                }
+                $null = Add-NetLbfoTeamNic @addNetLbfoTeamNic_parameters
+
                 Write-Verbose -Message ($LocalizedData.CreatedNetTeamNic -f $Name)
             }
             else
             {
-                $errorId = "TeamNicCreateError"
-                $errorCategory = [System.Management.Automation.ErrorCategory]::InvalidOperation
-                $errorMessage = $LocalizedData.FailedToCreateTeamNic
-                $exception = New-Object -TypeName System.InvalidOperationException `
-                                        -ArgumentList $errorMessage
-                $errorRecord = New-Object -TypeName System.Management.Automation.ErrorRecord `
-                                          -ArgumentList $exception, $errorId, $errorCategory, $null
-                $PSCmdlet.ThrowTerminatingError($errorRecord)
+                New-InvalidOperationException `
+                    -Message ($localizedData.FailedToCreateTeamNic)
             }
         }
     }
     else
     {
         Write-Verbose -Message ($LocalizedData.RemoveTeamNic -f $Name)
-        $null = Remove-NetLbfoTeamNic -Team $teamNic.Team -VlanID $teamNic.VlanID `
-                                      -ErrorAction Stop -Confirm:$false
+
+        $removeNetLbfoTeamNic_parameters = @{
+            Team        = $teamNic.Team
+            VlanId      = $teamNic.VlanId
+            ErrorAction = 'Stop'
+            Confirm     = $false
+        }
+        $null = Remove-NetLbfoTeamNic @removeNetLbfoTeamNic_parameters
     }
 }
 
@@ -174,8 +218,8 @@ function Set-TargetResource
     .PARAMETER TeamName
     Specifies the name of the network team on which this particular interface should exist.
 
-    .PARAMETER VlanID
-    Specifies VlanID to be set on network team interface.
+    .PARAMETER VlanId
+    Specifies VlanId to be set on network team interface.
 
     .PARAMETER Ensure
     Specifies if the network team interface should be created or deleted.
@@ -186,53 +230,65 @@ function Test-TargetResource
     [OutputType([System.Boolean])]
     param
     (
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
 
-        [parameter(Mandatory = $true)]
+        [Parameter(Mandatory = $true)]
         [System.String]
         $TeamName,
 
+        [Parameter()]
         [System.UInt32]
-        $VlanID,
+        $VlanId,
 
-        [ValidateSet("Present","Absent")]
+        [Parameter()]
+        [ValidateSet('Present', 'Absent')]
         [System.String]
-        $Ensure = "Present"
+        $Ensure = 'Present'
     )
 
     Write-Verbose -Message ($LocalizedData.GetTeamNicInfo -f $Name)
-    $teamNic = Get-NetLbfoTeamNic -Name $Name -Team $TeamName -ErrorAction SilentlyContinue
 
-    if ($VlanID -eq 0)
+    $getNetLbfoTeamNic_parameters = @{
+        Name        = $Name
+        Team        = $TeamName
+        ErrorAction = 'SilentlyContinue'
+    }
+    $teamNic = Get-NetLbfoTeamNic @getNetLbfoTeamNic_parameters
+
+    if ($VlanId -eq 0)
     {
         $VlanValue = $null
     }
     else
     {
-        $VlanValue = $VlanID
+        $VlanValue = $VlanId
     }
 
-    if ($Ensure -eq "Present")
+    if ($Ensure -eq 'Present')
     {
         if ($teamNic)
         {
             Write-Verbose -Message ($LocalizedData.FoundTeamNic -f $Name)
-            if ($teamNic.VlanID -eq $VlanValue)
+
+            if ($teamNic.VlanId -eq $VlanValue)
             {
                 Write-Verbose -Message ($LocalizedData.TeamNicExistsNoAction -f $Name)
+
                 return $true
             }
             else
             {
                 Write-Verbose -Message ($LocalizedData.TeamNicExistsWithDifferentConfig -f $Name)
+
                 return $false
             }
         }
         else
         {
             Write-Verbose -Message ($LocalizedData.TeamNicDoesNotExistShouldCreate -f $Name)
+
             return $false
         }
     }
@@ -241,11 +297,13 @@ function Test-TargetResource
         if ($teamNic)
         {
             Write-Verbose -Message ($LocalizedData.TeamNicExistsShouldRemove -f $Name)
+
             return $false
         }
         else
         {
             Write-Verbose -Message ($LocalizedData.TeamNicExistsNoAction -f $Name)
+
             return $true
         }
     }

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.schema.mof
@@ -5,5 +5,5 @@ class MSFT_xNetworkTeamInterface : OMI_BaseResource
     [Key, Description("Specifies the name of the network team interface to create.")] String Name;
     [Required, Description("Specifies the name of the network team on which this particular interface should exist.")] String TeamName;
     [Write, Description("Specifies VLAN ID to be set on network team interface.")] Uint32 VlanId;
-    [Write, Description("Specifies if the network team interface should be created or deleted. Defaults to 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies if the network team interface should be created or deleted. Defaults to Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.schema.mof
@@ -4,6 +4,6 @@ class MSFT_xNetworkTeamInterface : OMI_BaseResource
 {
     [Key, Description("Specifies the name of the network team interface to create.")] String Name;
     [Required, Description("Specifies the name of the network team on which this particular interface should exist.")] String TeamName;
-    [Write, Description("Specifies VlanID to be set on network team interface.")] Uint32 VlanID;
-    [Write, Description("Specifies if the network team interface should be created or deleted."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies VLAN ID to be set on network team interface.")] Uint32 VlanId;
+    [Write, Description("Specifies if the network team interface should be created or deleted. Defaults to 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.schema.mof
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/MSFT_xNetworkTeamInterface.schema.mof
@@ -5,5 +5,5 @@ class MSFT_xNetworkTeamInterface : OMI_BaseResource
     [Key, Description("Specifies the name of the network team interface to create.")] String Name;
     [Required, Description("Specifies the name of the network team on which this particular interface should exist.")] String TeamName;
     [Write, Description("Specifies VLAN ID to be set on network team interface.")] Uint32 VlanId;
-    [Write, Description("Specifies if the network team interface should be created or deleted. Defaults to Present."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
+    [Write, Description("Specifies if the network team interface should be created or deleted. Defaults to 'Present'."), ValueMap{"Present","Absent"}, Values{"Present","Absent"}] String Ensure;
 };

--- a/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/en-US/MSFT_xNetworkTeamInterface.strings.psd1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetworkTeamInterface/en-US/MSFT_xNetworkTeamInterface.strings.psd1
@@ -1,19 +1,19 @@
 # Localized resources for MSFT_xNetwrkTeamInterface
 
 ConvertFrom-StringData @"
-    getTeamNicInfo = Getting network team interface information for {0}.
-    foundTeamNic = Found a network team interface with name {0}.
-    teamNicNotFound = Network team interface with name {0} not found.
-    teamNicVlanMismatch = Vlan ID is different from the requested ID of {0}.
-    modifyTeamNic = Modifying the network team interface named {0}.
-    createTeamNic = Creating a network team interface with the name {0}.
-    removeTeamNic = Removing a network team interface with the name {0}.
-    teamNicExistsNoAction = Network team interface with name {0} exists. No action needed.
-    teamNicExistsWithDifferentConfig = Network team interface with name {0} exists but with different configuration. This will be modified.
-    teamNicDoesNotExistShouldCreate = Network team interface with name {0} does not exist. It will be created.
-    teamNicExistsShouldRemove = Network team interface with name {0} exists. It will be removed.
-    teamNicDoesNotExistNoAction = Network team interface with name {0} does not exist. No action needed.
-    waitingForTeamNic = Waiting for network team interface status to change to up.
-    createdNetTeamNic = Network Team Interface was created successfully.
-    failedToCreateTeamNic = Failed to create the network team interface with specific configuration.
+    GetTeamNicInfo = Getting network team interface information for '{0}'.
+    FoundTeamNic = Found a network team interface with name '{0}'.
+    TeamNicNotFound = Network team interface with name '{0}' not found.
+    TeamNicVlanMismatch = Vlan ID is different from the requested ID of '{0}'.
+    ModifyTeamNic = Modifying the network team interface named '{0}'.
+    CreateTeamNic = Creating a network team interface with the name '{0}'.
+    RemoveTeamNic = Removing a network team interface with the name '{0}'.
+    TeamNicExistsNoAction = Network team interface with name '{0}' exists. No action needed.
+    TeamNicExistsWithDifferentConfig = Network team interface with name '{0}' exists but with different configuration. This will be modified.
+    TeamNicDoesNotExistShouldCreate = Network team interface with name '{0}' does not exist. It will be created.
+    TeamNicExistsShouldRemove = Network team interface with name '{0}' exists. It will be removed.
+    TeamNicDoesNotExistNoAction = Network team interface with name '{0}' does not exist. No action needed.
+    WaitingForTeamNic = Waiting for network team interface status to change to up.
+    CreatedNetTeamNic = Network Team Interface was created successfully.
+    FailedToCreateTeamNic = Failed to create the network team interface with specific configuration.
 "@

--- a/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/Modules/xNetworking/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -379,10 +379,10 @@ function Get-IPAddressPrefix
     [cmdletbinding()]
     param
     (
-        [parameter(Mandatory=$True, ValueFromPipeline)]
+        [Parameter(Mandatory=$True, ValueFromPipeline)]
         [string[]]$IPAddress,
 
-        [parameter()]
+        [Parameter()]
         [ValidateSet('IPv4','IPv6')]
         [string]$AddressFamily = 'IPv4'
     )

--- a/Tests/Integration/MSFT_xNetworkTeam.config.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeam.config.ps1
@@ -8,8 +8,8 @@ configuration MSFT_xNetworkTeam_Config
         xNetworkTeam HostTeam
         {
             Name                   = $Node.Name
-            TeamingMode            = $Node.teamingMode
-            LoadBalancingAlgorithm = $Node.loadBalancingAlgorithm
+            TeamingMode            = $Node.TeamingMode
+            LoadBalancingAlgorithm = $Node.LoadBalancingAlgorithm
             TeamMembers            = $Node.Members
             Ensure                 = $Node.Ensure
         }

--- a/Tests/Integration/MSFT_xNetworkTeamInterface.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeamInterface.Integration.Tests.ps1
@@ -1,4 +1,14 @@
-#Remove this following line before using this integration test script
+<#
+    These tests can not be run in AppVeyor as this will cause the network
+    adapter to disconnect and terminate the build.
+
+    They can be run by commenting out the return below. All the physical
+    adapters in the machine will be used to create the team. The team will
+    be removed when tests are complete.
+
+    Loopback adapters can not be used for NIC teaming and only server OS
+    SKU machines will support it.
+#>
 return
 
 $script:DSCModuleName      = 'xNetworking'
@@ -30,46 +40,86 @@ try
     . $ConfigFile -Verbose -ErrorAction Stop
 
     Describe "$($script:DSCResourceName)_Integration" {
-        #region DEFAULT TESTS
-        It 'Should compile without throwing' {
-            {
-                & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
-                Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+        $teamMembers = (Get-NetAdapter -Physical).Name
+
+        $configurationData = @{
+            AllNodes = @(
+                @{
+                    NodeName               = 'localhost'
+                    TeamName               = 'TestName'
+                    Members                = $teamMembers
+                    LoadBalancingAlgorithm = 'MacAddresses'
+                    TeamingMode            = 'SwitchIndependent'
+                    Ensure                 = 'Present'
+                    InterfaceName          = 'TestInterface'
+                    VlanId                 = 100
+                }
+            )
         }
 
-        It 'should be able to call Get-DscConfiguration without throwing' {
-            Start-Sleep -Seconds 30
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+        It 'Should compile and apply the MOF without throwing' {
+            {
+                & "$($script:DSCResourceName)_Config" `
+                    -OutputPath $TestDrive `
+                    -ConfigurationData $configurationData
+
+                Start-DscConfiguration `
+                    -Path $TestDrive `
+                    -ComputerName localhost `
+                    -Wait `
+                    -Verbose `
+                    -Force `
+                    -ErrorAction Stop
+
+                # Wait for up to 60 seconds for the team to be created
+                $count = 0
+                While (-not (Get-NetLbfoTeam -Name 'TestTeam' -ErrorAction SilentlyContinue))
+                {
+                    Start-Sleep -Seconds 1
+
+                    if ($count -ge 60)
+                    {
+                        break
+                    }
+
+                    $count++
+                }
+            } | Should -Not -Throw
         }
-        #endregion
+
+        It 'Should be able to call Get-DscConfiguration without throwing' {
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
+        }
 
         It 'Should have set the resource and all the parameters should match' {
-            $result = Get-DscConfiguration    | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
-            $result[0].Ensure                 | Should Be $TestTeam.Ensure
-            $result[0].Name                   | Should Be $TestTeam.Name
-            $result[0].TeamMembers            | Should Be $script:teamMembers
-            $result[0].loadBalancingAlgorithm | Should Be $TestTeam.loadBalancingAlgorithm
-            $result[0].teamingMode            | Should Be $TestTeam.teamingMode
-            $result[1].Ensure                 | Should Be $TestInterface.Ensure
-            $result[1].Name                   | Should Be $TestInterface.Name
-            $result[1].TeamName               | Should be $TestInterface.TeamName
-            $result[1].VlanID                 | Should be $TestInterface.VlanID
+            $result = Get-DscConfiguration    | Where-Object -FilterScript {
+                $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
+            }
+            $result[0].Ensure                 | Should -Be $configurationData.AllNodes[0].Ensure
+            $result[0].Name                   | Should -Be $configurationData.AllNodes[0].TeamName
+            $result[0].TeamMembers            | Should -Be $configurationData.AllNodes[0].TeamMembers
+            $result[0].LoadBalancingAlgorithm | Should -Be $configurationData.AllNodes[0].LoadBalancingAlgorithm
+            $result[0].TeamingMode            | Should -Be $configurationData.AllNodes[0].TeamingMode
+            $result[1].Ensure                 | Should -Be $configurationData.AllNodes[0].Ensure
+            $result[1].Name                   | Should -Be $configurationData.AllNodes[0].InterfaceName
+            $result[1].TeamName               | Should -Be $configurationData.AllNodes[0].TeamName
+            $result[1].VlanId                 | Should -Be $configurationData.AllNodes[0].VlanId
         }
-
-        Remove-NetLbfoTeamNic `
-            -Team $TestInterface.TeamName `
-            -VlanID $TestInterface.VlanID `
-            -Confirm:$false
-
-        Remove-NetLbfoTeam `
-            -Name $TestTeam.Name `
-            -Confirm:$false
     }
-    #endregion
 }
 finally
 {
+    # Remove the team just in case it wasn't removed correctly
+    Remove-NetLbfoTeamNic `
+        -Team 'TestTeam' `
+        -VlanId 100 `
+        -Confirm:$false
+
+    Remove-NetLbfoTeam `
+        -Name 'TestTeam' `
+        -Confirm:$false `
+        -ErrorAction SilentlyContinue
+
     #region FOOTER
     Restore-TestEnvironment -TestEnvironment $TestEnvironment
     #endregion

--- a/Tests/Integration/MSFT_xNetworkTeamInterface.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeamInterface.Integration.Tests.ps1
@@ -71,9 +71,9 @@ try
                         -Force `
                         -ErrorAction Stop
 
-                    # Wait for up to 60 seconds for the team to be created
+                    # Wait for up to 60 seconds for the team interface to be created
                     $count = 0
-                    While (-not (Get-NetLbfoTeam -Name 'TestTeam' -ErrorAction SilentlyContinue))
+                    While (-not (Get-NetLbfoTeamNic -Name 'TestInterface' -Team 'TestTeam' -ErrorAction SilentlyContinue))
                     {
                         Start-Sleep -Seconds 1
 
@@ -124,9 +124,9 @@ try
                         -Force `
                         -ErrorAction Stop
 
-                    # Wait for up to 60 seconds for the team to be created
+                    # Wait for up to 60 seconds for the team interface to be created
                     $count = 0
-                    While (Get-NetLbfoTeam -Name 'TestTeam' -ErrorAction SilentlyContinue)
+                    While (Get-NetLbfoTeamNic -Name 'TestInterface' -Team 'TestTeam' -ErrorAction SilentlyContinue)
                     {
                         Start-Sleep -Seconds 1
 
@@ -166,7 +166,8 @@ finally
     Remove-NetLbfoTeamNic `
         -Team 'TestTeam' `
         -VlanId 100 `
-        -Confirm:$false
+        -Confirm:$false `
+        -ErrorAction SilentlyContinue
 
     Remove-NetLbfoTeam `
         -Name 'TestTeam' `

--- a/Tests/Integration/MSFT_xNetworkTeamInterface.config.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeamInterface.config.ps1
@@ -1,5 +1,5 @@
 
-configuration MSFT_xNetworkTeamInterface_Add_Config
+configuration MSFT_xNetworkTeamInterface_Config
 {
     Import-DSCResource -ModuleName xNetworking
 

--- a/Tests/Integration/MSFT_xNetworkTeamInterface.config.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeamInterface.config.ps1
@@ -1,45 +1,26 @@
-$TestTeam = [PSObject]@{
-    Name                    = 'TestTeam'
-    Members                 =  (Get-NetAdapter -Physical).Name
-    loadBalancingAlgorithm  = 'Dynamic'
-    teamingMode             = 'SwitchIndependent'
-    Ensure                  = 'Present'
-}
-
-$TestInterface = [PSObject]@{
-    Name                    = 'TestInterface'
-    TeamName                = $TestTeam.Name
-    VlanID                  = 100
-    Ensure                  = 'Present'
-}
 
 configuration MSFT_xNetworkTeamInterface_Config
 {
-    param
-    (
-        [string[]]$NodeName = 'localhost'
-    )
-
     Import-DSCResource -ModuleName xNetworking
 
     Node $NodeName
     {
         xNetworkTeam HostTeam
         {
-          Name = $TestTeam.Name
-          TeamingMode = $TestTeam.teamingMode
-          LoadBalancingAlgorithm = $TestTeam.loadBalancingAlgorithm
-          TeamMembers = $TestTeam.Members
-          Ensure = $TestTeam.Ensure
+            Name                   = $Node.TeamName
+            TeamingMode            = $Node.TeamingMode
+            LoadBalancingAlgorithm = $Node.LoadBalancingAlgorithm
+            TeamMembers            = $Node.Members
+            Ensure                 = $Node.Ensure
         }
-        
+
         xNetworkTeamInterface LbfoInterface
         {
-          Name = $TestInterface.Name
-          TeamName = $TestInterface.TeamName
-          VlanID = $TestInterface.VlanID
-          Ensure = $TestInterface.Ensure
-          DependsOn = '[xNetworkTeam]HostTeam'
+            Name      = $Node.InterfaceName
+            TeamName  = $Node.TeamName
+            VlanID    = $Node.VlanId
+            Ensure    = $Node.Ensure
+            DependsOn = '[xNetworkTeam] HostTeam'
         }
     }
 }

--- a/Tests/Integration/MSFT_xNetworkTeamInterface.config.ps1
+++ b/Tests/Integration/MSFT_xNetworkTeamInterface.config.ps1
@@ -1,9 +1,9 @@
 
-configuration MSFT_xNetworkTeamInterface_Config
+configuration MSFT_xNetworkTeamInterface_Add_Config
 {
     Import-DSCResource -ModuleName xNetworking
 
-    Node $NodeName
+    node localhost
     {
         xNetworkTeam HostTeam
         {
@@ -11,7 +11,7 @@ configuration MSFT_xNetworkTeamInterface_Config
             TeamingMode            = $Node.TeamingMode
             LoadBalancingAlgorithm = $Node.LoadBalancingAlgorithm
             TeamMembers            = $Node.Members
-            Ensure                 = $Node.Ensure
+            Ensure                 = 'Present'
         }
 
         xNetworkTeamInterface LbfoInterface
@@ -20,7 +20,7 @@ configuration MSFT_xNetworkTeamInterface_Config
             TeamName  = $Node.TeamName
             VlanID    = $Node.VlanId
             Ensure    = $Node.Ensure
-            DependsOn = '[xNetworkTeam] HostTeam'
+            DependsOn = '[xNetworkTeam]HostTeam'
         }
     }
 }

--- a/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetBIOS.Tests.ps1
@@ -1,5 +1,6 @@
 $script:DSCModuleName = 'xNetworking'
 $script:DSCResourceName = 'MSFT_xNetBIOS'
+Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
 
 #region HEADER
 # Unit Test Template Version: 1.1.0

--- a/Tests/Unit/MSFT_xNetworkTeamInterface.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetworkTeamInterface.Tests.ps1
@@ -84,7 +84,7 @@ try
         }
 
         Describe "$($Global:DSCResourceName)\Get-TargetResource" {
-            Context 'Team Interface does not exist' {
+            Context 'When team Interface does not exist' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter
@@ -132,7 +132,7 @@ try
         }
 
         Describe "$($Global:DSCResourceName)\Set-TargetResource" {
-            Context 'Team Interface does not exist but invalid VlanId (0) is passed' {
+            Context 'When team Interface does not exist but invalid VlanId (0) is passed' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter
@@ -167,7 +167,7 @@ try
                 }
             }
 
-            Context 'Team Interface does not exist but should' {
+            Context 'When team Interface does not exist but should' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter
@@ -201,7 +201,7 @@ try
                 }
             }
 
-            Context 'Team Interface exists but needs a different VlanId' {
+            Context 'When team Interface exists but needs a different VlanId' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter `
@@ -238,7 +238,7 @@ try
                 }
             }
 
-            Context 'Team Interface exists but should not exist' {
+            Context 'When team Interface exists but should not exist' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter `
@@ -282,7 +282,7 @@ try
         }
 
         Describe "$($Global:DSCResourceName)\Test-TargetResource" {
-            Context 'Team Interface does not exist but should' {
+            Context 'When team Interface does not exist but should' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter
@@ -305,7 +305,7 @@ try
                 }
             }
 
-            Context 'Team Interface exists but needs a different VlanId' {
+            Context 'When team Interface exists but needs a different VlanId' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter `
@@ -329,7 +329,7 @@ try
                 }
             }
 
-            Context 'Team Interface exists but should not exist' {
+            Context 'When team Interface exists but should not exist' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter `
@@ -353,7 +353,7 @@ try
                 }
             }
 
-            Context 'Team Interface exists and no action needed' {
+            Context 'When team Interface exists and no action needed' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter `
@@ -376,7 +376,7 @@ try
                 }
             }
 
-            Context 'Team Interface does not exist and no action needed' {
+            Context 'When team Interface does not exist and no action needed' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter
@@ -399,7 +399,7 @@ try
                 }
             }
 
-            Context 'Team Interface exists on the default 0 VLAN' {
+            Context 'When team Interface exists on the default 0 VLAN' {
                 Mock `
                     -CommandName Get-NetLbfoTeamNic `
                     -ParameterFilter $getNetLbfoTeamNic_ParameterFilter `


### PR DESCRIPTION
**Pull Request (PR) description**
Updated xNetworkTeamInterface to meet HQRM guidelines. This PR also corrects some style and HQRM issues missed in previous resources.

- MSFT_xNetworkTeamInterface:
  - Corrected style and formatting to meet HQRM guidelines.
  - Updated tests to meet Pester v4 guidelines.
  - Converted exceptions to use ResourceHelper functions.
  - Changed unit tests to output Verbose logs.
- MSFT_xNetBIOS:
  - Ensured CommonTestHelper.psm1 is loaded before running unit tests.
- MSFT_xNetworkTeam:
  - Added missing default from MOF description of Ensure parameter.
  - Fixed `Get-TargetResource` to always output Ensure parameter.
  - Changed unit tests to output Verbose logs.
- MSFT_xNetConnectionProfile:
  - Corrected style and formatting to meet HQRM guidelines.

**This Pull Request (PR) fixes the following issues:**
- #306

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [x] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [x] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

This is the final HQRM change - once merged I think this resource meets HQRM and we can being the rename process (after the PR for implementing Pester V4).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/311)
<!-- Reviewable:end -->
