### PR TITLE
Updated Pester tests to be V4 format - Fixes #272

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@
   - Changed unit tests to output Verbose logs.
 - MSFT_xNetConnectionProfile:
   - Corrected style and formatting to meet HQRM guidelines.
+- Updated tests to meet Pester V4 guidelines - Fixes [Issue #272](https://github.com/PowerShell/xNetworking/issues/272).
 
 ## 5.5.0.0
 

--- a/Tests/Integration/MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSConnectionSuffix.Integration.Tests.ps1
@@ -35,20 +35,20 @@ try
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
-            $current.InterfaceAlias                 | Should Be $TestDnsConnectionSuffix.InterfaceAlias
-            $current.ConnectionSpecificSuffix       | Should Be $TestDnsConnectionSuffix.ConnectionSpecificSuffix
-            $current.RegisterThisConnectionsAddress | Should Be $TestDnsConnectionSuffix.RegisterThisConnectionsAddress
-            $current.Ensure                         | Should Be $TestDnsConnectionSuffix.Ensure
+            $current.InterfaceAlias                 | Should -Be $TestDnsConnectionSuffix.InterfaceAlias
+            $current.ConnectionSpecificSuffix       | Should -Be $TestDnsConnectionSuffix.ConnectionSpecificSuffix
+            $current.RegisterThisConnectionsAddress | Should -Be $TestDnsConnectionSuffix.RegisterThisConnectionsAddress
+            $current.Ensure                         | Should -Be $TestDnsConnectionSuffix.Ensure
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDNSServerAddress.Integration.Tests.ps1
@@ -54,19 +54,19 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config_Static"}
-            $current.InterfaceAlias             | Should Be $adapterName
-            $current.AddressFamily              | Should Be 'IPv4'
-            $current.Address.Count              | Should Be 1
-            $current.Address                    | Should Be '10.139.17.99'
+            $current.InterfaceAlias             | Should -Be $adapterName
+            $current.AddressFamily              | Should -Be 'IPv4'
+            $current.Address.Count              | Should -Be 1
+            $current.Address                    | Should -Be '10.139.17.99'
         }
         #endregion
     }
@@ -93,20 +93,20 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config_Static"}
-            $current.InterfaceAlias             | Should Be $adapterName
-            $current.AddressFamily              | Should Be 'IPv4'
-            $current.Address.Count              | Should Be 2
-            $current.Address[0]                 | Should Be '10.139.17.99'
-            $current.Address[1]                 | Should Be '10.139.17.100'
+            $current.InterfaceAlias             | Should -Be $adapterName
+            $current.AddressFamily              | Should -Be 'IPv4'
+            $current.Address.Count              | Should -Be 2
+            $current.Address[0]                 | Should -Be '10.139.17.99'
+            $current.Address[1]                 | Should -Be '10.139.17.100'
         }
         #endregion
     }
@@ -134,19 +134,19 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration -Path $TestDrive `
                     -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config_DHCP"}
-            $current.InterfaceAlias             | Should Be $adapterName
-            $current.AddressFamily              | Should Be 'IPv4'
-            $current.Address.Count              | Should Be 0
-            $current.Address                    | Should BeNullOrEmpty
+            $current.InterfaceAlias             | Should -Be $adapterName
+            $current.AddressFamily              | Should -Be 'IPv4'
+            $current.Address.Count              | Should -Be 0
+            $current.Address                    | Should -BeNullOrEmpty
         }
         #endregion
     }

--- a/Tests/Integration/MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDefaultGatewayAddress.Integration.Tests.ps1
@@ -36,19 +36,19 @@ try
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration   | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
-            $current.InterfaceAlias           | Should Be $TestDefaultGatewayAddress.InterfaceAlias
-            $current.AddressFamily            | Should Be $TestDefaultGatewayAddress.AddressFamily
-            $current.Address                  | Should Be $TestDefaultGatewayAddress.Address
+            $current.InterfaceAlias           | Should -Be $TestDefaultGatewayAddress.InterfaceAlias
+            $current.AddressFamily            | Should -Be $TestDefaultGatewayAddress.AddressFamily
+            $current.Address                  | Should -Be $TestDefaultGatewayAddress.Address
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDhcpClient.Integration.Tests.ps1
@@ -35,19 +35,19 @@ try
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
-            $current.InterfaceAlias           | Should Be $TestDhcpClient.InterfaceAlias
-            $current.AddressFamily            | Should Be $TestDhcpClient.AddressFamily
-            $current.State                    | Should Be $TestDhcpClient.State
+            $current.InterfaceAlias           | Should -Be $TestDhcpClient.InterfaceAlias
+            $current.AddressFamily            | Should -Be $TestDhcpClient.AddressFamily
+            $current.State                    | Should -Be $TestDhcpClient.State
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xDnsClientGlobalSetting.Integration.Tests.ps1
@@ -66,11 +66,11 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration `
                     -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
@@ -84,7 +84,7 @@ try
             $parameterNewValue = (Get-Variable -Name configData).Value.AllNodes[0].$($parameter.Name)
 
             It "Should have set the '$parameterName' to '$parameterNewValue'" {
-                $parameterCurrentValue | Should Be $parameterNewValue
+                $parameterCurrentValue | Should -Be $parameterNewValue
             }
         }
     }

--- a/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewall.Integration.Tests.ps1
@@ -89,11 +89,11 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration `
                     -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
@@ -134,7 +134,7 @@ try
                 {
                     $parameterNew = $parameterNew -join $parameter.Delimiter
                     It "Should have set the '$parameterName' to '$parameterNew'" {
-                        $parameterValue | Should Be $parameterNew
+                        $parameterValue | Should -Be $parameterNew
                     }
                 }
                 elseif ($parameter.Type -eq 'ArrayIP')
@@ -142,14 +142,14 @@ try
                     for ([int] $entry = 0; $entry -lt $parameterNew.Count; $entry++)
                     {
                         It "Should have set the '$parameterName' arry item $entry to '$($parameterNew[$entry])'" {
-                            $parameterValue[$entry] | Should Be (Convert-CIDRToSubhetMask -Address $parameterNew[$entry])
+                            $parameterValue[$entry] | Should -Be (Convert-CIDRToSubhetMask -Address $parameterNew[$entry])
                         }
                     }
                 }
                 else
                 {
                     It "Should have set the '$parameterName' to '$parameterNew'" {
-                        $parameterValue | Should Be $parameterNew
+                        $parameterValue | Should -Be $parameterNew
                     }
                 }
             }
@@ -174,18 +174,18 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration `
                     -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have deleted the rule' {
             # Get the Rule details
             $firewallRule = Get-NetFireWallRule -Name $ruleName -ErrorAction SilentlyContinue
-            $firewallRule | Should BeNullOrEmpty
+            $firewallRule | Should -BeNullOrEmpty
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xFirewallProfile.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xFirewallProfile.Integration.Tests.ps1
@@ -106,11 +106,11 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration `
                     -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
@@ -125,7 +125,7 @@ try
             $parameterNewValue = (Get-Variable -Name configData).Value.AllNodes[0].$($parameter.Name)
 
             It "Should have set the '$parameterName' to '$parameterNewValue'" {
-                $parameterCurrentValue | Should Be $parameterNewValue
+                $parameterCurrentValue | Should -Be $parameterNewValue
             }
         }
     }

--- a/Tests/Integration/MSFT_xHostsFile.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xHostsFile.Integration.Tests.ps1
@@ -46,20 +46,20 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration `
                     -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should have set the resource and all the parameters should match' {
             $result = Get-DscConfiguration | Where-Object -FilterScript {
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
-            $result.Ensure                 | Should Be $configData.AllNodes[0].Ensure
-            $result.HostName               | Should Be $configData.AllNodes[0].HostName
-            $result.IPAddress              | Should Be $configData.AllNodes[0].IPAddress
+            $result.Ensure                 | Should -Be $configData.AllNodes[0].Ensure
+            $result.HostName               | Should -Be $configData.AllNodes[0].HostName
+            $result.IPAddress              | Should -Be $configData.AllNodes[0].IPAddress
         }
     }
 
@@ -85,20 +85,20 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration `
                     -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should have set the resource and all the parameters should match' {
             $result = Get-DscConfiguration | Where-Object -FilterScript {
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
-            $result.Ensure                 | Should Be $configData.AllNodes[0].Ensure
-            $result.HostName               | Should Be $configData.AllNodes[0].HostName
-            $result.IPAddress              | Should Be $configData.AllNodes[0].IPAddress
+            $result.Ensure                 | Should -Be $configData.AllNodes[0].Ensure
+            $result.HostName               | Should -Be $configData.AllNodes[0].HostName
+            $result.IPAddress              | Should -Be $configData.AllNodes[0].IPAddress
         }
     }
 
@@ -124,20 +124,20 @@ try
                     -ConfigurationData $configData
                 Start-DscConfiguration `
                     -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should have set the resource and all the parameters should match' {
             $result = Get-DscConfiguration | Where-Object -FilterScript {
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
-            $result.Ensure                 | Should Be $configData.AllNodes[0].Ensure
-            $result.HostName               | Should Be $configData.AllNodes[0].HostName
-            $result.IPAddress              | Should BeNullOrEmpty
+            $result.Ensure                 | Should -Be $configData.AllNodes[0].Ensure
+            $result.HostName               | Should -Be $configData.AllNodes[0].HostName
+            $result.IPAddress              | Should -BeNullOrEmpty
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddress.Integration.Tests.ps1
@@ -42,11 +42,11 @@ try
                     -Verbose `
                     -Force `
                     -ErrorAction Stop
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
@@ -54,9 +54,9 @@ try
             $current = Get-DscConfiguration | Where-Object -FilterScript {
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
-            $current.InterfaceAlias | Should Be $TestIPAddress.InterfaceAlias
-            $current.AddressFamily  | Should Be $TestIPAddress.AddressFamily
-            $current.IPAddress      | Should Be $TestIPAddress.IPAddress
+            $current.InterfaceAlias | Should -Be $TestIPAddress.InterfaceAlias
+            $current.AddressFamily  | Should -Be $TestIPAddress.AddressFamily
+            $current.IPAddress      | Should -Be $TestIPAddress.IPAddress
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xIPAddressOption.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xIPAddressOption.Integration.Tests.ps1
@@ -42,11 +42,11 @@ try
                     -Verbose `
                     -Force `
                     -ErrorAction Stop
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
@@ -54,11 +54,11 @@ try
             $current = Get-DscConfiguration | Where-Object -FilterScript {
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
-            $current[0].InterfaceAlias | Should Be $TestIPAddress.InterfaceAlias
-            $current[0].AddressFamily  | Should Be $TestIPAddress.AddressFamily
-            $current[0].IPAddress      | Should Be $TestIPAddress.IPAddress
-            $current[1].IPAddress      | Should Be $TestIPAddressOption.IPAddress
-            $current[1].SkipAsSource   | Should Be $TestIPAddressOption.SkipAsSource
+            $current[0].InterfaceAlias | Should -Be $TestIPAddress.InterfaceAlias
+            $current[0].AddressFamily  | Should -Be $TestIPAddress.AddressFamily
+            $current[0].IPAddress      | Should -Be $TestIPAddress.IPAddress
+            $current[1].IPAddress      | Should -Be $TestIPAddressOption.IPAddress
+            $current[1].SkipAsSource   | Should -Be $TestIPAddressOption.SkipAsSource
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xNetAdapterLso.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterLso.Integration.Tests.ps1
@@ -41,7 +41,7 @@ try
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should have set the resource and all the parameters should match' {

--- a/Tests/Integration/MSFT_xNetAdapterRDMA.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetAdapterRDMA.Integration.Tests.ps1
@@ -79,7 +79,7 @@ try
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should have set the resource and all the parameters should match' {

--- a/Tests/Integration/MSFT_xNetConnectionProfile.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetConnectionProfile.Integration.Tests.ps1
@@ -31,22 +31,22 @@ try
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
-            $rule.InterfaceAlias   | Should Be $current.InterfaceAlias
-            $rule.NetworkCategory  | Should Be $current.NetworkCategory
-            $rule.IPv4Connectivity | Should Be $current.IPv4Connectivity
-            $rule.IPv6Connectivity | Should Be $current.IPv6Connectivity
-            $rule.Address          | Should Be $current.Address
-            $rule.AddressFamily    | Should Be $current.AddressFamily
+            $rule.InterfaceAlias   | Should -Be $current.InterfaceAlias
+            $rule.NetworkCategory  | Should -Be $current.NetworkCategory
+            $rule.IPv4Connectivity | Should -Be $current.IPv4Connectivity
+            $rule.IPv6Connectivity | Should -Be $current.IPv6Connectivity
+            $rule.Address          | Should -Be $current.Address
+            $rule.AddressFamily    | Should -Be $current.AddressFamily
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xProxySettings.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xProxySettings.Integration.Tests.ps1
@@ -58,31 +58,31 @@ try
                     -Verbose `
                     -Force `
                     -ErrorAction Stop
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should be able to call Test-DscConfiguration without throwing' {
-            { $script:currentState = Test-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            { $script:currentState = Test-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should report that DSC is in state' {
-            $script:currentState | Should Be $true
+            $script:currentState | Should -Be $true
         }
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object { $_.ConfigurationName -eq "$($script:DSCResourceName)_Present_Config" }
-            $current.Ensure                  | Should Be 'Present'
-            $current.EnableAutoDetection     | Should Be $True
-            $current.EnableAutoConfiguration | Should Be $True
-            $current.EnableManualProxy       | Should Be $True
-            $current.ProxyServer             | Should Be $testProxyServer
-            $current.ProxyServerExceptions   | Should Be $testProxyExeceptions
-            $current.ProxyServerBypassLocal  | Should Be $True
-            $current.AutoConfigURL           | Should Be $testAutoConfigURL
+            $current.Ensure                  | Should -Be 'Present'
+            $current.EnableAutoDetection     | Should -Be $True
+            $current.EnableAutoConfiguration | Should -Be $True
+            $current.EnableManualProxy       | Should -Be $True
+            $current.ProxyServer             | Should -Be $testProxyServer
+            $current.ProxyServerExceptions   | Should -Be $testProxyExeceptions
+            $current.ProxyServerBypassLocal  | Should -Be $True
+            $current.AutoConfigURL           | Should -Be $testAutoConfigURL
         }
     }
 
@@ -102,24 +102,24 @@ try
                     -Verbose `
                     -Force `
                     -ErrorAction Stop
-            } | Should Not Throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should be able to call Test-DscConfiguration without throwing' {
-            { $script:currentState = Test-DscConfiguration -Verbose -ErrorAction Stop } | Should Not Throw
+            { $script:currentState = Test-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
 
         It 'Should report that DSC is in state' {
-            $script:currentState | Should Be $true
+            $script:currentState | Should -Be $true
         }
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object { $_.ConfigurationName -eq "$($script:DSCResourceName)_Absent_Config" }
-            $current.Ensure            | Should Be 'Absent'
+            $current.Ensure            | Should -Be 'Absent'
         }
     }
 }

--- a/Tests/Integration/MSFT_xRoute.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xRoute.Integration.Tests.ps1
@@ -78,13 +78,13 @@ try
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
 
-            $current.InterfaceAlias    | Should Be $configData.AllNodes[0].InterfaceAlias
-            $current.AddressFamily     | Should Be $configData.AllNodes[0].AddressFamily
-            $current.DestinationPrefix | Should Be $configData.AllNodes[0].DestinationPrefix
-            $current.NextHop           | Should Be $configData.AllNodes[0].NextHop
-            $current.Ensure            | Should Be $configData.AllNodes[0].Ensure
-            $current.RouteMetric       | Should Be $configData.AllNodes[0].RouteMetric
-            $current.Publish           | Should Be $configData.AllNodes[0].Publish
+            $current.InterfaceAlias    | Should -Be $configData.AllNodes[0].InterfaceAlias
+            $current.AddressFamily     | Should -Be $configData.AllNodes[0].AddressFamily
+            $current.DestinationPrefix | Should -Be $configData.AllNodes[0].DestinationPrefix
+            $current.NextHop           | Should -Be $configData.AllNodes[0].NextHop
+            $current.Ensure            | Should -Be $configData.AllNodes[0].Ensure
+            $current.RouteMetric       | Should -Be $configData.AllNodes[0].RouteMetric
+            $current.Publish           | Should -Be $configData.AllNodes[0].Publish
         }
 
         It 'Should have created the route' {
@@ -135,11 +135,11 @@ try
                 $_.ConfigurationName -eq "$($script:DSCResourceName)_Config"
             }
 
