### PR TITLE
xNetBios: Fix issue with InterfaceAlias matching on Adapter description - Fixes #315

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,8 @@
 - MSFT_xNetBIOS:
   - Corrected style and formatting to meet HQRM guidelines.
   - Ensured CommonTestHelper.psm1 is loaded before running unit tests.
+  - Fix issue with InterfaceAlias matching on Adapter description
+    rather than Adapter Name - Fixes [Issue #315](https://github.com/PowerShell/xNetworking/issues/315).
 - MSFT_xNetworkTeam:
   - Corrected style and formatting to meet HQRM guidelines.
   - Added missing default from MOF description of Ensure parameter.

--- a/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.psm1
+++ b/Modules/xNetworking/DSCResources/MSFT_xNetBIOS/MSFT_xNetBIOS.psm1
@@ -66,7 +66,7 @@ function Get-TargetResource
 
     $netAdapter = Get-CimInstance `
         -ClassName Win32_NetworkAdapter `
-        -Filter ('Name="{0}"' -f $InterfaceAlias)
+        -Filter ('NetConnectionID="{0}"' -f $InterfaceAlias)
 
     if ($netAdapter)
     {
@@ -128,7 +128,7 @@ function Set-TargetResource
 
     $netAdapter = Get-CimInstance `
         -ClassName Win32_NetworkAdapter `
-        -Filter ('Name="{0}"' -f $InterfaceAlias)
+        -Filter ('NetConnectionID="{0}"' -f $InterfaceAlias)
 
     if ($netAdapter)
     {
@@ -207,7 +207,7 @@ function Test-TargetResource
 
     $netAdapter = Get-CimInstance `
         -ClassName Win32_NetworkAdapter `
-        -Filter ('Name="{0}"' -f $InterfaceAlias)
+        -Filter ('NetConnectionID="{0}"' -f $InterfaceAlias)
 
     if ($netAdapter)
     {

--- a/Tests/Integration/MSFT_xNetBIOS.Integration.Tests.ps1
+++ b/Tests/Integration/MSFT_xNetBIOS.Integration.Tests.ps1
@@ -26,7 +26,7 @@ if (-not $netAdapterConfig)
     Write-Verbose -Message ('There are no enabled network adapters with IP enabled in this system. Integration tests will be skipped.') -Verbose
     return
 }
-Write-Verbose -Message ('A network adapter ({0}) was found in this system that meets requirements for integration testing.' -f $netAdapter.Name) -Verbose
+Write-Verbose -Message ('A network adapter ({0}) was found in this system that meets requirements for integration testing.' -f $netAdapter.NetConnectionID) -Verbose
 
 #region HEADER
 # Integration Test Template Version: 1.1.0
@@ -77,7 +77,7 @@ try
                 AllNodes = @(
                     @{
                         NodeName            = 'localhost'
-                        InterfaceAlias      = $netAdapter.Name
+                        InterfaceAlias      = $netAdapter.NetConnectionID
                         Setting             = 'Disable'
                     }
                 )
@@ -116,7 +116,7 @@ try
                 AllNodes = @(
                     @{
                         NodeName            = 'localhost'
-                        InterfaceAlias      = $netAdapter.Name
+                        InterfaceAlias      = $netAdapter.NetConnectionID
                         Setting             = 'Enable'
                     }
                 )
@@ -155,7 +155,7 @@ try
                 AllNodes = @(
                     @{
                         NodeName            = 'localhost'
-                        InterfaceAlias      = $netAdapter.Name
+                        InterfaceAlias      = $netAdapter.NetConnectionID
                         Setting             = 'Default'
                     }
                 )


### PR DESCRIPTION
**Pull Request (PR) description**
This PR fixes an issue with InterfaceAlias matching on Adapter description rather than Adapter Name.

**This Pull Request (PR) fixes the following issues:**
- Fixes #315

**Task list:**
- [x] Change details added to Unreleased section of CHANGELOG.md?
- [ ] Added/updated documentation, comment-based help and descriptions in .schema.mof files where appropriate?
- [ ] Examples appropriately updated?
- [x] New/changed code adheres to [Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md)?
- [x] [Unit and (optional) Integration tests](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md) created/updated where possible?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/powershell/xnetworking/316)
<!-- Reviewable:end -->