-            $current.InterfaceAlias    | Should Be $configData.AllNodes[0].InterfaceAlias
-            $current.AddressFamily     | Should Be $configData.AllNodes[0].AddressFamily
-            $current.DestinationPrefix | Should Be $configData.AllNodes[0].DestinationPrefix
-            $current.NextHop           | Should Be $configData.AllNodes[0].NextHop
-            $current.Ensure            | Should Be $configData.AllNodes[0].Ensure
+            $current.InterfaceAlias    | Should -Be $configData.AllNodes[0].InterfaceAlias
+            $current.AddressFamily     | Should -Be $configData.AllNodes[0].AddressFamily
+            $current.DestinationPrefix | Should -Be $configData.AllNodes[0].DestinationPrefix
+            $current.NextHop           | Should -Be $configData.AllNodes[0].NextHop
+            $current.Ensure            | Should -Be $configData.AllNodes[0].Ensure
         }
 
         It 'Should have deleted the route' {

--- a/Tests/Integration/MSFT_xWeakHostReceive.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWeakHostReceive.Integration.Tests.ps1
@@ -35,19 +35,19 @@ try
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force -ErrorAction Stop
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -eq "$($script:DSCResourceName)_Config"}
-            $current.InterfaceAlias           | Should Be $TestWeakHostReceive.InterfaceAlias
-            $current.AddressFamily            | Should Be $TestWeakHostReceive.AddressFamily
-            $current.State                    | Should Be $TestWeakHostReceive.State
+            $current.InterfaceAlias           | Should -Be $TestWeakHostReceive.InterfaceAlias
+            $current.AddressFamily            | Should -Be $TestWeakHostReceive.AddressFamily
+            $current.State                    | Should -Be $TestWeakHostReceive.State
         }
     }
     #endregion

--- a/Tests/Integration/MSFT_xWeakHostSend.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xWeakHostSend.Integration.Tests.ps1
@@ -35,19 +35,19 @@ try
             {
                 & "$($script:DSCResourceName)_Config" -OutputPath $TestDrive
                 Start-DscConfiguration -Path $TestDrive -ComputerName localhost -Wait -Verbose -Force -ErrorAction Stop
-            } | Should not throw
+            } | Should -Not -Throw
         }
 
         It 'Should be able to call Get-DscConfiguration without throwing' {
-            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should Not throw
+            { Get-DscConfiguration -Verbose -ErrorAction Stop } | Should -Not -Throw
         }
         #endregion
 
         It 'Should have set the resource and all the parameters should match' {
             $current = Get-DscConfiguration | Where-Object {$_.ConfigurationName -like "*$($script:DSCResourceName)*"}
-            $current.InterfaceAlias           | Should Be $TestWeakHostSend.InterfaceAlias
-            $current.AddressFamily            | Should Be $TestWeakHostSend.AddressFamily
-            $current.State                    | Should Be $TestWeakHostSend.State
+            $current.InterfaceAlias           | Should -Be $TestWeakHostSend.InterfaceAlias
+            $current.AddressFamily            | Should -Be $TestWeakHostSend.AddressFamily
+            $current.State                    | Should -Be $TestWeakHostSend.State
         }
     }
     #endregion

--- a/Tests/Integration/ModuleConflict.Tests.ps1
+++ b/Tests/Integration/ModuleConflict.Tests.ps1
@@ -34,7 +34,7 @@ try
             It "Should be able to install DSC Resource module '$moduleToTest'" {
                 {
                     Install-Module -Name $moduleToTest -ErrorAction Stop
-                } | Should Not Throw
+                } | Should -Not -Throw
             }
         }
     }

--- a/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDNSServerAddress.Tests.ps1
@@ -38,7 +38,7 @@ try
                         }
 
                         $Result = Get-TargetResource @getTargetResourceSplat
-                        $Result.Address | Should Be '192.168.0.1'
+                        $Result.Address | Should -Be '192.168.0.1'
                     }
 
                     It 'Should call all the mocks' {
@@ -60,7 +60,7 @@ try
                         }
 
                         $Result = Get-TargetResource @getTargetResourceSplat
-                        $Result.Address | Should Be 'fe80:ab04:30F5:002b::1'
+                        $Result.Address | Should -Be 'fe80:ab04:30F5:002b::1'
                     }
 
                     It 'Should call all the mocks' {
@@ -82,7 +82,7 @@ try
                         }
 
                         $Result = Get-TargetResource @getTargetResourceSplat
-                        $Result.Address | Should BeNullOrEmpty
+                        $Result.Address | Should -BeNullOrEmpty
                     }
 
                     It 'Should call all the mocks' {
@@ -110,7 +110,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -130,7 +130,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -151,7 +151,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -171,7 +171,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -190,7 +190,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -212,7 +212,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -234,7 +234,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -263,7 +263,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -283,7 +283,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -304,7 +304,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -324,7 +324,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -343,7 +343,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -365,7 +365,7 @@ try
                             Verbose        = $true
                         }
 
-                        { Set-TargetResource @setTargetResourceSplat } | Should Not Throw
+                        { Set-TargetResource @setTargetResourceSplat } | Should -Not -Throw
                     }
 
                     It 'Should call all the mocks' {
@@ -394,7 +394,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $true
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $true
                     }
 
                     It 'Should call all the mocks' {
@@ -411,7 +411,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $False
                     }
 
                     It 'Should call all the mocks' {
@@ -428,7 +428,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $False
                     }
 
                     It 'Should call all the mocks' {
@@ -444,7 +444,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $False
                     }
 
                     It 'Should call all the mocks' {
@@ -464,7 +464,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $False
                     }
 
                     It 'Should call all the mocks' {
@@ -488,7 +488,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $true
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $true
                     }
 
                     It 'Should call all the mocks' {
@@ -505,7 +505,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $False
                     }
 
                     It 'Should call all the mocks' {
@@ -522,7 +522,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $False
                     }
 
                     It 'Should call all the mocks' {
@@ -538,7 +538,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $False
                     }
 
                     It 'Should call all the mocks' {
@@ -558,7 +558,7 @@ try
                             Verbose        = $true
                         }
 
-                        Test-TargetResource @testTargetResourceSplat | Should Be $False
+                        Test-TargetResource @testTargetResourceSplat | Should -Be $False
                     }
 
                     It 'Should call all the mocks' {
@@ -586,7 +586,7 @@ try
                         -Message ($LocalizedData.InterfaceNotAvailableError -f $assertResourcePropertySplat.InterfaceAlias) `
                         -ArgumentName 'InterfaceAlias'
 
-                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should -Throw $ErrorRecord
                 }
             }
 
@@ -603,7 +603,7 @@ try
                         -Message ($LocalizedData.AddressFormatError -f $assertResourcePropertySplat.Address) `
                         -ArgumentName 'Address'
 
-                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should -Throw $ErrorRecord
                 }
             }
 
@@ -620,7 +620,7 @@ try
                         -Message ($LocalizedData.AddressIPv4MismatchError -f $assertResourcePropertySplat.Address,$assertResourcePropertySplat.AddressFamily) `
                         -ArgumentName 'Address'
 
-                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should -Throw $ErrorRecord
                 }
             }
 
@@ -637,7 +637,7 @@ try
                         -Message ($LocalizedData.AddressIPv6MismatchError -f $assertResourcePropertySplat.Address,$assertResourcePropertySplat.AddressFamily) `
                         -ArgumentName 'Address'
 
-                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should -Throw $ErrorRecord
                 }
             }
 
@@ -650,7 +650,7 @@ try
                         Verbose        = $true
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should -Not -Throw
                 }
             }
 
@@ -663,7 +663,7 @@ try
                         Verbose        = $true
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertySplat } | Should -Not -Throw
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xDefaultGatewayAddress.Tests.ps1
@@ -45,7 +45,7 @@ try
 
                     $result = Get-TargetResource @getTargetResourceParameters
 
-                    $result.Address | Should Be '192.168.0.1'
+                    $result.Address | Should -Be '192.168.0.1'
                 }
             }
 
@@ -62,7 +62,7 @@ try
 
                     $result = Get-TargetResource @getTargetResourceParameters
 
-                    $result.Address | Should BeNullOrEmpty
+                    $result.Address | Should -BeNullOrEmpty
                 }
             }
         }
@@ -93,9 +93,9 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
 
-                    $result | Should BeNullOrEmpty
+                    $result | Should -BeNullOrEmpty
                 }
 
                 It 'Should call all the mocks' {
@@ -113,9 +113,9 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
+                    { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
 
-                    $result | Should BeNullOrEmpty
+                    $result | Should -BeNullOrEmpty
                 }
 
                 It 'Should call all the mocks' {
@@ -153,7 +153,7 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
 
@@ -176,7 +176,7 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @testTargetResourceParameters | Should Be $False
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $False
                 }
             }
 
@@ -192,7 +192,7 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @testTargetResourceParameters | Should Be $False
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $False
                 }
             }
 
@@ -207,7 +207,7 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
             }
         }
@@ -228,7 +228,7 @@ try
                     $errorRecord = Get-InvalidOperationRecord `
                         -Message ($LocalizedData.InterfaceNotAvailableError -f $assertResourcePropertyParameters.InterfaceAlias)
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $ErrorRecord
                 }
             }
 
@@ -244,7 +244,7 @@ try
                         -Message ($LocalizedData.AddressFormatError -f $assertResourcePropertyParameters.Address) `
                         -ArgumentName 'Address'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $ErrorRecord
                 }
             }
 
@@ -260,7 +260,7 @@ try
                         -Message ($LocalizedData.AddressIPv4MismatchError -f $assertResourcePropertyParameters.Address,$assertResourcePropertyParameters.AddressFamily) `
                         -ArgumentName 'AddressFamily'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $ErrorRecord
                 }
             }
 
@@ -276,7 +276,7 @@ try
                         -Message ($LocalizedData.AddressIPv6MismatchError -f $assertResourcePropertyParameters.Address,$assertResourcePropertyParameters.AddressFamily) `
                         -ArgumentName 'AddressFamily'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $ErrorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $ErrorRecord
                 }
             }
 
@@ -288,7 +288,7 @@ try
                         AddressFamily = 'IPv4'
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Not -Throw
                 }
             }
 
@@ -300,7 +300,7 @@ try
                         AddressFamily = 'IPv6'
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Not -Throw
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
+++ b/Tests/Unit/MSFT_xDhcpClient.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xNetworking'
+$script:DSCModuleName = 'xNetworking'
 $script:DSCResourceName = 'MSFT_xDhcpClient'
 
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
@@ -64,9 +64,9 @@ try
 
                 It 'Should return DHCP state of enabled' {
                     $Result = Get-TargetResource @testNetIPInterfaceEnabled
-                    $Result.State          | Should Be $testNetIPInterfaceEnabled.State
-                    $Result.InterfaceAlias | Should Be $testNetIPInterfaceEnabled.InterfaceAlias
-                    $Result.AddressFamily  | Should Be $testNetIPInterfaceEnabled.AddressFamily
+                    $Result.State          | Should -Be $testNetIPInterfaceEnabled.State
+                    $Result.InterfaceAlias | Should -Be $testNetIPInterfaceEnabled.InterfaceAlias
+                    $Result.AddressFamily  | Should -Be $testNetIPInterfaceEnabled.AddressFamily
                 }
 
                 It 'Should call the expected mocks' {
@@ -80,9 +80,9 @@ try
 
                 It 'Should return DHCP state of disabled' {
                     $Result = Get-TargetResource @testNetIPInterfaceDisabled
-                    $Result.State          | Should Be $testNetIPInterfaceDisabled.State
-                    $Result.InterfaceAlias | Should Be $testNetIPInterfaceDisabled.InterfaceAlias
-                    $Result.AddressFamily  | Should Be $testNetIPInterfaceDisabled.AddressFamily
+                    $Result.State          | Should -Be $testNetIPInterfaceDisabled.State
+                    $Result.InterfaceAlias | Should -Be $testNetIPInterfaceDisabled.InterfaceAlias
+                    $Result.AddressFamily  | Should -Be $testNetIPInterfaceDisabled.AddressFamily
                 }
 
                 It 'Should call the expected mocks' {
@@ -103,7 +103,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceDisabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPInterfaceEnabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPInterfaceEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -118,7 +118,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceDisabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPInterfaceDisabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPInterfaceDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -133,7 +133,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceEnabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPInterfaceEnabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPInterfaceEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -148,7 +148,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceEnabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPInterfaceDisabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPInterfaceDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -169,7 +169,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceDisabled }
 
                 It 'Should return false' {
-                    Test-TargetResource @testNetIPInterfaceEnabled | Should Be $False
+                    Test-TargetResource @testNetIPInterfaceEnabled | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -182,7 +182,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceDisabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testNetIPInterfaceDisabled | Should Be $true
+                    Test-TargetResource @testNetIPInterfaceDisabled | Should -Be $true
                 }
 
                 It 'Should call expected mocks' {
@@ -195,7 +195,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceEnabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testNetIPInterfaceEnabled | Should Be $true
+                    Test-TargetResource @testNetIPInterfaceEnabled | Should -Be $true
                 }
 
                 It 'Should call expected mocks' {
@@ -208,7 +208,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPInterfaceEnabled }
 
                 It 'Should return false' {
-                    Test-TargetResource @testNetIPInterfaceDisabled | Should Be $False
+                    Test-TargetResource @testNetIPInterfaceDisabled | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -226,7 +226,7 @@ try
                     $errorRecord = Get-InvalidOperationRecord `
                         -Message ($LocalizedData.InterfaceNotAvailableError -f $testNetIPInterfaceEnabled.InterfaceAlias)
 
-                    { Assert-ResourceProperty @testNetIPInterfaceEnabled } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @testNetIPInterfaceEnabled } | Should -Throw $errorRecord
                 }
             }
         }

--- a/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsClientGlobalSetting.Tests.ps1
@@ -51,9 +51,9 @@ try
             Context 'DNS Client Global Settings Exists' {
                 It 'Should return correct DNS Client Global Settings values' {
                     $getTargetResourceParameters = Get-TargetResource -IsSingleInstance 'Yes'
-                    $getTargetResourceParameters.SuffixSearchList | Should Be $dnsClientGlobalSettings.SuffixSearchList
-                    $getTargetResourceParameters.DevolutionLevel  | Should Be $dnsClientGlobalSettings.DevolutionLevel
-                    $getTargetResourceParameters.UseDevolution    | Should Be $dnsClientGlobalSettings.UseDevolution
+                    $getTargetResourceParameters.SuffixSearchList | Should -Be $dnsClientGlobalSettings.SuffixSearchList
+                    $getTargetResourceParameters.DevolutionLevel  | Should -Be $dnsClientGlobalSettings.DevolutionLevel
+                    $getTargetResourceParameters.UseDevolution    | Should -Be $dnsClientGlobalSettings.UseDevolution
                 }
 
                 It 'Should call the expected mocks' {
@@ -74,7 +74,7 @@ try
                     {
                         $setTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         Set-TargetResource @setTargetResourceParameters
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call expected Mocks' {
@@ -91,7 +91,7 @@ try
                         $setTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $setTargetResourceParameters.SuffixSearchList = 'fabrikam.com'
                         Set-TargetResource @setTargetResourceParameters
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call expected Mocks' {
@@ -114,7 +114,7 @@ try
                         $setTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $setTargetResourceParameters.SuffixSearchList = $suffixSearchListArray
                         Set-TargetResource @setTargetResourceParameters
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call expected Mocks' {
@@ -131,7 +131,7 @@ try
                         $setTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $setTargetResourceParameters.DevolutionLevel = $setTargetResourceParameters.DevolutionLevel + 1
                         Set-TargetResource @setTargetResourceParameters
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call expected Mocks' {
@@ -148,7 +148,7 @@ try
                         $setTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $setTargetResourceParameters.UseDevolution = -not $setTargetResourceParameters.UseDevolution
                         Set-TargetResource @setTargetResourceParameters
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call expected Mocks' {
@@ -167,7 +167,7 @@ try
                 Context 'DNS Client Global Settings all parameters are the same' {
                     It 'Should return true' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
-                        Test-TargetResource @testTargetResourceParameters | Should Be $true
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $true
                     }
 
                     It 'Should call expected Mocks' {
@@ -179,7 +179,7 @@ try
                     It 'Should return false' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $testTargetResourceParameters.SuffixSearchList = 'fabrikam.com'
-                        Test-TargetResource @testTargetResourceParameters | Should Be $False
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $False
                     }
 
                     It 'Should call expected Mocks' {
@@ -191,7 +191,7 @@ try
                     It 'Should return false' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $testTargetResourceParameters.DevolutionLevel = $testTargetResourceParameters.DevolutionLevel + 1
-                        Test-TargetResource @testTargetResourceParameters | Should Be $False
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $False
                     }
 
                     It 'Should call expected Mocks' {
@@ -203,7 +203,7 @@ try
                     It 'Should return false' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $testTargetResourceParameters.UseDevolution = -not $testTargetResourceParameters.UseDevolution
-                        Test-TargetResource @testTargetResourceParameters | Should Be $False
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $False
                     }
 
                     It 'Should call expected Mocks' {
@@ -221,7 +221,7 @@ try
                     It 'Should return false' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $testTargetResourceParameters.SuffixSearchList = @('fabrikam.com', 'contoso.com')
-                        Test-TargetResource @testTargetResourceParameters | Should Be $False
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $False
                     }
 
                     It 'Should call expected Mocks' {
@@ -233,7 +233,7 @@ try
                     It 'Should return true' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $testTargetResourceParameters.SuffixSearchList = @('fabrikam.com', 'fourthcoffee.com')
-                        Test-TargetResource @testTargetResourceParameters | Should Be $true
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $true
                     }
 
                     It 'Should call expected Mocks' {
@@ -245,7 +245,7 @@ try
                     It 'Should return false' {
                         $testTargetResourceParameters = $dnsClientGlobalSettingsSplat.Clone()
                         $testTargetResourceParameters.SuffixSearchList = @('fourthcoffee.com', 'fabrikam.com')
-                        Test-TargetResource @testTargetResourceParameters | Should Be $False
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $False
                     }
 
                     It 'Should call expected Mocks' {

--- a/Tests/Unit/MSFT_xDnsConnectionSuffix.Tests.ps1
+++ b/Tests/Unit/MSFT_xDnsConnectionSuffix.Tests.ps1
@@ -51,7 +51,7 @@ try
 
                     $targetResource = Get-TargetResource @testDnsSuffixParams
 
-                    $targetResource -is [System.Collections.Hashtable] | Should Be $true
+                    $targetResource -is [System.Collections.Hashtable] | Should -Be $true
                 }
 
                 It 'Should return "Present" when DNS suffix matches and "Ensure" = "Present"' {
@@ -59,7 +59,7 @@ try
 
                     $targetResource = Get-TargetResource @testDnsSuffixParams
 
-                    $targetResource.Ensure | Should Be 'Present'
+                    $targetResource.Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return "Absent" when DNS suffix does not match and "Ensure" = "Present"' {
@@ -67,7 +67,7 @@ try
 
                     $targetResource = Get-TargetResource @testDnsSuffixParams
 
-                    $targetResource.Ensure | Should Be 'Absent'
+                    $targetResource.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return "Absent" when no DNS suffix is defined and "Ensure" = "Present"' {
@@ -75,7 +75,7 @@ try
 
                     $targetResource = Get-TargetResource @testDnsSuffixParams
 
-                    $targetResource.Ensure | Should Be 'Absent'
+                    $targetResource.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return "Absent" when no DNS suffix is defined and "Ensure" = "Absent"' {
@@ -83,7 +83,7 @@ try
 
                     $targetResource = Get-TargetResource @testDnsSuffixParams -Ensure Absent
 
-                    $targetResource.Ensure | Should Be 'Absent'
+                    $targetResource.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return "Present" when DNS suffix is defined and "Ensure" = "Absent"' {
@@ -91,7 +91,7 @@ try
 
                     $targetResource = Get-TargetResource @testDnsSuffixParams -Ensure Absent
 
-                    $targetResource.Ensure | Should Be 'Present'
+                    $targetResource.Ensure | Should -Be 'Present'
                 }
 
             } #end Context 'Validates "Get-TargetResource" method'
@@ -104,7 +104,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams
 
-                    $targetResource | Should Be $true
+                    $targetResource | Should -Be $true
                 }
 
                 It 'Should pass when no DNS suffix is registered and "Ensure" = "Absent"' {
@@ -112,7 +112,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams -Ensure Absent
 
-                    $targetResource | Should Be $true
+                    $targetResource | Should -Be $true
                 }
 
                 It 'Should pass when "RegisterThisConnectionsAddress" setting is correct' {
@@ -120,7 +120,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams -RegisterThisConnectionsAddress $true
 
-                    $targetResource | Should Be $true
+                    $targetResource | Should -Be $true
                 }
 
                 It 'Should pass when "UseSuffixWhenRegistering" setting is correct' {
@@ -128,7 +128,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams -UseSuffixWhenRegistering $false
 
-                    $targetResource | Should Be $true
+                    $targetResource | Should -Be $true
                 }
 
 
@@ -137,7 +137,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams
 
-                    $targetResource | Should Be $false
+                    $targetResource | Should -Be $false
                 }
 
                 It 'Should fail when the registered DNS suffix is incorrect and "Ensure" = "Present"' {
@@ -145,7 +145,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams
 
-                    $targetResource | Should Be $false
+                    $targetResource | Should -Be $false
                 }
 
                 It 'Should fail when a DNS suffix is registered and "Ensure" = "Absent"' {
@@ -153,7 +153,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams -Ensure Absent
 
-                    $targetResource | Should Be $false
+                    $targetResource | Should -Be $false
                 }
 
                 It 'Should fail when "RegisterThisConnectionsAddress" setting is incorrect' {
@@ -161,7 +161,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams -RegisterThisConnectionsAddress $false
 
-                    $targetResource | Should Be $false
+                    $targetResource | Should -Be $false
                 }
 
                 It 'Should fail when "UseSuffixWhenRegistering" setting is incorrect' {
@@ -169,7 +169,7 @@ try
 
                     $targetResource = Test-TargetResource @testDnsSuffixParams -UseSuffixWhenRegistering $true
 
-                    $targetResource | Should Be $false
+                    $targetResource | Should -Be $false
                 }
             } #end Context 'Validates "Test-TargetResource" method'
         }

--- a/Tests/Unit/MSFT_xFirewall.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewall.Tests.ps1
@@ -47,8 +47,8 @@ try
 
                 It "Should return absent on firewall rule $($firewallRule.Name)" {
                     $result = Get-TargetResource -Name 'FirewallRule'
-                    $result.Name | Should Be 'FirewallRule'
-                    $result.Ensure | Should Be 'Absent'
+                    $result.Name | Should -Be 'FirewallRule'
+                    $result.Ensure | Should -Be 'Absent'
                 }
             }
 
@@ -77,7 +77,7 @@ try
                             $parameterNew = $parameterNew -join ','
                         }
 
-                        $parameterNew | Should Be $parameterValue
+                        $parameterNew | Should -Be $parameterValue
                     }
                 }
             }
@@ -91,7 +91,7 @@ try
 
                 It "Should return $true on firewall rule $($firewallRule.Name)" {
                     $result = Test-TargetResource -Name 'FirewallRule' -Ensure 'Absent'
-                    $result | Should Be $true
+                    $result | Should -Be $true
                 }
             }
 
@@ -100,7 +100,7 @@ try
 
                 It "Should return $false on firewall rule $($firewallRule.Name)" {
                     $result = Test-TargetResource -Name $firewallRule.Name -Ensure 'Absent'
-                    $result | Should Be $false
+                    $result | Should -Be $false
                 }
             }
 
@@ -109,7 +109,7 @@ try
 
                 It "Should return $true on firewall rule $($firewallRule.Name)" {
                     $result = Test-TargetResource -Name $firewallRule.Name
-                    $result | Should Be $true
+                    $result | Should -Be $true
                 }
             }
 
@@ -118,7 +118,7 @@ try
 
                 It "Should return $false on firewall rule $($firewallRule.Name)" {
                     $result = Test-TargetResource -Name $firewallRule.Name
-                    $result | Should Be $false
+                    $result | Should -Be $false
                 }
             }
 
@@ -126,7 +126,7 @@ try
                 Mock -CommandName Get-FirewallRule
                 It "Should return $false on firewall rule $($firewallRule.Name)" {
                     $result = Test-TargetResource -Name $firewallRule.Name
-                    $result | Should Be $false
+                    $result | Should -Be $false
                 }
             }
         }
@@ -748,7 +748,7 @@ try
 
                 It "Should return True on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $true
+                    $result | Should -Be $true
                 }
             }
 
@@ -758,7 +758,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -768,7 +768,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -778,7 +778,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -796,7 +796,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -814,7 +814,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -832,7 +832,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -850,7 +850,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -860,7 +860,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -870,7 +870,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -888,7 +888,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -898,7 +898,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -908,7 +908,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -918,7 +918,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -936,7 +936,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -954,7 +954,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -964,7 +964,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -982,7 +982,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -992,7 +992,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1002,7 +1002,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1012,7 +1012,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1022,7 +1022,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1032,7 +1032,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1042,7 +1042,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1052,7 +1052,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1062,7 +1062,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1072,7 +1072,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1082,7 +1082,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1092,7 +1092,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1102,7 +1102,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1112,7 +1112,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
 
@@ -1122,7 +1122,7 @@ try
 
                 It "Should return False on firewall rule $($firewallRule.Name)" {
                     $result = Test-RuleProperties -FirewallRule $firewallRule @compareRule
-                    $result | Should be $False
+                    $result | Should -Be $False
                 }
             }
         }
@@ -1133,14 +1133,14 @@ try
             Context 'testing with firewall that exists' {
                 It "Should return a firewall rule when name is passed on firewall rule $($firewallRule.Name)" {
                     $result = Get-FirewallRule -Name $firewallRule.Name
-                    $result | Should Not BeNullOrEmpty
+                    $result | Should -Not -BeNullOrEmpty
                 }
             }
 
             Context 'testing with firewall that does not exist' {
                 It "Should not return anything on firewall rule $($firewallRule.Name)" {
                     $result = Get-FirewallRule -Name 'Does not exist'
-                    $result | Should BeNullOrEmpty
+                    $result | Should -BeNullOrEmpty
                 }
             }
 
@@ -1151,7 +1151,7 @@ try
                     -Message ($LocalizedData.RuleNotUniqueError -f 2, $firewallRule.Name)
 
                 It "Should throw RuleNotUnique exception on firewall rule $($firewallRule.Name)" {
-                    { $result = Get-FirewallRule -Name $firewallRule.Name } | Should Throw $errorRecord
+                    { $result = Get-FirewallRule -Name $firewallRule.Name } | Should -Throw $errorRecord
                 }
             }
         }
@@ -1167,57 +1167,57 @@ try
                     $expected = Get-NetFirewallAddressFilter -AssociatedNetFirewallRule $firewallRule
 
                     $($result.AddressFilters | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
 
                 It "Should return the right application filter on firewall rule $($firewallRule.Name)" {
                     $expected = Get-NetFirewallApplicationFilter -AssociatedNetFirewallRule $firewallRule
 
                     $($result.ApplicationFilters | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
 
                 It "Should return the right interface filter on firewall rule $($firewallRule.Name)" {
                     $expected = Get-NetFirewallInterfaceFilter -AssociatedNetFirewallRule $firewallRule
 
                     $($result.InterfaceFilters | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
 
                 It "Should return the right interface type filter on firewall rule $($firewallRule.Name)" {
                     $expected = Get-NetFirewallInterfaceTypeFilter -AssociatedNetFirewallRule $firewallRule
                     $($result.InterfaceTypeFilters | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
 
                 It "Should return the right port filter on firewall rule $($firewallRule.Name)" {
                     $expected = Get-NetFirewallPortFilter -AssociatedNetFirewallRule $firewallRule
                     $($result.PortFilters | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
 
                 It "Should return the right Profile on firewall rule $($firewallRule.Name)" {
                     $expected = Get-NetFirewallProfile -AssociatedNetFirewallRule $firewallRule
                     $($result.Profile | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
 
                 It "Should return the right Profile on firewall rule $($firewallRule.Name)" {
                     $expected = Get-NetFirewallProfile -AssociatedNetFirewallRule $firewallRule
                     $($result.Profile | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
 
                 It "Should return the right Security Filters on firewall rule $($firewallRule.Name)" {
                     $expected = Get-NetFirewallSecurityFilter -AssociatedNetFirewallRule $firewallRule
                     $($result.SecurityFilters | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
 
                 It "Should return the right Service Filters on firewall rule $($firewallRule.Name)" {
                     $expected = Get-NetFirewallServiceFilter -AssociatedNetFirewallRule $firewallRule
                     $($result.ServiceFilters | Out-String -Stream) |
-                        Should Be $($expected | Out-String -Stream)
+                        Should -Be $($expected | Out-String -Stream)
                 }
             }
         }

--- a/Tests/Unit/MSFT_xFirewallProfile.Tests.ps1
+++ b/Tests/Unit/MSFT_xFirewallProfile.Tests.ps1
@@ -105,24 +105,24 @@ try
             Context 'Firewall Profile Exists' {
                 It 'Should return correct Firewall Profile values' {
                     $getTargetResourceParameters = Get-TargetResource -Name 'Private'
-                    $getTargetResourceParameters.Name                            | Should Be $firewallProfile.Name
-                    $getTargetResourceParameters.Enabled                         | Should Be $firewallProfile.Enabled
-                    $getTargetResourceParameters.DefaultInboundAction            | Should Be $firewallProfile.DefaultInboundAction
-                    $getTargetResourceParameters.DefaultOutboundAction           | Should Be $firewallProfile.DefaultOutboundAction
-                    $getTargetResourceParameters.AllowInboundRules               | Should Be $firewallProfile.AllowInboundRules
-                    $getTargetResourceParameters.AllowLocalFirewallRules         | Should Be $firewallProfile.AllowLocalFirewallRules
-                    $getTargetResourceParameters.AllowLocalIPsecRules            | Should Be $firewallProfile.AllowLocalIPsecRules
-                    $getTargetResourceParameters.AllowUserApps                   | Should Be $firewallProfile.AllowUserApps
-                    $getTargetResourceParameters.AllowUserPorts                  | Should Be $firewallProfile.AllowUserPorts
-                    $getTargetResourceParameters.AllowUnicastResponseToMulticast | Should Be $firewallProfile.AllowUnicastResponseToMulticast
-                    $getTargetResourceParameters.NotifyOnListen                  | Should Be $firewallProfile.NotifyOnListen
-                    $getTargetResourceParameters.EnableStealthModeForIPsec       | Should Be $firewallProfile.EnableStealthModeForIPsec
-                    $getTargetResourceParameters.LogFileName                     | Should Be $firewallProfile.LogFileName
-                    $getTargetResourceParameters.LogMaxSizeKilobytes             | Should Be $firewallProfile.LogMaxSizeKilobytes
-                    $getTargetResourceParameters.LogAllowed                      | Should Be $firewallProfile.LogAllowed
-                    $getTargetResourceParameters.LogBlocked                      | Should Be $firewallProfile.LogBlocked
-                    $getTargetResourceParameters.LogIgnored                      | Should Be $firewallProfile.LogIgnored
-                    $getTargetResourceParameters.DisabledInterfaceAliases        | Should Be $firewallProfile.DisabledInterfaceAliases
+                    $getTargetResourceParameters.Name                            | Should -Be $firewallProfile.Name
+                    $getTargetResourceParameters.Enabled                         | Should -Be $firewallProfile.Enabled
+                    $getTargetResourceParameters.DefaultInboundAction            | Should -Be $firewallProfile.DefaultInboundAction
+                    $getTargetResourceParameters.DefaultOutboundAction           | Should -Be $firewallProfile.DefaultOutboundAction
+                    $getTargetResourceParameters.AllowInboundRules               | Should -Be $firewallProfile.AllowInboundRules
+                    $getTargetResourceParameters.AllowLocalFirewallRules         | Should -Be $firewallProfile.AllowLocalFirewallRules
+                    $getTargetResourceParameters.AllowLocalIPsecRules            | Should -Be $firewallProfile.AllowLocalIPsecRules
+                    $getTargetResourceParameters.AllowUserApps                   | Should -Be $firewallProfile.AllowUserApps
+                    $getTargetResourceParameters.AllowUserPorts                  | Should -Be $firewallProfile.AllowUserPorts
+                    $getTargetResourceParameters.AllowUnicastResponseToMulticast | Should -Be $firewallProfile.AllowUnicastResponseToMulticast
+                    $getTargetResourceParameters.NotifyOnListen                  | Should -Be $firewallProfile.NotifyOnListen
+                    $getTargetResourceParameters.EnableStealthModeForIPsec       | Should -Be $firewallProfile.EnableStealthModeForIPsec
+                    $getTargetResourceParameters.LogFileName                     | Should -Be $firewallProfile.LogFileName
+                    $getTargetResourceParameters.LogMaxSizeKilobytes             | Should -Be $firewallProfile.LogMaxSizeKilobytes
+                    $getTargetResourceParameters.LogAllowed                      | Should -Be $firewallProfile.LogAllowed
+                    $getTargetResourceParameters.LogBlocked                      | Should -Be $firewallProfile.LogBlocked
+                    $getTargetResourceParameters.LogIgnored                      | Should -Be $firewallProfile.LogIgnored
+                    $getTargetResourceParameters.DisabledInterfaceAliases        | Should -Be $firewallProfile.DisabledInterfaceAliases
                 }
 
                 It 'Should call the expected mocks' {
@@ -143,7 +143,7 @@ try
                     {
                         $setTargetResourceParameters = $firewallProfileSplat.Clone()
                         Set-TargetResource @setTargetResourceParameters
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call expected Mocks' {
@@ -163,7 +163,7 @@ try
                             $setTargetResourceParameters = $firewallProfileSplat.Clone()
                             $setTargetResourceParameters.$parameterName = 'True'
                             Set-TargetResource @setTargetResourceParameters
-                        } | Should Not Throw
+                        } | Should -Not -Throw
                     }
 
                     It 'Should call expected Mocks' {
@@ -184,7 +184,7 @@ try
                             $setTargetResourceParameters = $firewallProfileSplat.Clone()
                             $setTargetResourceParameters.$parameterName = 'Allow'
                             Set-TargetResource @setTargetResourceParameters
-                        } | Should Not Throw
+                        } | Should -Not -Throw
                     }
 
                     It 'Should call expected Mocks' {
@@ -202,7 +202,7 @@ try
                         $setTargetResourceParameters = $firewallProfileSplat.Clone()
                         $setTargetResourceParameters.LogFileName = 'c:\differentfile.txt'
                         Set-TargetResource @setTargetResourceParameters
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call expected Mocks' {
@@ -219,7 +219,7 @@ try
                         $setTargetResourceParameters = $firewallProfileSplat.Clone()
                         $setTargetResourceParameters.DisabledInterfaceAliases = 'DifferentInterface'
                         Set-TargetResource @setTargetResourceParameters
-                    } | Should Not Throw
+                    } | Should -Not -Throw
                 }
 
                 It 'Should call expected Mocks' {
@@ -237,7 +237,7 @@ try
             Context 'Firewall Profile all parameters are the same' {
                 It 'Should return true' {
                     $testTargetResourceParameters = $firewallProfileSplat.Clone()
-                    Test-TargetResource @testTargetResourceParameters | Should Be $true
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $true
                 }
 
                 It 'Should call expected Mocks' {
@@ -252,7 +252,7 @@ try
                     It 'Should return false' {
                         $testTargetResourceParameters = $firewallProfileSplat.Clone()
                         $testTargetResourceParameters.$parameterName = 'True'
-                        Test-TargetResource @testTargetResourceParameters | Should Be $False
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $False
                     }
 
                     It 'Should call expected Mocks' {
@@ -268,7 +268,7 @@ try
                     It 'Should return false' {
                         $testTargetResourceParameters = $firewallProfileSplat.Clone()
                         $testTargetResourceParameters.$parameterName = 'Allow'
-                        Test-TargetResource @testTargetResourceParameters | Should Be $False
+                        Test-TargetResource @testTargetResourceParameters | Should -Be $False
                     }
 
                     It 'Should call expected Mocks' {
@@ -281,7 +281,7 @@ try
                 It 'Should return false' {
                     $testTargetResourceParameters = $firewallProfileSplat.Clone()
                     $testTargetResourceParameters.LogFileName = 'c:\differentfile.txt'
-                    Test-TargetResource @testTargetResourceParameters | Should Be $False
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $False
                 }
 
                 It 'Should call expected Mocks' {
@@ -293,7 +293,7 @@ try
                 It 'Should return false' {
                     $testTargetResourceParameters = $firewallProfileSplat.Clone()
                     $testTargetResourceParameters.DisabledInterfaceAliases = 'DifferentInterface'
-                    Test-TargetResource @testTargetResourceParameters | Should Be $False
+                    Test-TargetResource @testTargetResourceParameters | Should -Be $False
                 }
 
                 It 'Should call expected Mocks' {

--- a/Tests/Unit/MSFT_xHostsFile.Tests.ps1
+++ b/Tests/Unit/MSFT_xHostsFile.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xNetworking'
+$script:DSCModuleName = 'xNetworking'
 $script:DSCResourceName = 'MSFT_xHostsFile'
 
 #region HEADER
@@ -46,11 +46,11 @@ try
                 }
 
                 It 'Should return absent from the get method' {
-                    (Get-TargetResource @testParams).Ensure | Should Be 'Absent'
+                    (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return false from the test method' {
-                    Test-TargetResource @testParams | Should Be $false
+                    Test-TargetResource @testParams | Should -Be $false
                 }
 
                 It 'Should create the entry in the set method' {
@@ -78,11 +78,11 @@ try
                 }
 
                 It 'Should return present from the get method' {
-                    (Get-TargetResource @testParams).Ensure | Should Be 'Present'
+                    (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return false from the test method' {
-                    Test-TargetResource @testParams | Should Be $false
+                    Test-TargetResource @testParams | Should -Be $false
                 }
 
                 It 'Should update the entry in the set method' {
@@ -110,11 +110,11 @@ try
                 }
 
                 It 'Should return present from the get method' {
-                    (Get-TargetResource @testParams).Ensure | Should Be 'Present'
+                    (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return true from the test method' {
-                    Test-TargetResource @testParams | Should Be $true
+                    Test-TargetResource @testParams | Should -Be $true
                 }
             }
 
@@ -137,11 +137,11 @@ try
                 }
 
                 It 'Should return present from the get method' {
-                    (Get-TargetResource @testParams).Ensure | Should Be 'Present'
+                    (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return false from the test method' {
-                    Test-TargetResource @testParams | Should Be $false
+                    Test-TargetResource @testParams | Should -Be $false
                 }
 
                 It 'Should remove the entry in the set method' {
@@ -169,11 +169,11 @@ try
                 }
 
                 It 'Should return present from the get method' {
-                    (Get-TargetResource @testParams).Ensure | Should Be 'Absent'
+                    (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return false from the test method' {
-                    Test-TargetResource @testParams | Should Be $false
+                    Test-TargetResource @testParams | Should -Be $false
                 }
 
                 It 'Should add the entry in the set method' {
@@ -200,11 +200,11 @@ try
                 }
 
                 It 'Should return absent from the get method' {
-                    (Get-TargetResource @testParams).Ensure | Should Be 'Absent'
+                    (Get-TargetResource @testParams).Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should return true from the test method' {
-                    Test-TargetResource @testParams | Should Be $true
+                    Test-TargetResource @testParams | Should -Be $true
                 }
             }
 
@@ -227,11 +227,11 @@ try
                 }
 
                 It 'Should return present from the get method' {
-                    (Get-TargetResource @testParams).Ensure | Should Be 'Present'
+                    (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return true from the test method' {
-                    Test-TargetResource @testParams | Should Be $true
+                    Test-TargetResource @testParams | Should -Be $true
                 }
             }
 
@@ -254,11 +254,11 @@ try
                 }
 
                 It 'Should return present from the get method' {
-                    (Get-TargetResource @testParams).Ensure | Should Be 'Present'
+                    (Get-TargetResource @testParams).Ensure | Should -Be 'Present'
                 }
 
                 It 'Should return false from the test method' {
-                    Test-TargetResource @testParams | Should Be $false
+                    Test-TargetResource @testParams | Should -Be $false
                 }
 
                 It 'Should update the entry in the set method' {
@@ -284,7 +284,7 @@ try
                 }
 
                 It 'Should throw an error when IP Address is not provide and ensure is present' {
-                    { Set-TargetResource @testParams } | Should throw $LocalizedData.UnableToEnsureWithoutIP
+                    { Set-TargetResource @testParams } | Should -Throw $LocalizedData.UnableToEnsureWithoutIP
                 }
             }
         }

--- a/Tests/Unit/MSFT_xIPAddress.Tests.ps1
+++ b/Tests/Unit/MSFT_xIPAddress.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xNetworking'
+$script:DSCModuleName = 'xNetworking'
 $script:DSCResourceName = 'MSFT_xIPAddress'
 
 Import-Module -Name (Join-Path -Path (Join-Path -Path (Split-Path $PSScriptRoot -Parent) -ChildPath 'TestHelpers') -ChildPath 'CommonTestHelper.psm1') -Global
@@ -45,7 +45,7 @@ try
                     }
 
                     $result = Get-TargetResource @getTargetResourceParameters
-                    $result.IPAddress | Should Be $getTargetResourceParameters.IPAddress
+                    $result.IPAddress | Should -Be $getTargetResourceParameters.IPAddress
                 }
             }
 
@@ -70,7 +70,7 @@ try
                     }
 
                     $result = Get-TargetResource @getTargetResourceParameters
-                    $result.IPAddress | Should Be $getTargetResourceParameters.IPAddress
+                    $result.IPAddress | Should -Be $getTargetResourceParameters.IPAddress
                 }
             }
         }
@@ -112,8 +112,8 @@ try
                             InterfaceAlias = 'Ethernet'
                             AddressFamily  = 'IPv4'
                         }
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call all the mocks' {
@@ -132,8 +132,8 @@ try
                             InterfaceAlias = 'Ethernet'
                             AddressFamily  = 'IPv4'
                         }
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call all the mocks' {
@@ -153,8 +153,8 @@ try
                             AddressFamily  = 'IPv4'
                         }
 
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call expected mocks' {
@@ -177,8 +177,8 @@ try
                             AddressFamily  = 'IPv4'
                         }
 
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call expected mocks' {
@@ -200,8 +200,8 @@ try
                             AddressFamily  = 'IPv4'
                         }
 
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call expected mocks' {
@@ -253,8 +253,8 @@ try
                             AddressFamily  = 'IPv6'
                         }
 
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call all the mocks' {
@@ -274,8 +274,8 @@ try
                             AddressFamily  = 'IPv6'
                         }
 
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call all the mocks' {
@@ -295,8 +295,8 @@ try
                             AddressFamily  = 'IPv6'
                         }
 
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call expected mocks' {
@@ -353,8 +353,8 @@ try
                             AddressFamily  = 'IPv4'
                         }
 
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call expected mocks' {
@@ -374,8 +374,8 @@ try
                             AddressFamily  = 'IPv4'
                         }
 
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call expected mocks' {
@@ -421,7 +421,7 @@ try
                             -Message ($LocalizedData.AddressFormatError -f $testGetResourceParameters.IPAddress) `
                             -ArgumentName 'IPAddress'
 
-                        { $result = Test-TargetResource @testGetResourceParameters } | Should Throw $errorRecord
+                        { $result = Test-TargetResource @testGetResourceParameters } | Should -Throw $errorRecord
                     }
                 }
 
@@ -434,7 +434,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -451,7 +451,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
 
                     It 'Should call appropriate mocks' {
@@ -468,7 +468,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -505,7 +505,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -522,7 +522,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -539,7 +539,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
 
                     It 'Should call appropriate mocks' {
@@ -556,7 +556,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -573,7 +573,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -590,7 +590,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
                     It 'Should call appropriate mocks' {
                         Assert-MockCalled -CommandName Get-NetIPAddress -Exactly -Times 1
@@ -606,7 +606,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -643,7 +643,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
 
                     It 'Should call appropriate mocks' {
@@ -680,7 +680,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
 
                     It 'Should call appropriate mocks' {
@@ -717,7 +717,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
 
                     It 'Should call appropriate mocks' {
@@ -757,7 +757,7 @@ try
                             -Message ($LocalizedData.AddressFormatError -f $testGetResourceParameters.IPAddress) `
                             -ArgumentName 'IPAddress'
 
-                        { $result = Test-TargetResource @testGetResourceParameters } | Should Throw $errorRecord
+                        { $result = Test-TargetResource @testGetResourceParameters } | Should -Throw $errorRecord
                     }
                 }
 
@@ -770,7 +770,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -786,7 +786,7 @@ try
                             AddressFamily  = 'IPv6'
                         }
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
 
                     It 'Should call appropriate mocks' {
@@ -803,7 +803,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
 
                     It 'Should call appropriate mocks' {
@@ -840,7 +840,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -857,7 +857,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -874,7 +874,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
 
                     It 'Should call appropriate mocks' {
@@ -891,7 +891,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -908,7 +908,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $false
+                        $result | Should -Be $false
                     }
 
                     It 'Should call appropriate mocks' {
@@ -939,7 +939,7 @@ try
                         -Message ($LocalizedData.InterfaceNotAvailableError -f $assertResourcePropertyParameters.InterfaceAlias) `
                         -ArgumentName 'Interface'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $errorRecord
                 }
             }
 
@@ -955,7 +955,7 @@ try
                         -Message ($LocalizedData.AddressFormatError -f $assertResourcePropertyParameters.IPAddress) `
                         -ArgumentName 'IPAddress'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $errorRecord
                 }
             }
 
@@ -971,7 +971,7 @@ try
                         -Message ($LocalizedData.AddressIPv4MismatchError -f $assertResourcePropertyParameters.IPAddress, $assertResourcePropertyParameters.AddressFamily) `
                         -ArgumentName 'IPAddress'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $errorRecord
                 }
             }
 
@@ -987,7 +987,7 @@ try
                         -Message ($LocalizedData.AddressIPv6MismatchError -f $assertResourcePropertyParameters.IPAddress, $assertResourcePropertyParameters.AddressFamily) `
                         -ArgumentName 'IPAddress'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $errorRecord
                 }
             }
 
@@ -999,7 +999,7 @@ try
                         AddressFamily  = 'IPv4'
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Not -Throw
                 }
             }
 
@@ -1011,7 +1011,7 @@ try
                         AddressFamily  = 'IPv4'
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Not -Throw
                 }
             }
 
@@ -1023,7 +1023,7 @@ try
                         AddressFamily  = 'IPv6'
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Not -Throw
                 }
             }
 
@@ -1041,7 +1041,7 @@ try
                         -Message ($LocalizedData.PrefixLengthError -f $prefixLength, $assertResourcePropertyParameters.AddressFamily) `
                         -ArgumentName 'IPAddress'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $errorRecord
                 }
 
                 It 'Should throw an Argument error when less than 0' {
@@ -1050,7 +1050,7 @@ try
                         InterfaceAlias = 'Ethernet'
                         AddressFamily  = 'IPv4'
                     }
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw 'Value was either too large or too small for a UInt32.'
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw 'Value was either too large or too small for a UInt32.'
                 }
             }
 
@@ -1068,7 +1068,7 @@ try
                         -Message ($LocalizedData.PrefixLengthError -f $prefixLength, $assertResourcePropertyParameters.AddressFamily) `
                         -ArgumentName 'IPAddress'
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw $errorRecord
                 }
 
                 It 'Should throw an Argument error when less than 0' {
@@ -1078,7 +1078,7 @@ try
                         AddressFamily  = 'IPv6'
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Throw 'Value was either too large or too small for a UInt32.'
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Throw 'Value was either too large or too small for a UInt32.'
                 }
             }
 
@@ -1090,7 +1090,7 @@ try
                         AddressFamily  = 'IPv6'
                     }
 
-                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should Not Throw
+                    { Assert-ResourceProperty @assertResourcePropertyParameters } | Should -Not -Throw
                 }
             }
         }

--- a/Tests/Unit/MSFT_xIPAddressOption.Tests.ps1
+++ b/Tests/Unit/MSFT_xIPAddressOption.Tests.ps1
@@ -43,8 +43,8 @@ try
                         IPAddress = '192.168.0.1'
                     }
                     $result = Get-TargetResource @getTargetResourceParameters
-                    $result.IPAddress    | Should Be $getTargetResourceParameters.IPAddress
-                    $result.SkipAsSource | Should Be $true
+                    $result.IPAddress    | Should -Be $getTargetResourceParameters.IPAddress
+                    $result.SkipAsSource | Should -Be $true
                 }
             }
         }
@@ -72,8 +72,8 @@ try
                             IPAddress    = '192.168.0.1'
                             SkipAsSource = $true
                         }
-                        { $result = Set-TargetResource @setTargetResourceParameters } | Should Not Throw
-                        $result | Should BeNullOrEmpty
+                        { $result = Set-TargetResource @setTargetResourceParameters } | Should -Not -Throw
+                        $result | Should -BeNullOrEmpty
                     }
 
                     It 'Should call all the mock' {
@@ -106,7 +106,7 @@ try
                         }
 
                         $result = Test-TargetResource @testGetResourceParameters
-                        $result | Should Be $true
+                        $result | Should -Be $true
                     }
                 }
             }

--- a/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterBinding.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xNetworking'
+$script:DSCModuleName = 'xNetworking'
 $script:DSCResourceName = 'MSFT_xNetAdapterBinding'
 
 #region HEADER
@@ -75,10 +75,10 @@ try
 
                 It 'Should return existing binding' {
                     $result = Get-TargetResource @testBindingEnabled
-                    $result.InterfaceAlias | Should Be $testBindingEnabled.InterfaceAlias
-                    $result.ComponentId | Should Be $testBindingEnabled.ComponentId
-                    $result.State | Should Be 'Enabled'
-                    $result.CurrentState | Should Be 'Enabled'
+                    $result.InterfaceAlias | Should -Be $testBindingEnabled.InterfaceAlias
+                    $result.ComponentId | Should -Be $testBindingEnabled.ComponentId
+                    $result.State | Should -Be 'Enabled'
+                    $result.CurrentState | Should -Be 'Enabled'
                 }
 
                 It 'Should call all the mocks' {
@@ -91,10 +91,10 @@ try
 
                 It 'Should return existing binding' {
                     $result = Get-TargetResource @testBindingDisabled
-                    $result.InterfaceAlias | Should Be $testBindingDisabled.InterfaceAlias
-                    $result.ComponentId | Should Be $testBindingDisabled.ComponentId
-                    $result.State | Should Be 'Disabled'
-                    $result.CurrentState | Should Be 'Disabled'
+                    $result.InterfaceAlias | Should -Be $testBindingDisabled.InterfaceAlias
+                    $result.ComponentId | Should -Be $testBindingDisabled.ComponentId
+                    $result.State | Should -Be 'Disabled'
+                    $result.CurrentState | Should -Be 'Disabled'
                 }
 
                 It 'Should call all the mocks' {
@@ -107,10 +107,10 @@ try
 
                 It 'Should return existing binding' {
                     $result = Get-TargetResource @testBindingMixed
-                    $result.InterfaceAlias | Should Be $testBindingMixed.InterfaceAlias
-                    $result.ComponentId | Should Be $testBindingMixed.ComponentId
-                    $result.State | Should Be 'Enabled'
-                    $result.CurrentState | Should Be 'Mixed'
+                    $result.InterfaceAlias | Should -Be $testBindingMixed.InterfaceAlias
+                    $result.ComponentId | Should -Be $testBindingMixed.ComponentId
+                    $result.State | Should -Be 'Enabled'
+                    $result.CurrentState | Should -Be 'Mixed'
                 }
 
                 It 'Should call all the mocks' {
@@ -127,7 +127,7 @@ try
                 Mock -CommandName Disable-NetAdapterBinding
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testBindingEnabled } | Should Not Throw
+                    { Set-TargetResource @testBindingEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call all the mocks' {
@@ -143,7 +143,7 @@ try
                 Mock -CommandName Disable-NetAdapterBinding
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testBindingDisabled } | Should Not Throw
+                    { Set-TargetResource @testBindingDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call all the mocks' {
@@ -159,7 +159,7 @@ try
                 Mock -CommandName Get-Binding -MockWith { $mockBindingEnabled }
 
                 It 'Should return false' {
-                    Test-TargetResource @testBindingDisabled | Should Be $False
+                    Test-TargetResource @testBindingDisabled | Should -Be $False
                 }
 
                 It 'Should call all the mocks' {
@@ -171,7 +171,7 @@ try
                 Mock -CommandName Get-Binding -MockWith { $mockBindingDisabled }
 
                 It 'Should return false' {
-                    Test-TargetResource @testBindingEnabled | Should Be $False
+                    Test-TargetResource @testBindingEnabled | Should -Be $False
                 }
 
                 It 'Should call all the mocks' {
@@ -183,7 +183,7 @@ try
                 Mock -CommandName Get-Binding -MockWith { $mockBindingEnabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testBindingEnabled | Should Be $true
+                    Test-TargetResource @testBindingEnabled | Should -Be $true
                 }
 
                 It 'Should call all the mocks' {
@@ -195,7 +195,7 @@ try
                 Mock -CommandName Get-Binding -MockWith { $mockBindingDisabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testBindingDisabled | Should Be $true
+                    Test-TargetResource @testBindingDisabled | Should -Be $true
                 }
 
                 It 'Should call all the mocks' {
@@ -213,7 +213,7 @@ try
                         -Message ($LocalizedData.InterfaceNotAvailableError -f $testBindingEnabled.InterfaceAlias) `
                         -ArgumentName 'Interface'
 
-                    { Get-Binding @testBindingEnabled } | Should Throw $errorRecord
+                    { Get-Binding @testBindingEnabled } | Should -Throw $errorRecord
                 }
 
                 It 'Should call all the mocks' {
@@ -227,9 +227,9 @@ try
 
                 It 'Should return the adapter binding' {
                     $result = Get-Binding @testBindingEnabled
-                    $result.InterfaceAlias | Should Be $mockBindingEnabled.InterfaceAlias
-                    $result.ComponentId    | Should Be $mockBindingEnabled.ComponentId
-                    $result.Enabled        | Should Be $mockBindingEnabled.Enabled
+                    $result.InterfaceAlias | Should -Be $mockBindingEnabled.InterfaceAlias
+                    $result.ComponentId    | Should -Be $mockBindingEnabled.ComponentId
+                    $result.Enabled        | Should -Be $mockBindingEnabled.Enabled
                 }
 
                 It 'Should call all the mocks' {
@@ -244,9 +244,9 @@ try
 
                 It 'Should return the adapter binding' {
                     $result = Get-Binding @testBindingDisabled
-                    $result.InterfaceAlias | Should Be $mockBindingDisabled.InterfaceAlias
-                    $result.ComponentId    | Should Be $mockBindingDisabled.ComponentId
-                    $result.Enabled        | Should Be $mockBindingDisabled.Enabled
+                    $result.InterfaceAlias | Should -Be $mockBindingDisabled.InterfaceAlias
+                    $result.ComponentId    | Should -Be $mockBindingDisabled.ComponentId
+                    $result.Enabled        | Should -Be $mockBindingDisabled.Enabled
                 }
 
                 It 'Should call all the mocks' {

--- a/Tests/Unit/MSFT_xNetAdapterRDMA.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterRDMA.Tests.ps1
@@ -69,8 +69,8 @@ try
 
                 It 'Should return network adapter RDMA properties' {
                     $Result = Get-TargetResource @targetParameters
-                    $Result.Name                   | Should Be $targetParameters.Name
-                    $Result.Enabled                | Should Be $true
+                    $Result.Name                   | Should -Be $targetParameters.Name
+                    $Result.Enabled                | Should -Be $true
                 }
 
                 It 'Should call the expected mocks' {

--- a/Tests/Unit/MSFT_xNetAdapterRsc.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterRsc.Tests.ps1
@@ -76,8 +76,8 @@ try
 
                 It 'Should return the Rsc state' {
                     $result = Get-TargetResource @TestAllRscEnabled
-                    $result.StateIPv4 | Should Be $TestAllRscEnabled.State
-                    $result.StateIPv6 | Should Be $TestAllRscEnabled.State
+                    $result.StateIPv4 | Should -Be $TestAllRscEnabled.State
+                    $result.StateIPv6 | Should -Be $TestAllRscEnabled.State
                 }
 
                 It 'Should call all mocks' {
@@ -95,8 +95,8 @@ try
 
                 It 'Should return the Rsc state' {
                     $result = Get-TargetResource @TestAllRscDisabled
-                    $result.StateIPv4 | Should Be $TestAllRscDisabled.State
-                    $result.StateIPv6 | Should Be $TestAllRscDisabled.State
+                    $result.StateIPv4 | Should -Be $TestAllRscDisabled.State
+                    $result.StateIPv6 | Should -Be $TestAllRscDisabled.State
 
                 }
 
@@ -115,7 +115,7 @@ try
 
                 It 'Should return the Rsc state of IPv4' {
                     $result = Get-TargetResource @TestIPv4RscEnabled
-                    $result.State | Should Be $TestIPv4RscEnabled.State
+                    $result.State | Should -Be $TestIPv4RscEnabled.State
                 }
 
                 It 'Should call all mocks' {
@@ -132,7 +132,7 @@ try
 
                 It 'Should return the Rsc state of IPv4' {
                     $result = Get-TargetResource @TestIPv4RscDisabled
-                    $result.State | Should Be $TestIPv4RscDisabled.State
+                    $result.State | Should -Be $TestIPv4RscDisabled.State
                 }
 
                 It 'Should call all mocks' {
@@ -149,7 +149,7 @@ try
 
                 It 'Should return the Rsc state of IPv6' {
                     $result = Get-TargetResource @TestIPv6RscEnabled
-                    $result.State | Should Be $TestIPv6RscEnabled.State
+                    $result.State | Should -Be $TestIPv6RscEnabled.State
                 }
 
                 It 'Should call all mocks' {
@@ -166,7 +166,7 @@ try
 
                 It 'Should return the Rsc state of IPv6' {
                     $result = Get-TargetResource @TestIPv6RscDisabled
-                    $result.State | Should Be $TestIPv6RscDisabled.State
+                    $result.State | Should -Be $TestIPv6RscDisabled.State
                 }
 
                 It 'Should call all mocks' {
@@ -181,7 +181,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundMessage)
 
                 It 'Should throw an exception' {
-                    { Get-TargetResource @TestAdapterNotFound } | Should throw $errorRecord
+                    { Get-TargetResource @TestAdapterNotFound } | Should -Throw $errorRecord
                 }
 
                 It 'Should call all mocks' {
@@ -203,7 +203,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestAllRscEnabled } | Should Not Throw
+                    { Set-TargetResource @TestAllRscEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -222,7 +222,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestAllRscDisabled } | Should Not Throw
+                    { Set-TargetResource @TestAllRscDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -241,7 +241,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestAllRscDisabled } | Should Not Throw
+                    { Set-TargetResource @TestAllRscDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -260,7 +260,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestAllRscEnabled } | Should Not Throw
+                    { Set-TargetResource @TestAllRscEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -279,7 +279,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestAllRscEnabled } | Should Not Throw
+                    { Set-TargetResource @TestAllRscEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -298,7 +298,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestAllRscDisabled } | Should Not Throw
+                    { Set-TargetResource @TestAllRscDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -315,7 +315,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestIPv4RscEnabled } | Should Not Throw
+                    { Set-TargetResource @TestIPv4RscEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -331,7 +331,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestIPv4RscDisabled } | Should Not Throw
+                    { Set-TargetResource @TestIPv4RscDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -347,7 +347,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestIPv4RscDisabled } | Should Not Throw
+                    { Set-TargetResource @TestIPv4RscDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -363,7 +363,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestIPv4RscEnabled } | Should Not Throw
+                    { Set-TargetResource @TestIPv4RscEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -380,7 +380,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestIPv6RscEnabled } | Should Not Throw
+                    { Set-TargetResource @TestIPv6RscEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -396,7 +396,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestIPv6RscDisabled } | Should Not Throw
+                    { Set-TargetResource @TestIPv6RscDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -412,7 +412,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestIPv6RscDisabled } | Should Not Throw
+                    { Set-TargetResource @TestIPv6RscDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -428,7 +428,7 @@ try
                 Mock -CommandName Set-NetAdapterRsc
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @TestIPv6RscEnabled } | Should Not Throw
+                    { Set-TargetResource @TestIPv6RscEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call all mocks' {
@@ -445,7 +445,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundMessage)
 
                 It 'Should throw an exception' {
-                    { Set-TargetResource @TestAdapterNotFound } | Should throw $errorRecord
+                    { Set-TargetResource @TestAdapterNotFound } | Should -Throw $errorRecord
                 }
 
                 It 'Should call all mocks' {
@@ -466,7 +466,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @TestAllRscEnabled | Should Be $true
+                    Test-TargetResource @TestAllRscEnabled | Should -Be $true
                 }
 
                 it 'Should call all mocks' {
@@ -483,7 +483,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @TestAllRscDisabled | Should Be $false
+                    Test-TargetResource @TestAllRscDisabled | Should -Be $false
                 }
 
                 it 'Should call all mocks' {
@@ -499,7 +499,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @TestAllRscDisabled | Should Be $true
+                    Test-TargetResource @TestAllRscDisabled | Should -Be $true
                 }
 
                 it 'Should call all mocks' {
@@ -515,7 +515,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @TestAllRscEnabled | Should Be $false
+                    Test-TargetResource @TestAllRscEnabled | Should -Be $false
                 }
 
                 it 'Should call all mocks' {
@@ -530,7 +530,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @TestIPv4RscEnabled | Should Be $true
+                    Test-TargetResource @TestIPv4RscEnabled | Should -Be $true
                 }
 
                 it 'Should call all mocks' {
@@ -544,7 +544,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @TestIPv4RscDisabled | Should Be $false
+                    Test-TargetResource @TestIPv4RscDisabled | Should -Be $false
                 }
 
                 it 'Should call all mocks' {
@@ -558,7 +558,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @TestIPv4RscDisabled | Should Be $true
+                    Test-TargetResource @TestIPv4RscDisabled | Should -Be $true
                 }
 
                 it 'Should call all mocks' {
@@ -572,7 +572,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @TestIPv4RscEnabled | Should Be $false
+                    Test-TargetResource @TestIPv4RscEnabled | Should -Be $false
                 }
 
                 it 'Should call all mocks' {
@@ -587,7 +587,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @TestIPv6RscEnabled | Should Be $true
+                    Test-TargetResource @TestIPv6RscEnabled | Should -Be $true
                 }
 
                 it 'Should call all mocks' {
@@ -601,7 +601,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @TestIPv6RscDisabled | Should Be $false
+                    Test-TargetResource @TestIPv6RscDisabled | Should -Be $false
                 }
 
                 it 'Should call all mocks' {
@@ -615,7 +615,7 @@ try
                 }
 
                 It 'Should return true' {
-                    Test-TargetResource @TestIPv6RscDisabled | Should Be $true
+                    Test-TargetResource @TestIPv6RscDisabled | Should -Be $true
                 }
 
                 it 'Should call all mocks' {
@@ -629,7 +629,7 @@ try
                 }
 
                 It 'Should return false' {
-                    Test-TargetResource @TestIPv6RscEnabled | Should Be $false
+                    Test-TargetResource @TestIPv6RscEnabled | Should -Be $false
                 }
 
                 it 'Should call all mocks' {
@@ -645,7 +645,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundMessage)
 
                 It 'Should throw an exception' {
-                    { Test-TargetResource @TestAdapterNotFound } | Should throw $errorRecord
+                    { Test-TargetResource @TestAdapterNotFound } | Should -Throw $errorRecord
                 }
 
                 It 'Should call all mocks' {

--- a/Tests/Unit/MSFT_xNetAdapterRss.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetAdapterRss.Tests.ps1
@@ -1,4 +1,4 @@
-﻿$script:DSCModuleName = 'xNetworking'
+$script:DSCModuleName = 'xNetworking'
 $script:DSCResourceName = 'MSFT_xNetAdapterRss'
 
 #region HEADER
@@ -44,7 +44,7 @@ try
 
                 It 'Should return the RSS Enabled' {
                     $result = Get-TargetResource @TestRssEnabled
-                    $result.Enabled | Should Be $TestRSSEnabled.Enabled
+                    $result.Enabled | Should -Be $TestRSSEnabled.Enabled
                 }
 
                 It 'Should call all mocks' {
@@ -59,7 +59,7 @@ try
 
                 It 'Should return the RSS Enabled' {
                     $result = Get-TargetResource @TestRSSDisabled
-                    $result.Enabled | Should Be $TestRSSDisabled.Enabled
+                    $result.Enabled | Should -Be $TestRSSDisabled.Enabled
                 }
 
                 It 'Should call all mocks' {
@@ -74,7 +74,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundMessage)
 
                 It 'Should throw an exception' {
-                    { Get-TargetResource @TestAdapterNotFound } | Should throw $errorRecord
+                    { Get-TargetResource @TestAdapterNotFound } | Should -Throw $errorRecord
                 }
 
                 It 'Should call all mocks' {
@@ -91,7 +91,7 @@ try
                     Mock -CommandName Set-NetAdapterRSS
 
                     It 'Should not throw an exception' {
-                        { Set-TargetResource @TestRSSEnabled } | Should Not Throw
+                        { Set-TargetResource @TestRSSEnabled } | Should -Not -Throw
                     }
 
                     It 'Should call all mocks' {
@@ -107,7 +107,7 @@ try
                     Mock -CommandName Set-NetAdapterRSS
 
                     It 'Should not throw an exception' {
-                        { Set-TargetResource @TestRSSDisabled } | Should Not Throw
+                        { Set-TargetResource @TestRSSDisabled } | Should -Not -Throw
                     }
 
                     It 'Should call all mocks' {
@@ -123,7 +123,7 @@ try
                     Mock -CommandName Set-NetAdapterRSS
 
                     It 'Should not throw an exception' {
-                        { Set-TargetResource @TestRSSDisabled } | Should Not Throw
+                        { Set-TargetResource @TestRSSDisabled } | Should -Not -Throw
                     }
 
                     It 'Should call all mocks' {
@@ -139,7 +139,7 @@ try
                     Mock -CommandName Set-NetAdapterRSS
 
                     It 'Should not throw an exception' {
-                        { Set-TargetResource @TestRSSEnabled } | Should Not Throw
+                        { Set-TargetResource @TestRSSEnabled } | Should -Not -Throw
                     }
 
                     It 'Should call all mocks' {
@@ -156,7 +156,7 @@ try
                         -Message ($LocalizedData.NetAdapterNotFoundMessage)
 
                     It 'Should throw an exception' {
-                        { Set-TargetResource @TestAdapterNotFound } | Should throw $errorRecord
+                        { Set-TargetResource @TestAdapterNotFound } | Should -Throw $errorRecord
                     }
 
                     It 'Should call all mocks' {
@@ -174,7 +174,7 @@ try
                     }
 
                     It 'Should return true' {
-                        Test-TargetResource @TestRSSEnabled | Should Be $true
+                        Test-TargetResource @TestRSSEnabled | Should -Be $true
                     }
 
                     It 'Should call all mocks' {
@@ -188,7 +188,7 @@ try
                     }
 
                     It 'Should return false' {
-                        Test-TargetResource @TestRSSDisabled | Should Be $false
+                        Test-TargetResource @TestRSSDisabled | Should -Be $false
                     }
 
                     it 'Should call all mocks' {
@@ -202,7 +202,7 @@ try
                     }
 
                     It 'Should return true' {
-                        Test-TargetResource @TestRSSDisabled | Should Be $true
+                        Test-TargetResource @TestRSSDisabled | Should -Be $true
                     }
 
                     it 'Should call all mocks' {
@@ -216,7 +216,7 @@ try
                     }
 
                     It 'Should return false' {
-                        Test-TargetResource @TestRSSEnabled | Should Be $false
+                        Test-TargetResource @TestRSSEnabled | Should -Be $false
                     }
 
                     it 'Should call all mocks' {
@@ -232,7 +232,7 @@ try
                         -Message ($LocalizedData.NetAdapterNotFoundMessage)
 
                     It 'Should throw an exception' {
-                        { Test-TargetResource @TestAdapterNotFound } | Should throw $errorRecord
+                        { Test-TargetResource @TestAdapterNotFound } | Should -Throw $errorRecord
                     }
 
                     It 'Should call all mocks' {

--- a/Tests/Unit/MSFT_xNetconnectionProfile.tests.ps1
+++ b/Tests/Unit/MSFT_xNetconnectionProfile.tests.ps1
@@ -77,10 +77,10 @@ try
             $result = Get-TargetResource -InterfaceAlias $mockNetAdapter.Name
 
             It 'Should return the correct values' {
-                $result.InterfaceAlias   | Should Be $mockNetConnnectionProfileAll.InterfaceAlias
-                $result.NetworkCategory  | Should Be $mockNetConnnectionProfileAll.NetworkCategory
-                $result.IPv4Connectivity | Should Be $mockNetConnnectionProfileAll.IPv4Connectivity
-                $result.IPv6Connectivity | Should Be $mockNetConnnectionProfileAll.IPv6Connectivity
+                $result.InterfaceAlias   | Should -Be $mockNetConnnectionProfileAll.InterfaceAlias
+                $result.NetworkCategory  | Should -Be $mockNetConnnectionProfileAll.NetworkCategory
+                $result.IPv4Connectivity | Should -Be $mockNetConnnectionProfileAll.IPv4Connectivity
+                $result.IPv6Connectivity | Should -Be $mockNetConnnectionProfileAll.IPv6Connectivity
             }
         }
 
@@ -95,37 +95,37 @@ try
 
             Context 'NetworkCategory matches' {
                 It 'Should return false' {
-                    Test-TargetResource @testNetworkCategoryMatches | should be $true
+                    Test-TargetResource @testNetworkCategoryMatches | should -be $true
                 }
             }
 
             Context 'NetworkCategory does not match' {
                 It 'Should return false' {
-                    Test-TargetResource @testNetworkCategoryNoMatches | should be $false
+                    Test-TargetResource @testNetworkCategoryNoMatches | should -be $false
                 }
             }
 
             Context 'IPv4Connectivity matches' {
                 It 'Should return false' {
-                    Test-TargetResource @testIPv4ConnectivityMatches | should be $true
+                    Test-TargetResource @testIPv4ConnectivityMatches | should -be $true
                 }
             }
 
             Context 'IPv4Connectivity does not match' {
                 It 'Should return false' {
-                    Test-TargetResource @testIPv4ConnectivityNoMatches | should be $false
+                    Test-TargetResource @testIPv4ConnectivityNoMatches | should -be $false
                 }
             }
 
             Context 'IPv6Connectivity matches' {
                 It 'Should return false' {
-                    Test-TargetResource @testIPv6ConnectivityMatches | should be $true
+                    Test-TargetResource @testIPv6ConnectivityMatches | should -be $true
                 }
             }
 
             Context 'IPv6Connectivity does not match' {
                 It 'Should return false' {
-                    Test-TargetResource @testIPv6ConnectivityNoMatches | should be $false
+                    Test-TargetResource @testIPv6ConnectivityNoMatches | should -be $false
                 }
             }
         }
@@ -149,7 +149,7 @@ try
                     $errorRecord = Get-InvalidOperationRecord `
                         -Message ($LocalizedData.InterfaceNotAvailableError -f $testValidInterfaceAliasOnlyPassed.InterfaceAlias)
 
-                    { Assert-ResourceProperty @testValidInterfaceAliasOnlyPassed } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @testValidInterfaceAliasOnlyPassed } | Should -Throw $errorRecord
                 }
             }
 
@@ -160,7 +160,7 @@ try
                     -Message ($LocalizedData.ParameterCombinationError)
 
                 It 'Should not ParameterCombinationError exception' {
-                    { Assert-ResourceProperty @testValidInterfaceAliasOnlyPassed } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @testValidInterfaceAliasOnlyPassed } | Should -Throw $errorRecord
                 }
             }
 
@@ -168,7 +168,7 @@ try
                 Mock -CommandName Get-NetAdapter -MockWith { return $mockNetAdapter }
 
                 It 'Should not throw an exception' {
-                    { Assert-ResourceProperty @testNetworkCategoryMatches } | Should Not Throw
+                    { Assert-ResourceProperty @testNetworkCategoryMatches } | Should -Not -Throw
                 }
             }
 
@@ -176,7 +176,7 @@ try
                 Mock -CommandName Get-NetAdapter -MockWith { return $mockNetAdapter }
 
                 It 'Should not throw an exception' {
-                    { Assert-ResourceProperty @testIPv4ConnectivityMatches } | Should Not Throw
+                    { Assert-ResourceProperty @testIPv4ConnectivityMatches } | Should -Not -Throw
                 }
             }
 
@@ -184,7 +184,7 @@ try
                 Mock -CommandName Get-NetAdapter -MockWith { return $mockNetAdapter }
 
                 It 'Should not throw an exception' {
-                    { Assert-ResourceProperty @testIPv6ConnectivityMatches } | Should Not Throw
+                    { Assert-ResourceProperty @testIPv6ConnectivityMatches } | Should -Not -Throw
                 }
             }
         }

--- a/Tests/Unit/MSFT_xNetworkTeamInterface.Tests.ps1
+++ b/Tests/Unit/MSFT_xNetworkTeamInterface.Tests.ps1
@@ -116,10 +116,10 @@ try
                 }
 
                 It 'Should return team properties' {
-                    $script:result.Ensure   | Should Be 'Present'
-                    $script:result.Name     | Should Be $testTeamNic.Name
-                    $script:result.TeamName | Should Be $testTeamNic.TeamName
-                    $script:result.VlanId   | Should be 100
+                    $script:result.Ensure   | Should -Be 'Present'
+                    $script:result.Name     | Should -Be $testTeamNic.Name
+                    $script:result.TeamName | Should -Be $testTeamNic.TeamName
+                    $script:result.VlanId   | Should -Be 100
                 }
 
                 It 'Should call the expected mocks' {

--- a/Tests/Unit/MSFT_xProxySettings.Tests.ps1
+++ b/Tests/Unit/MSFT_xProxySettings.Tests.ps1
@@ -103,11 +103,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:getTargetResourceResult = Get-TargetResource -IsSingleInstance 'Yes' -Verbose } | Should Not Throw
+                    { $script:getTargetResourceResult = Get-TargetResource -IsSingleInstance 'Yes' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return the expected values' {
-                    $script:getTargetResourceResult.Ensure | Should Be 'Absent'
+                    $script:getTargetResourceResult.Ensure | Should -Be 'Absent'
                 }
 
                 It 'Should call expected mocks' {
@@ -131,18 +131,18 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:getTargetResourceResult = Get-TargetResource -IsSingleInstance 'Yes' -Verbose } | Should Not Throw
+                    { $script:getTargetResourceResult = Get-TargetResource -IsSingleInstance 'Yes' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return the expected values' {
-                    $script:getTargetResourceResult.Ensure | Should Be 'Present'
-                    $script:getTargetResourceResult.EnableAutoDetection | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoDetection
-                    $script:getTargetResourceResult.EnableManualProxy | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableManualProxy
-                    $script:getTargetResourceResult.ProxyServer | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServer
-                    $script:getTargetResourceResult.ProxyServerBypassLocal | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerBypassLocal
-                    $script:getTargetResourceResult.ProxyServerExceptions | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerExceptions
-                    $script:getTargetResourceResult.EnableAutoConfiguration | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoConfiguration
-                    $script:getTargetResourceResult.AutoConfigURL | Should Be $testProxyAllEnabledWithBypassLocalSettings.AutoConfigURL
+                    $script:getTargetResourceResult.Ensure | Should -Be 'Present'
+                    $script:getTargetResourceResult.EnableAutoDetection | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoDetection
+                    $script:getTargetResourceResult.EnableManualProxy | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableManualProxy
+                    $script:getTargetResourceResult.ProxyServer | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServer
+                    $script:getTargetResourceResult.ProxyServerBypassLocal | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerBypassLocal
+                    $script:getTargetResourceResult.ProxyServerExceptions | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerExceptions
+                    $script:getTargetResourceResult.EnableAutoConfiguration | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoConfiguration
+                    $script:getTargetResourceResult.AutoConfigURL | Should -Be $testProxyAllEnabledWithBypassLocalSettings.AutoConfigURL
                 }
 
                 It 'Should call expected mocks' {
@@ -166,18 +166,18 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:getTargetResourceResult = Get-TargetResource -IsSingleInstance 'Yes' -Verbose } | Should Not Throw
+                    { $script:getTargetResourceResult = Get-TargetResource -IsSingleInstance 'Yes' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return the expected values' {
-                    $script:getTargetResourceResult.Ensure | Should Be 'Present'
-                    $script:getTargetResourceResult.EnableAutoDetection | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoDetection
-                    $script:getTargetResourceResult.EnableManualProxy | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableManualProxy
-                    $script:getTargetResourceResult.ProxyServer | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServer
-                    $script:getTargetResourceResult.ProxyServerBypassLocal | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerBypassLocal
-                    $script:getTargetResourceResult.ProxyServerExceptions | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerExceptions
-                    $script:getTargetResourceResult.EnableAutoConfiguration | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoConfiguration
-                    $script:getTargetResourceResult.AutoConfigURL | Should Be $testProxyAllEnabledWithBypassLocalSettings.AutoConfigURL
+                    $script:getTargetResourceResult.Ensure | Should -Be 'Present'
+                    $script:getTargetResourceResult.EnableAutoDetection | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoDetection
+                    $script:getTargetResourceResult.EnableManualProxy | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableManualProxy
+                    $script:getTargetResourceResult.ProxyServer | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServer
+                    $script:getTargetResourceResult.ProxyServerBypassLocal | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerBypassLocal
+                    $script:getTargetResourceResult.ProxyServerExceptions | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerExceptions
+                    $script:getTargetResourceResult.EnableAutoConfiguration | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoConfiguration
+                    $script:getTargetResourceResult.AutoConfigURL | Should -Be $testProxyAllEnabledWithBypassLocalSettings.AutoConfigURL
                 }
 
                 It 'Should call expected mocks' {
@@ -197,7 +197,7 @@ try
                     -ParameterFilter { $Name -eq 'SavedLegacySettings' }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'All' -Verbose } | Should Not Throw
+                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'All' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -223,7 +223,7 @@ try
                     -ParameterFilter { $Name -eq 'SavedLegacySettings' }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'Default' -Verbose } | Should Not Throw
+                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'Default' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -249,7 +249,7 @@ try
                     -ParameterFilter { $Name -eq 'SavedLegacySettings' }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'Legacy' -Verbose } | Should Not Throw
+                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'Legacy' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -275,7 +275,7 @@ try
                     -ParameterFilter { $Name -eq 'SavedLegacySettings' }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'All' -Verbose } | Should Not Throw
+                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'All' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -301,7 +301,7 @@ try
                     -ParameterFilter { $Name -eq 'SavedLegacySettings' }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Default' -Verbose } | Should Not Throw
+                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Default' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -327,7 +327,7 @@ try
                     -ParameterFilter { $Name -eq 'SavedLegacySettings' }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Legacy' -Verbose } | Should Not Throw
+                    { Set-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Legacy' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -351,11 +351,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'All' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'All' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testTargetResourceResult | Should Be $True
+                    $script:testTargetResourceResult | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -374,11 +374,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'All' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'All' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:testTargetResourceResult | Should Be $False
+                    $script:testTargetResourceResult | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -397,11 +397,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'Legacy' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'Legacy' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testTargetResourceResult | Should Be $True
+                    $script:testTargetResourceResult | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -420,11 +420,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'All' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'All' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:testTargetResourceResult | Should Be $False
+                    $script:testTargetResourceResult | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -443,11 +443,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'Default' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Absent' -ConnectionType 'Default' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testTargetResourceResult | Should Be $True
+                    $script:testTargetResourceResult | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -471,11 +471,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Default' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Default' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:testTargetResourceResult | Should Be $False
+                    $script:testTargetResourceResult | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -503,11 +503,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Legacy' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Legacy' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:testTargetResourceResult | Should Be $False
+                    $script:testTargetResourceResult | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -535,11 +535,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Default' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Default' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testTargetResourceResult | Should Be $True
+                    $script:testTargetResourceResult | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -567,11 +567,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Legacy' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Legacy' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testTargetResourceResult | Should Be $True
+                    $script:testTargetResourceResult | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -599,11 +599,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Legacy' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Legacy' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:testTargetResourceResult | Should Be $False
+                    $script:testTargetResourceResult | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -631,11 +631,11 @@ try
                     -Verifiable
 
                 It 'Should not throw an exception' {
-                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Default' -Verbose } | Should Not Throw
+                    { $script:testTargetResourceResult = Test-TargetResource -IsSingleInstance 'Yes' -Ensure 'Present' -ConnectionType 'Default' -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:testTargetResourceResult | Should Be $False
+                    $script:testTargetResourceResult | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -656,11 +656,11 @@ try
                     { $script:testProxySettingsResult = Test-ProxySettings `
                             -CurrentValues $testProxyAllDisabledSettings `
                             -DesiredValues $testProxyAllDisabledSettings `
-                            -Verbose } | Should Not Throw
+                            -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testProxySettingsResult | Should Be $true
+                    $script:testProxySettingsResult | Should -Be $true
                 }
             }
 
@@ -669,11 +669,11 @@ try
                     { $script:testProxySettingsResult = Test-ProxySettings `
                             -CurrentValues $testProxyAllEnabledWithoutBypassLocalSettings `
                             -DesiredValues $testProxyAllEnabledWithoutBypassLocalSettings `
-                            -Verbose  } | Should Not Throw
+                            -Verbose  } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testProxySettingsResult | Should Be $true
+                    $script:testProxySettingsResult | Should -Be $true
                 }
             }
 
@@ -682,11 +682,11 @@ try
                     { $script:testProxySettingsResult = Test-ProxySettings `
                             -CurrentValues $testProxyAllEnabledWithBypassLocalSettings `
                             -DesiredValues $testProxyAllEnabledWithBypassLocalSettings `
-                            -Verbose  } | Should Not Throw
+                            -Verbose  } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testProxySettingsResult | Should Be $true
+                    $script:testProxySettingsResult | Should -Be $true
                 }
             }
 
@@ -695,11 +695,11 @@ try
                     { $script:testProxySettingsResult = Test-ProxySettings `
                             -CurrentValues $testProxyAllEnabledWithBypassLocalSettings `
                             -DesiredValues $testProxyAllEnabledWithoutBypassLocalSettings `
-                            -Verbose  } | Should Not Throw
+                            -Verbose  } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:testProxySettingsResult | Should Be $false
+                    $script:testProxySettingsResult | Should -Be $false
                 }
             }
 
@@ -708,11 +708,11 @@ try
                     { $script:testProxySettingsResult = Test-ProxySettings `
                             -CurrentValues $testProxyManualProxyWithExceptionsSettings `
                             -DesiredValues $testProxyManualProxyWithExceptionsSettings `
-                            -Verbose  } | Should Not Throw
+                            -Verbose  } | Should -Not -Throw
                 }
 
                 It 'Should return true' {
-                    $script:testProxySettingsResult | Should Be $true
+                    $script:testProxySettingsResult | Should -Be $true
                 }
             }
 
@@ -721,11 +721,11 @@ try
                     { $script:testProxySettingsResult = Test-ProxySettings `
                             -CurrentValues $testProxyManualProxyWithExceptionsSettings `
                             -DesiredValues $testProxyManualProxyWithAlternateExceptionsSettings `
-                            -Verbose  } | Should Not Throw
+                            -Verbose  } | Should -Not -Throw
                 }
 
                 It 'Should return false' {
-                    $script:testProxySettingsResult | Should Be $false
+                    $script:testProxySettingsResult | Should -Be $false
                 }
             }
         }
@@ -733,141 +733,141 @@ try
         Describe "$script:DSCResourceName\Convert*-ProxySettingsBinary" {
             Context 'All Proxy Types Disabled' {
                 It 'Should not throw an exception when converting to Proxy Settings Binary' {
-                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyAllDisabledSettings -Verbose } | Should Not Throw
+                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyAllDisabledSettings -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should not throw an exception when converting from Proxy Settings Binary' {
-                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should Not Throw
+                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should convert the values to binary and back to source values correctly' {
-                    $script:proxySettingsResult.EnableAutoDetection | Should Be $testProxyAllDisabledSettings.EnableAutoDetection
-                    $script:proxySettingsResult.EnableManualProxy | Should Be $testProxyAllDisabledSettings.EnableManualProxy
-                    $script:proxySettingsResult.ProxyServer | Should BeNullOrEmpty
-                    $script:proxySettingsResult.ProxyServerBypassLocal | Should Be $False
-                    $script:proxySettingsResult.ProxyServerExceptions | Should BeNullOrEmpty
-                    $script:proxySettingsResult.EnableAutoConfiguration | Should Be $testProxyAllDisabledSettings.EnableAutoConfiguration
-                    $script:proxySettingsResult.AutoConfigURL | Should BeNullOrEmpty
+                    $script:proxySettingsResult.EnableAutoDetection | Should -Be $testProxyAllDisabledSettings.EnableAutoDetection
+                    $script:proxySettingsResult.EnableManualProxy | Should -Be $testProxyAllDisabledSettings.EnableManualProxy
+                    $script:proxySettingsResult.ProxyServer | Should -BeNullOrEmpty
+                    $script:proxySettingsResult.ProxyServerBypassLocal | Should -Be $False
+                    $script:proxySettingsResult.ProxyServerExceptions | Should -BeNullOrEmpty
+                    $script:proxySettingsResult.EnableAutoConfiguration | Should -Be $testProxyAllDisabledSettings.EnableAutoConfiguration
+                    $script:proxySettingsResult.AutoConfigURL | Should -BeNullOrEmpty
                 }
             }
 
             Context 'Only Manual Proxy Server type Enabled' {
                 It 'Should not throw an exception when converting to Proxy Settings Binary' {
-                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyManualProxySettings -Verbose } | Should Not Throw
+                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyManualProxySettings -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should not throw an exception when converting from Proxy Settings Binary' {
-                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should Not Throw
+                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should convert the values to binary and back to source values correctly' {
-                    $script:proxySettingsResult.EnableAutoDetection | Should Be $testProxyManualProxySettings.EnableAutoDetection
-                    $script:proxySettingsResult.EnableManualProxy | Should Be $testProxyManualProxySettings.EnableManualProxy
-                    $script:proxySettingsResult.ProxyServer | Should Be $testProxyManualProxySettings.ProxyServer
-                    $script:proxySettingsResult.ProxyServerBypassLocal | Should Be $False
-                    $script:proxySettingsResult.ProxyServerExceptions | Should BeNullOrEmpty
-                    $script:proxySettingsResult.EnableAutoConfiguration | Should Be $testProxyManualProxySettings.EnableAutoConfiguration
-                    $script:proxySettingsResult.AutoConfigURL | Should BeNullOrEmpty
+                    $script:proxySettingsResult.EnableAutoDetection | Should -Be $testProxyManualProxySettings.EnableAutoDetection
+                    $script:proxySettingsResult.EnableManualProxy | Should -Be $testProxyManualProxySettings.EnableManualProxy
+                    $script:proxySettingsResult.ProxyServer | Should -Be $testProxyManualProxySettings.ProxyServer
+                    $script:proxySettingsResult.ProxyServerBypassLocal | Should -Be $False
+                    $script:proxySettingsResult.ProxyServerExceptions | Should -BeNullOrEmpty
+                    $script:proxySettingsResult.EnableAutoConfiguration | Should -Be $testProxyManualProxySettings.EnableAutoConfiguration
+                    $script:proxySettingsResult.AutoConfigURL | Should -BeNullOrEmpty
                 }
             }
 
             Context 'Only Manual Proxy Server type Enabled with Exceptions Only' {
                 It 'Should not throw an exception when converting to Proxy Settings Binary' {
-                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyManualProxyWithExceptionsSettings -Verbose } | Should Not Throw
+                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyManualProxyWithExceptionsSettings -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should not throw an exception when converting from Proxy Settings Binary' {
-                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should Not Throw
+                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should convert the values to binary and back to source values correctly' {
-                    $script:proxySettingsResult.EnableAutoDetection | Should Be $testProxyManualProxyWithExceptionsSettings.EnableAutoDetection
-                    $script:proxySettingsResult.EnableManualProxy | Should Be $testProxyManualProxyWithExceptionsSettings.EnableManualProxy
-                    $script:proxySettingsResult.ProxyServer | Should Be $testProxyManualProxyWithExceptionsSettings.ProxyServer
-                    $script:proxySettingsResult.ProxyServerBypassLocal | Should Be $False
-                    $script:proxySettingsResult.ProxyServerExceptions | Should Be $testProxyManualProxyWithExceptionsSettings.ProxyServerExceptions
-                    $script:proxySettingsResult.EnableAutoConfiguration | Should Be $testProxyManualProxyWithExceptionsSettings.EnableAutoConfiguration
-                    $script:proxySettingsResult.AutoConfigURL | Should BeNullOrEmpty
+                    $script:proxySettingsResult.EnableAutoDetection | Should -Be $testProxyManualProxyWithExceptionsSettings.EnableAutoDetection
+                    $script:proxySettingsResult.EnableManualProxy | Should -Be $testProxyManualProxyWithExceptionsSettings.EnableManualProxy
+                    $script:proxySettingsResult.ProxyServer | Should -Be $testProxyManualProxyWithExceptionsSettings.ProxyServer
+                    $script:proxySettingsResult.ProxyServerBypassLocal | Should -Be $False
+                    $script:proxySettingsResult.ProxyServerExceptions | Should -Be $testProxyManualProxyWithExceptionsSettings.ProxyServerExceptions
+                    $script:proxySettingsResult.EnableAutoConfiguration | Should -Be $testProxyManualProxyWithExceptionsSettings.EnableAutoConfiguration
+                    $script:proxySettingsResult.AutoConfigURL | Should -BeNullOrEmpty
                 }
             }
 
             Context 'Only Manual Proxy Server type Enabled with Bypass Local Only' {
                 It 'Should not throw an exception when converting to Proxy Settings Binary' {
-                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyManualProxyWithBypassLocalOnlySettings -Verbose } | Should Not Throw
+                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyManualProxyWithBypassLocalOnlySettings -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should not throw an exception when converting from Proxy Settings Binary' {
-                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should Not Throw
+                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should convert the values to binary and back to source values correctly' {
-                    $script:proxySettingsResult.EnableAutoDetection | Should Be $testProxyManualProxyWithBypassLocalOnlySettings.EnableAutoDetection
-                    $script:proxySettingsResult.EnableManualProxy | Should Be $testProxyManualProxyWithBypassLocalOnlySettings.EnableManualProxy
-                    $script:proxySettingsResult.ProxyServer | Should Be $testProxyManualProxyWithBypassLocalOnlySettings.ProxyServer
-                    $script:proxySettingsResult.ProxyServerBypassLocal | Should Be $True
-                    $script:proxySettingsResult.ProxyServerExceptions | Should BeNullOrEmpty
-                    $script:proxySettingsResult.EnableAutoConfiguration | Should Be $testProxyManualProxyWithBypassLocalOnlySettings.EnableAutoConfiguration
-                    $script:proxySettingsResult.AutoConfigURL | Should BeNullOrEmpty
+                    $script:proxySettingsResult.EnableAutoDetection | Should -Be $testProxyManualProxyWithBypassLocalOnlySettings.EnableAutoDetection
+                    $script:proxySettingsResult.EnableManualProxy | Should -Be $testProxyManualProxyWithBypassLocalOnlySettings.EnableManualProxy
+                    $script:proxySettingsResult.ProxyServer | Should -Be $testProxyManualProxyWithBypassLocalOnlySettings.ProxyServer
+                    $script:proxySettingsResult.ProxyServerBypassLocal | Should -Be $True
+                    $script:proxySettingsResult.ProxyServerExceptions | Should -BeNullOrEmpty
+                    $script:proxySettingsResult.EnableAutoConfiguration | Should -Be $testProxyManualProxyWithBypassLocalOnlySettings.EnableAutoConfiguration
+                    $script:proxySettingsResult.AutoConfigURL | Should -BeNullOrEmpty
                 }
             }
 
             Context 'Only Auto Config Proxy type Enabled' {
                 It 'Should not throw an exception when converting to Proxy Settings Binary' {
-                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyAutoConfigOnlySettings -Verbose } | Should Not Throw
+                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyAutoConfigOnlySettings -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should not throw an exception when converting from Proxy Settings Binary' {
-                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should Not Throw
+                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should convert the values to binary and back to source values correctly' {
-                    $script:proxySettingsResult.EnableAutoDetection | Should Be $testProxyAutoConfigOnlySettings.EnableAutoDetection
-                    $script:proxySettingsResult.EnableManualProxy | Should Be $testProxyAutoConfigOnlySettings.EnableManualProxy
-                    $script:proxySettingsResult.ProxyServer | Should BeNullOrEmpty
-                    $script:proxySettingsResult.ProxyServerBypassLocal | Should Be $False
-                    $script:proxySettingsResult.ProxyServerExceptions | Should BeNullOrEmpty
-                    $script:proxySettingsResult.EnableAutoConfiguration | Should Be $testProxyAutoConfigOnlySettings.EnableAutoConfiguration
-                    $script:proxySettingsResult.AutoConfigURL | Should Be $testProxyAutoConfigOnlySettings.AutoConfigURL
+                    $script:proxySettingsResult.EnableAutoDetection | Should -Be $testProxyAutoConfigOnlySettings.EnableAutoDetection
+                    $script:proxySettingsResult.EnableManualProxy | Should -Be $testProxyAutoConfigOnlySettings.EnableManualProxy
+                    $script:proxySettingsResult.ProxyServer | Should -BeNullOrEmpty
+                    $script:proxySettingsResult.ProxyServerBypassLocal | Should -Be $False
+                    $script:proxySettingsResult.ProxyServerExceptions | Should -BeNullOrEmpty
+                    $script:proxySettingsResult.EnableAutoConfiguration | Should -Be $testProxyAutoConfigOnlySettings.EnableAutoConfiguration
+                    $script:proxySettingsResult.AutoConfigURL | Should -Be $testProxyAutoConfigOnlySettings.AutoConfigURL
                 }
             }
 
             Context 'All Proxy Types Enabled and Proxy Bypass Local Disabled' {
                 It 'Should not throw an exception when converting to Proxy Settings Binary' {
-                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyAllEnabledWithoutBypassLocalSettings -Verbose } | Should Not Throw
+                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyAllEnabledWithoutBypassLocalSettings -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should not throw an exception when converting from Proxy Settings Binary' {
-                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should Not Throw
+                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should convert the values to binary and back to source values correctly' {
-                    $script:proxySettingsResult.EnableAutoDetection | Should Be $testProxyAllEnabledWithoutBypassLocalSettings.EnableAutoDetection
-                    $script:proxySettingsResult.EnableManualProxy | Should Be $testProxyAllEnabledWithoutBypassLocalSettings.EnableManualProxy
-                    $script:proxySettingsResult.ProxyServer | Should Be $testProxyAllEnabledWithoutBypassLocalSettings.ProxyServer
-                    $script:proxySettingsResult.ProxyServerBypassLocal | Should Be $testProxyAllEnabledWithoutBypassLocalSettings.ProxyServerBypassLocal
-                    $script:proxySettingsResult.ProxyServerExceptions | Should Be $testProxyAllEnabledWithoutBypassLocalSettings.ProxyServerExceptions
-                    $script:proxySettingsResult.EnableAutoConfiguration | Should Be $testProxyAllEnabledWithoutBypassLocalSettings.EnableAutoConfiguration
-                    $script:proxySettingsResult.AutoConfigURL | Should Be $testProxyAllEnabledWithoutBypassLocalSettings.AutoConfigURL
+                    $script:proxySettingsResult.EnableAutoDetection | Should -Be $testProxyAllEnabledWithoutBypassLocalSettings.EnableAutoDetection
+                    $script:proxySettingsResult.EnableManualProxy | Should -Be $testProxyAllEnabledWithoutBypassLocalSettings.EnableManualProxy
+                    $script:proxySettingsResult.ProxyServer | Should -Be $testProxyAllEnabledWithoutBypassLocalSettings.ProxyServer
+                    $script:proxySettingsResult.ProxyServerBypassLocal | Should -Be $testProxyAllEnabledWithoutBypassLocalSettings.ProxyServerBypassLocal
+                    $script:proxySettingsResult.ProxyServerExceptions | Should -Be $testProxyAllEnabledWithoutBypassLocalSettings.ProxyServerExceptions
+                    $script:proxySettingsResult.EnableAutoConfiguration | Should -Be $testProxyAllEnabledWithoutBypassLocalSettings.EnableAutoConfiguration
+                    $script:proxySettingsResult.AutoConfigURL | Should -Be $testProxyAllEnabledWithoutBypassLocalSettings.AutoConfigURL
                 }
             }
 
             Context 'All Proxy Types Enabled and Proxy Bypass Local Enabled' {
                 It 'Should not throw an exception when converting to Proxy Settings Binary' {
-                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyAllEnabledWithBypassLocalSettings -Verbose } | Should Not Throw
+                    { $script:proxyBinary = ConvertTo-ProxySettingsBinary @testProxyAllEnabledWithBypassLocalSettings -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should not throw an exception when converting from Proxy Settings Binary' {
-                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should Not Throw
+                    { $script:proxySettingsResult = ConvertFrom-ProxySettingsBinary -ProxySettings $script:proxyBinary -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should convert the values to binary and back to source values correctly' {
-                    $script:proxySettingsResult.EnableAutoDetection | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoDetection
-                    $script:proxySettingsResult.EnableManualProxy | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableManualProxy
-                    $script:proxySettingsResult.ProxyServer | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServer
-                    $script:proxySettingsResult.ProxyServerBypassLocal | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerBypassLocal
-                    $script:proxySettingsResult.ProxyServerExceptions | Should Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerExceptions
-                    $script:proxySettingsResult.EnableAutoConfiguration | Should Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoConfiguration
-                    $script:proxySettingsResult.AutoConfigURL | Should Be $testProxyAllEnabledWithBypassLocalSettings.AutoConfigURL
+                    $script:proxySettingsResult.EnableAutoDetection | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoDetection
+                    $script:proxySettingsResult.EnableManualProxy | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableManualProxy
+                    $script:proxySettingsResult.ProxyServer | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServer
+                    $script:proxySettingsResult.ProxyServerBypassLocal | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerBypassLocal
+                    $script:proxySettingsResult.ProxyServerExceptions | Should -Be $testProxyAllEnabledWithBypassLocalSettings.ProxyServerExceptions
+                    $script:proxySettingsResult.EnableAutoConfiguration | Should -Be $testProxyAllEnabledWithBypassLocalSettings.EnableAutoConfiguration
+                    $script:proxySettingsResult.AutoConfigURL | Should -Be $testProxyAllEnabledWithBypassLocalSettings.AutoConfigURL
                 }
             }
         }

--- a/Tests/Unit/MSFT_xWeakHostReceive.Tests.ps1
+++ b/Tests/Unit/MSFT_xWeakHostReceive.Tests.ps1
@@ -73,9 +73,9 @@ try
 
                 It 'Should return Weak Host Receiving state of enabled' {
                     $Result = Get-TargetResource @testNetIPWeakHostReceiveEnabled
-                    $Result.State          | Should Be $testNetIPWeakHostReceiveEnabled.State
-                    $Result.InterfaceAlias | Should Be $testNetIPWeakHostReceiveEnabled.InterfaceAlias
-                    $Result.AddressFamily  | Should Be $testNetIPWeakHostReceiveEnabled.AddressFamily
+                    $Result.State          | Should -Be $testNetIPWeakHostReceiveEnabled.State
+                    $Result.InterfaceAlias | Should -Be $testNetIPWeakHostReceiveEnabled.InterfaceAlias
+                    $Result.AddressFamily  | Should -Be $testNetIPWeakHostReceiveEnabled.AddressFamily
                 }
 
                 It 'Should call the expected mocks' {
@@ -89,9 +89,9 @@ try
 
                 It 'Should return Weak Host Receiving state of disabled' {
                     $Result = Get-TargetResource @testNetIPWeakHostReceiveDisabled
-                    $Result.State          | Should Be $testNetIPWeakHostReceiveDisabled.State
-                    $Result.InterfaceAlias | Should Be $testNetIPWeakHostReceiveDisabled.InterfaceAlias
-                    $Result.AddressFamily  | Should Be $testNetIPWeakHostReceiveDisabled.AddressFamily
+                    $Result.State          | Should -Be $testNetIPWeakHostReceiveDisabled.State
+                    $Result.InterfaceAlias | Should -Be $testNetIPWeakHostReceiveDisabled.InterfaceAlias
+                    $Result.AddressFamily  | Should -Be $testNetIPWeakHostReceiveDisabled.AddressFamily
                 }
 
                 It 'Should call the expected mocks' {
@@ -112,7 +112,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostReceiveDisabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPWeakHostReceiveEnabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPWeakHostReceiveEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -127,7 +127,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostReceiveDisabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPWeakHostReceiveDisabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPWeakHostReceiveDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -142,7 +142,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostReceiveEnabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPWeakHostReceiveEnabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPWeakHostReceiveEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -157,7 +157,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostReceiveEnabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPWeakHostReceiveDisabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPWeakHostReceiveDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -178,7 +178,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostReceiveDisabled }
 
                 It 'Should return false' {
-                    Test-TargetResource @testNetIPWeakHostReceiveEnabled | Should Be $False
+                    Test-TargetResource @testNetIPWeakHostReceiveEnabled | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -191,7 +191,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostReceiveDisabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testNetIPWeakHostReceiveDisabled | Should Be $True
+                    Test-TargetResource @testNetIPWeakHostReceiveDisabled | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -204,7 +204,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostReceiveEnabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testNetIPWeakHostReceiveEnabled | Should Be $True
+                    Test-TargetResource @testNetIPWeakHostReceiveEnabled | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -217,7 +217,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostReceiveEnabled }
 
                 It 'Should return false' {
-                    Test-TargetResource @testNetIPWeakHostReceiveDisabled | Should Be $False
+                    Test-TargetResource @testNetIPWeakHostReceiveDisabled | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -235,7 +235,7 @@ try
                     $errorRecord = Get-InvalidOperationRecord `
                         -Message ($LocalizedData.InterfaceNotAvailableError -f $testNetIPWeakHostReceiveEnabled.InterfaceAlias)
 
-                    { Assert-ResourceProperty @testNetIPWeakHostReceiveEnabled } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @testNetIPWeakHostReceiveEnabled } | Should -Throw $errorRecord
                 }
             }
         }

--- a/Tests/Unit/MSFT_xWeakHostSend.Tests.ps1
+++ b/Tests/Unit/MSFT_xWeakHostSend.Tests.ps1
@@ -66,9 +66,9 @@ try
 
                 It 'Should return Weak Host Sending state of enabled' {
                     $Result = Get-TargetResource @testNetIPWeakHostSendEnabled
-                    $Result.State          | Should Be $testNetIPWeakHostSendEnabled.State
-                    $Result.InterfaceAlias | Should Be $testNetIPWeakHostSendEnabled.InterfaceAlias
-                    $Result.AddressFamily  | Should Be $testNetIPWeakHostSendEnabled.AddressFamily
+                    $Result.State          | Should -Be $testNetIPWeakHostSendEnabled.State
+                    $Result.InterfaceAlias | Should -Be $testNetIPWeakHostSendEnabled.InterfaceAlias
+                    $Result.AddressFamily  | Should -Be $testNetIPWeakHostSendEnabled.AddressFamily
                 }
 
                 It 'Should call the expected mocks' {
@@ -82,9 +82,9 @@ try
 
                 It 'Should return Weak Host Sending state of disabled' {
                     $Result = Get-TargetResource @testNetIPWeakHostSendDisabled
-                    $Result.State          | Should Be $testNetIPWeakHostSendDisabled.State
-                    $Result.InterfaceAlias | Should Be $testNetIPWeakHostSendDisabled.InterfaceAlias
-                    $Result.AddressFamily  | Should Be $testNetIPWeakHostSendDisabled.AddressFamily
+                    $Result.State          | Should -Be $testNetIPWeakHostSendDisabled.State
+                    $Result.InterfaceAlias | Should -Be $testNetIPWeakHostSendDisabled.InterfaceAlias
+                    $Result.AddressFamily  | Should -Be $testNetIPWeakHostSendDisabled.AddressFamily
                 }
 
                 It 'Should call the expected mocks' {
@@ -105,7 +105,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostSendDisabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPWeakHostSendEnabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPWeakHostSendEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -120,7 +120,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostSendDisabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPWeakHostSendDisabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPWeakHostSendDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -135,7 +135,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostSendEnabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPWeakHostSendEnabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPWeakHostSendEnabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -150,7 +150,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostSendEnabled }
 
                 It 'Should not throw an exception' {
-                    { Set-TargetResource @testNetIPWeakHostSendDisabled } | Should Not Throw
+                    { Set-TargetResource @testNetIPWeakHostSendDisabled } | Should -Not -Throw
                 }
 
                 It 'Should call expected mocks' {
@@ -171,7 +171,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostSendDisabled }
 
                 It 'Should return false' {
-                    Test-TargetResource @testNetIPWeakHostSendEnabled | Should Be $False
+                    Test-TargetResource @testNetIPWeakHostSendEnabled | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -184,7 +184,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostSendDisabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testNetIPWeakHostSendDisabled | Should Be $True
+                    Test-TargetResource @testNetIPWeakHostSendDisabled | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -197,7 +197,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostSendEnabled }
 
                 It 'Should return true' {
-                    Test-TargetResource @testNetIPWeakHostSendEnabled | Should Be $True
+                    Test-TargetResource @testNetIPWeakHostSendEnabled | Should -Be $True
                 }
 
                 It 'Should call expected mocks' {
@@ -210,7 +210,7 @@ try
                 Mock -CommandName Get-NetIPInterface -MockWith { $mockNetIPWeakHostSendEnabled }
 
                 It 'Should return false' {
-                    Test-TargetResource @testNetIPWeakHostSendDisabled | Should Be $False
+                    Test-TargetResource @testNetIPWeakHostSendDisabled | Should -Be $False
                 }
 
                 It 'Should call expected mocks' {
@@ -228,7 +228,7 @@ try
                     $errorRecord = Get-InvalidOperationRecord `
                         -Message ($LocalizedData.InterfaceNotAvailableError -f $testNetIPWeakHostSendEnabled.InterfaceAlias)
 
-                    { Assert-ResourceProperty @testNetIPWeakHostSendEnabled } | Should Throw $errorRecord
+                    { Assert-ResourceProperty @testNetIPWeakHostSendEnabled } | Should -Throw $errorRecord
                 }
             }
         }

--- a/Tests/Unit/MSFT_xWinsSetting.Tests.ps1
+++ b/Tests/Unit/MSFT_xWinsSetting.Tests.ps1
@@ -115,8 +115,8 @@ try
                 }
 
                 It 'Should return expected results' {
-                    $script:result.EnableLmHosts | Should Be $true
-                    $script:result.EnableDns | Should Be $true
+                    $script:result.EnableLmHosts | Should -Be $true
+                    $script:result.EnableDns | Should -Be $true
                 }
 
                 It 'Should call the expected mocks' {
@@ -148,8 +148,8 @@ try
                 }
 
                 It 'Should return expected results' {
-                    $script:result.EnableLmHosts | Should Be $false
-                    $script:result.EnableDns | Should Be $false
+                    $script:result.EnableLmHosts | Should -Be $false
+                    $script:result.EnableDns | Should -Be $false
                 }
 
                 It 'Should call the expected mocks' {

--- a/Tests/Unit/NetworkingDsc.Common.tests.ps1
+++ b/Tests/Unit/NetworkingDsc.Common.tests.ps1
@@ -28,39 +28,39 @@ try
     Describe "NetworkingDsc.Common\Convert-CIDRToSubhetMask" {
         Context 'Subnet Mask Notation Used "192.168.0.0/255.255.0.0"' {
             It 'Should Return "192.168.0.0/255.255.0.0"' {
-                Convert-CIDRToSubhetMask -Address @('192.168.0.0/255.255.0.0') | Should Be '192.168.0.0/255.255.0.0'
+                Convert-CIDRToSubhetMask -Address @('192.168.0.0/255.255.0.0') | Should -Be '192.168.0.0/255.255.0.0'
             }
         }
         Context 'Subnet Mask Notation Used "192.168.0.10/255.255.0.0" resulting in source bits masked' {
             It 'Should Return "192.168.0.0/255.255.0.0" with source bits masked' {
-                Convert-CIDRToSubhetMask -Address @('192.168.0.10/255.255.0.0') | Should Be '192.168.0.0/255.255.0.0'
+                Convert-CIDRToSubhetMask -Address @('192.168.0.10/255.255.0.0') | Should -Be '192.168.0.0/255.255.0.0'
             }
         }
         Context 'CIDR Notation Used "192.168.0.0/16"' {
             It 'Should Return "192.168.0.0/255.255.0.0"' {
-                Convert-CIDRToSubhetMask -Address @('192.168.0.0/16') | Should Be '192.168.0.0/255.255.0.0'
+                Convert-CIDRToSubhetMask -Address @('192.168.0.0/16') | Should -Be '192.168.0.0/255.255.0.0'
             }
         }
         Context 'CIDR Notation Used "192.168.0.10/16" resulting in source bits masked' {
             It 'Should Return "192.168.0.0/255.255.0.0" with source bits masked' {
-                Convert-CIDRToSubhetMask -Address @('192.168.0.10/16') | Should Be '192.168.0.0/255.255.0.0'
+                Convert-CIDRToSubhetMask -Address @('192.168.0.10/16') | Should -Be '192.168.0.0/255.255.0.0'
             }
         }
         Context 'Multiple Notations Used "192.168.0.0/16,10.0.0.24/255.255.255.0"' {
             $Result = Convert-CIDRToSubhetMask -Address @('192.168.0.0/16', '10.0.0.24/255.255.255.0')
             It 'Should Return "192.168.0.0/255.255.0.0,10.0.0.0/255.255.255.0"' {
-                $Result[0] | Should Be '192.168.0.0/255.255.0.0'
-                $Result[1] | Should Be '10.0.0.0/255.255.255.0'
+                $Result[0] | Should -Be '192.168.0.0/255.255.0.0'
+                $Result[1] | Should -Be '10.0.0.0/255.255.255.0'
             }
         }
         Context 'Range Used "192.168.1.0-192.168.1.128"' {
             It 'Should Return "192.168.1.0-192.168.1.128"' {
-                Convert-CIDRToSubhetMask -Address @('192.168.1.0-192.168.1.128') | Should Be '192.168.1.0-192.168.1.128'
+                Convert-CIDRToSubhetMask -Address @('192.168.1.0-192.168.1.128') | Should -Be '192.168.1.0-192.168.1.128'
             }
         }
         Context 'IPv6 Used "fe80::/112"' {
             It 'Should Return "fe80::/112"' {
-                Convert-CIDRToSubhetMask -Address @('fe80::/112') | Should Be 'fe80::/112'
+                Convert-CIDRToSubhetMask -Address @('fe80::/112') | Should -Be 'fe80::/112'
             }
         }
     }
@@ -112,11 +112,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -Name $adapterName -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -Name $adapterName -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -133,7 +133,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -Name 'NOMATCH' -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -Name 'NOMATCH' -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -147,11 +147,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -168,7 +168,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -PhysicalMediaType 'NOMATCH' -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -PhysicalMediaType 'NOMATCH' -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -182,11 +182,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -Status $adapterStatus -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -Status $adapterStatus -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -203,7 +203,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -Status 'Disabled' -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -Status 'Disabled' -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -217,11 +217,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -MacAddress $adapterMacAddress -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -MacAddress $adapterMacAddress -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -238,7 +238,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -MacAddress '00-00-00-00-00-00' -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -MacAddress '00-00-00-00-00-00' -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -252,11 +252,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -InterfaceDescription $adapterInterfaceDescription -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -InterfaceDescription $adapterInterfaceDescription -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -273,7 +273,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -InterfaceDescription 'NOMATCH' -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -InterfaceDescription 'NOMATCH' -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -287,11 +287,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -InterfaceIndex $adapterInterfaceIndex -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -InterfaceIndex $adapterInterfaceIndex -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -308,7 +308,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -InterfaceIndex 99 -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -InterfaceIndex 99 -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -322,11 +322,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -InterfaceGuid $adapterInterfaceGuid -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -InterfaceGuid $adapterInterfaceGuid -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -343,7 +343,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -InterfaceGuid 'NOMATCH' -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -InterfaceGuid 'NOMATCH' -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -357,11 +357,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -DriverDescription $adapterDriverDescription -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -DriverDescription $adapterDriverDescription -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -378,7 +378,7 @@ try
                     -Message ($LocalizedData.NetAdapterNotFoundError)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -DriverDescription 'NOMATCH' -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -DriverDescription 'NOMATCH' -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -395,7 +395,7 @@ try
                     -Message ($LocalizedData.MultipleMatchingNetAdapterFound -f 2)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -409,11 +409,11 @@ try
                     -MockWith { $adapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -IgnoreMultipleMatchingAdapters:$true -InterfaceNumber 2 -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -IgnoreMultipleMatchingAdapters:$true -InterfaceNumber 2 -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -430,7 +430,7 @@ try
                     -Message ($LocalizedData.MultipleMatchingNetAdapterFound -f 2)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -444,11 +444,11 @@ try
                     -MockWith { $multipleMatchingAdapterArray }
 
                 It 'Should not throw exception' {
-                    { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -IgnoreMultipleMatchingAdapters:$true -Verbose } | Should Not Throw
+                    { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -IgnoreMultipleMatchingAdapters:$true -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected adapter' {
-                    $script:result.Name | Should Be $adapterName
+                    $script:result.Name | Should -Be $adapterName
                 }
 
                 It 'Should call expected mocks' {
@@ -465,7 +465,7 @@ try
                     -Message ($LocalizedData.InvalidNetAdapterNumberError -f 2, 3)
 
                 It 'Should throw the correct exception' {
-                    { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -IgnoreMultipleMatchingAdapters:$true -InterfaceNumber 3 -Verbose } | Should Throw $errorRecord
+                    { $script:result = Find-NetworkAdapter -PhysicalMediaType $adapterPhysicalMediaType -IgnoreMultipleMatchingAdapters:$true -InterfaceNumber 3 -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -518,7 +518,7 @@ try
                     -Message ($LocalizedData.InterfaceAliasNotFoundError -f $interfaceAlias)
 
                 It 'Should throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Throw $errorRecord
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should -Throw $errorRecord
                 }
 
                 It 'Should call expected mocks' {
@@ -540,11 +540,11 @@ try
                 }
 
                 It 'Should not throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return null' {
-                    $script:result | Should BeNullOrEmpty
+                    $script:result | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected mocks' {
@@ -567,11 +567,11 @@ try
                 }
 
                 It 'Should not throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return null' {
-                    $script:result | Should BeNullOrEmpty
+                    $script:result | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected mocks' {
@@ -594,11 +594,11 @@ try
                 }
 
                 It 'Should not throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected address' {
-                    $script:result | Should Be $oneIpv4StaticAddressString
+                    $script:result | Should -Be $oneIpv4StaticAddressString
                 }
 
                 It 'Should call expected mocks' {
@@ -621,12 +621,12 @@ try
                 }
 
                 It 'Should not throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should Not Throw
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv4Parameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return two expected addresses' {
-                    $script:result[0] | Should Be $oneIpv4StaticAddressString
-                    $script:result[1] | Should Be $secondIpv4StaticAddressString
+                    $script:result[0] | Should -Be $oneIpv4StaticAddressString
+                    $script:result[1] | Should -Be $secondIpv4StaticAddressString
                 }
 
                 It 'Should call expected mocks' {
@@ -649,11 +649,11 @@ try
                 }
 
                 It 'Should not throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return null' {
-                    $script:result | Should BeNullOrEmpty
+                    $script:result | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected mocks' {
@@ -676,11 +676,11 @@ try
                 }
 
                 It 'Should not throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return null' {
-                    $script:result | Should BeNullOrEmpty
+                    $script:result | Should -BeNullOrEmpty
                 }
 
                 It 'Should call expected mocks' {
@@ -703,11 +703,11 @@ try
                 }
 
                 It 'Should not throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return expected address' {
-                    $script:result | Should Be $oneIpv6StaticAddressString
+                    $script:result | Should -Be $oneIpv6StaticAddressString
                 }
 
                 It 'Should call expected mocks' {
@@ -730,12 +730,12 @@ try
                 }
 
                 It 'Should not throw exception' {
-                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should Not Throw
+                    { $script:result = Get-DnsClientServerStaticAddress @ipv6Parameters -Verbose } | Should -Not -Throw
                 }
 
                 It 'Should return two expected addresses' {
-                    $script:result[0] | Should Be $oneIpv6StaticAddressString
-                    $script:result[1] | Should Be $secondIpv6StaticAddressString
+                    $script:result[0] | Should -Be $oneIpv6StaticAddressString
+                    $script:result[1] | Should -Be $secondIpv6StaticAddressString
                 }
 
                 It 'Should call expected mocks' {
@@ -753,8 +753,8 @@ try
             it 'Should return the provided IP and prefix as separate properties' {
                 $IPaddress = Get-IPAddressPrefix -IPAddress '192.168.10.0/24'
 
-                $IPaddress.IPaddress | Should be '192.168.10.0'
-                $IPaddress.PrefixLength | Should be 24
+                $IPaddress.IPaddress | Should -Be '192.168.10.0'
+                $IPaddress.PrefixLength | Should -Be 24
             }
         }
 
@@ -762,8 +762,8 @@ try
             it 'Should return correct prefix when Class A address provided' {
                 $IPaddress = Get-IPAddressPrefix -IPAddress '10.1.2.3'
 
-                $IPaddress.IPaddress | Should be '10.1.2.3'
-                $IPaddress.PrefixLength | Should be 8
+                $IPaddress.IPaddress | Should -Be '10.1.2.3'
+                $IPaddress.PrefixLength | Should -Be 8
             }
         }
 
@@ -771,8 +771,8 @@ try
             it 'Should return correct prefix when Class B address provided' {
                 $IPaddress = Get-IPAddressPrefix -IPAddress '172.16.2.3'
 
-                $IPaddress.IPaddress | Should be '172.16.2.3'
-                $IPaddress.PrefixLength | Should be 16
+                $IPaddress.IPaddress | Should -Be '172.16.2.3'
+                $IPaddress.PrefixLength | Should -Be 16
             }
         }
 
@@ -780,8 +780,8 @@ try
             it 'Should return correct prefix when Class C address provided' {
                 $IPaddress = Get-IPAddressPrefix -IPAddress '192.168.20.3'
 
-                $IPaddress.IPaddress | Should be '192.168.20.3'
-                $IPaddress.PrefixLength | Should be 24
+                $IPaddress.IPaddress | Should -Be '192.168.20.3'
+                $IPaddress.PrefixLength | Should -Be 24
             }
         }
 
@@ -789,8 +789,8 @@ try
             it 'Should return provided IP and prefix as separate properties' {
                 $IPaddress = Get-IPAddressPrefix -IPAddress 'FF12::12::123/64' -AddressFamily IPv6
 
-                $IPaddress.IPaddress | Should be 'FF12::12::123'
-                $IPaddress.PrefixLength | Should be 64
+                $IPaddress.IPaddress | Should -Be 'FF12::12::123'
+                $IPaddress.PrefixLength | Should -Be 64
             }
         }
 
@@ -798,8 +798,8 @@ try
             it 'Should return provided IP and correct IPv6 prefix' {
                 $IPaddress = Get-IPAddressPrefix -IPAddress 'FF12::12::123' -AddressFamily IPv6
 
-                $IPaddress.IPaddress | Should be 'FF12::12::123'
-                $IPaddress.PrefixLength | Should be 64
+                $IPaddress.IPaddress | Should -Be 'FF12::12::123'
+                $IPaddress.PrefixLength | Should -Be 64
             }
         }
     }


### PR DESCRIPTION
**Pull Request (PR) description**
This PR updates all the Pester test commands to meet the newer Pester V4 format (e.g. `Should Not Be ...` -> `Should -Not -Be ...`)

**This Pull Request (PR) fixes the following issues:**
Fixes #272

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [ ] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/313)
<!-- Reviewable:end -->
