### PR TITLE
Expose -IncludeHidden parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated build to use `Sampler.GitHubTasks` - Fixes [Issue #489](https://github.com/dsccommunity/NetworkingDsc/issues/489).
 - Added support for publishing code coverage to `CodeCov.io` and
   Azure Pipelines - Fixes [Issue #491](https://github.com/dsccommunity/NetworkingDsc/issues/491).
+- Allow configuration of hidden network adapters.
 
 ## [8.2.0] - 2020-10-16
 

--- a/source/DSCResources/DSC_DefaultGatewayAddress/DSC_DefaultGatewayAddress.psm1
+++ b/source/DSCResources/DSC_DefaultGatewayAddress/DSC_DefaultGatewayAddress.psm1
@@ -292,7 +292,7 @@ function Assert-ResourceProperty
         $Address
     )
 
-    if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    if (-not (Get-NetAdapter -IncludeHidden:$IncludeHidden | Where-Object -Property Name -EQ $InterfaceAlias ))
     {
         New-InvalidOperationException `
             -Message ($script:localizedData.InterfaceNotAvailableError -f $InterfaceAlias)

--- a/source/DSCResources/DSC_DefaultGatewayAddress/DSC_DefaultGatewayAddress.psm1
+++ b/source/DSCResources/DSC_DefaultGatewayAddress/DSC_DefaultGatewayAddress.psm1
@@ -266,6 +266,9 @@ function Test-TargetResource
     .PARAMETER InterfaceAlias
         Alias of the network interface for which the default gateway address is set.
 
+    .PARAMETER IncludeHidden
+        Whether to include hidden network adapters.
+
     .PARAMETER AddressFamily
         IP address family.
 
@@ -281,6 +284,10 @@ function Assert-ResourceProperty
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter()]
         [ValidateSet('IPv4', 'IPv6')]

--- a/source/DSCResources/DSC_NetAdapterAdvancedProperty/DSC_NetAdapterAdvancedProperty.psm1
+++ b/source/DSCResources/DSC_NetAdapterAdvancedProperty/DSC_NetAdapterAdvancedProperty.psm1
@@ -17,6 +17,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER NetworkAdapterName
         Specifies the name of the network adapter to set the advanced property for.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER RegistryKeyword
         Specifies the registry keyword that should be in desired state.
 
@@ -32,6 +35,10 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $NetworkAdapterName,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -51,6 +58,7 @@ function Get-TargetResource
     {
         $netAdapterAdvancedProperty = Get-NetAdapterAdvancedProperty `
             -Name $networkAdapterName `
+            -IncludeHidden:$IncludeHidden `
             -RegistryKeyword $RegistryKeyword `
             -ErrorAction Stop
     }
@@ -85,6 +93,9 @@ function Get-TargetResource
     .PARAMETER NetworkAdapterName
         Specifies the name of the network adapter to set the advanced property for.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER RegistryKeyword
         Specifies the registry keyword that should be in desired state.
 
@@ -99,6 +110,10 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $NetworkAdapterName,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -118,6 +133,7 @@ function Set-TargetResource
     {
         $netAdapterAdvancedProperty = Get-NetAdapterAdvancedProperty `
             -Name $networkAdapterName `
+            -IncludeHidden:$IncludeHidden `
             -RegistryKeyword $RegistryKeyword `
             -ErrorAction Stop
     }
@@ -146,6 +162,7 @@ function Set-TargetResource
             Set-NetAdapterAdvancedProperty `
                 -RegistryValue $RegistryValue `
                 -Name $networkAdapterName `
+                -IncludeHidden:$IncludeHidden `
                 -RegistryKeyword $RegistryKeyword
         }
     }
@@ -157,6 +174,9 @@ function Set-TargetResource
 
     .PARAMETER NetworkAdapterName
         Specifies the name of the network adapter to set the advanced property for.
+
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
 
     .PARAMETER RegistryKeyword
         Specifies the registry keyword that should be in desired state.
@@ -173,6 +193,10 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $NetworkAdapterName,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [System.String]
@@ -192,6 +216,7 @@ function Test-TargetResource
     {
         $netAdapterAdvancedProperty = Get-NetAdapterAdvancedProperty `
             -Name $networkAdapterName `
+            -IncludeHidden:$IncludeHidden `
             -RegistryKeyword $RegistryKeyword `
             -ErrorAction Stop
     }

--- a/source/DSCResources/DSC_NetAdapterAdvancedProperty/DSC_NetAdapterAdvancedProperty.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterAdvancedProperty/DSC_NetAdapterAdvancedProperty.schema.mof
@@ -2,6 +2,7 @@
 class DSC_NetAdapterAdvancedProperty : OMI_BaseResource
 {
     [Key, Description("Specifies the name of the network adapter to set the advanced property for.")] String NetworkAdapterName;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Key, Description("Specifies the registry keyword that should be in desired state.")] String RegistryKeyword;
     [Required, Description("Specifies the value of the registry keyword.")] String RegistryValue;
     [Read, Description("Output Display value of selected RegistryKeyword.")] String DisplayValue;

--- a/source/DSCResources/DSC_NetAdapterBinding/DSC_NetAdapterBinding.psm1
+++ b/source/DSCResources/DSC_NetAdapterBinding/DSC_NetAdapterBinding.psm1
@@ -17,6 +17,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface. Supports the use of '*'.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER ComponentId
         Specifies the underlying name of the transport or filter in the following
         form - ms_xxxx, such as ms_tcpip.
@@ -34,6 +37,10 @@ function Get-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -86,6 +93,9 @@ function Get-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface. Supports the use of '*'.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER ComponentId
         Specifies the underlying name of the transport or filter in the following
         form - ms_xxxx, such as ms_tcpip.
@@ -102,6 +112,10 @@ function Set-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -151,6 +165,9 @@ function Set-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface. Supports the use of '*'.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER ComponentId
         Specifies the underlying name of the transport or filter in the following
         form - ms_xxxx, such as ms_tcpip.
@@ -168,6 +185,10 @@ function Test-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
@@ -231,6 +252,9 @@ function Test-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface. Supports the use of '*'.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER ComponentId
         Specifies the underlying name of the transport or filter in the following
         form - ms_xxxx, such as ms_tcpip.
@@ -249,6 +273,10 @@ function Get-Binding
         [System.String]
         $InterfaceAlias,
 
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
@@ -260,7 +288,7 @@ function Get-Binding
         $State = 'Enabled'
     )
 
-    if (-not (Get-NetAdapter -Name $InterfaceAlias -ErrorAction SilentlyContinue))
+    if (-not (Get-NetAdapter -Name $InterfaceAlias -IncludeHidden:$IncludeHidden -ErrorAction SilentlyContinue))
     {
         New-InvalidArgumentException `
             -Message ($script:localizedData.InterfaceNotAvailableError -f $InterfaceAlias) `

--- a/source/DSCResources/DSC_NetAdapterBinding/DSC_NetAdapterBinding.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterBinding/DSC_NetAdapterBinding.schema.mof
@@ -2,6 +2,7 @@
 class DSC_NetAdapterBinding : OMI_BaseResource
 {
     [Key, Description("Specifies the alias of a network interface. Supports the use of '*'.")] string InterfaceAlias;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Key, Description("Specifies the underlying name of the transport or filter in the following form - ms_xxxx, such as ms_tcpip.")] string ComponentId;
     [Write, Description("Specifies if the component ID for the Interface should be Enabled or Disabled."), ValueMap{"Enabled", "Disabled"}, Values{"Enabled", "Disabled"}] string State;
     [Read, Description("Returns the current state of the component ID for the Interfaces."), ValueMap{"Enabled", "Disabled","Mixed"}, Values{"Enabled", "Disabled","Mixed"}] string CurrentState;

--- a/source/DSCResources/DSC_NetAdapterLso/DSC_NetAdapterLso.psm1
+++ b/source/DSCResources/DSC_NetAdapterLso/DSC_NetAdapterLso.psm1
@@ -17,6 +17,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER Name
         Specifies the name of the network adapter to check.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Protocol
         Specifies which protocol to target.
 
@@ -32,6 +35,10 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('V1IPv4', 'IPv4', 'IPv6')]
@@ -50,7 +57,9 @@ function Get-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterLso -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterLso -Name $Name `
+                                        -IncludeHidden:$IncludeHidden `
+                                        -ErrorAction Stop
     }
     catch
     {
@@ -99,6 +108,9 @@ function Get-TargetResource
     .PARAMETER Name
         Specifies the name of the network adapter to check.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Protocol
         Specifies which protocol to target.
 
@@ -113,6 +125,10 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('V1IPv4', 'IPv4', 'IPv6')]
@@ -131,7 +147,9 @@ function Set-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterLso -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterLso -Name $Name `
+                                        -IncludeHidden:$IncludeHidden `
+                                        -ErrorAction Stop
     }
     catch
     {
@@ -154,7 +172,9 @@ function Set-TargetResource
                             $Name, $Protocol, $($netAdapter.V1IPv4Enabled.ToString()), $($State.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterLso -Name $Name -V1IPv4Enabled $State
+            Set-NetAdapterLso -Name $Name `
+                              -IncludeHidden:$IncludeHidden `
+                              -ErrorAction Stop
         }
         elseif ($Protocol -eq 'IPv4' -and $State -ne $netAdapter.IPv4Enabled)
         {
@@ -164,7 +184,9 @@ function Set-TargetResource
                             $Name, $Protocol, $($netAdapter.IPv4Enabled.ToString()), $($State.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterLso -Name $Name -IPv4Enabled $State
+            Set-NetAdapterLso -Name $Name `
+                              -IncludeHidden:$IncludeHidden `
+                              -ErrorAction Stop
         }
         elseif ($Protocol -eq 'IPv6' -and $State -ne $netAdapter.IPv6Enabled)
         {
@@ -174,7 +196,9 @@ function Set-TargetResource
                             $Name, $Protocol, $($netAdapter.IPv6Enabled.ToString()), $($State.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterLso -Name $Name -IPv6Enabled $State
+            Set-NetAdapterLso -Name $Name `
+                              -IncludeHidden:$IncludeHidden `
+                              -ErrorAction Stop
         }
     }
 }
@@ -185,6 +209,9 @@ function Set-TargetResource
 
     .PARAMETER Name
         Specifies the name of the network adapter to check.
+
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
 
     .PARAMETER Protocol
         Specifies which protocol to target.
@@ -201,6 +228,10 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('V1IPv4', 'IPv4', 'IPv6')]
@@ -219,7 +250,9 @@ function Test-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterLso -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterLso -Name $Name `
+                                        -IncludeHidden:$IncludeHidden `
+                                        -ErrorAction Stop
     }
     catch
     {

--- a/source/DSCResources/DSC_NetAdapterLso/DSC_NetAdapterLso.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterLso/DSC_NetAdapterLso.schema.mof
@@ -2,6 +2,7 @@
 class DSC_NetAdapterLso : OMI_BaseResource
 {
     [Key, Description("Specifies the name of network adapter.")] String Name;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Key, Description("Specifies which protocol to make changes to."), ValueMap{"V1IPv4","IPv4","IPv6"}, Values{"V1IPv4","IPv4","IPv6"}] String Protocol;
     [Required, Description("Specifies whether LSO should be enabled or disabled.")] Boolean State;
 };

--- a/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.psm1
+++ b/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.psm1
@@ -21,6 +21,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER Name
         This is the name of the network adapter to find.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER PhysicalMediaType
         This is the media type of the network adapter to find.
 
@@ -67,6 +70,10 @@ function Get-TargetResource
         $Name,
 
         [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
+        [Parameter()]
         [System.String]
         $PhysicalMediaType,
 
@@ -111,6 +118,7 @@ function Get-TargetResource
 
     $adapter = Find-NetworkAdapter `
         -Name $NewName `
+        -IncludeHidden:$IncludeHidden `
         -ErrorAction SilentlyContinue
 
     if (-not $adapter)
@@ -132,6 +140,7 @@ function Get-TargetResource
 
     $returnValue = @{
         Name                           = $adapter.Name
+        IncludeHidden                  = $IncludeHidden
         PhysicalMediaType              = $adapter.PhysicalMediaType
         Status                         = $adapter.Status
         MacAddress                     = $adapter.MacAddress
@@ -155,6 +164,9 @@ function Get-TargetResource
 
     .PARAMETER Name
         This is the name of the network adapter to find.
+
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
 
     .PARAMETER PhysicalMediaType
         This is the media type of the network adapter to find.
@@ -199,6 +211,10 @@ function Set-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter()]
         [System.String]
@@ -253,7 +269,8 @@ function Set-TargetResource
             $($script:localizedData.RenamingNetAdapterNameMessage -f $adapter.Name, $NewName)
         ) -join '')
 
-    $adapter | Rename-NetAdapter -NewName $NewName
+    $adapter | Rename-NetAdapter -NewName $NewName `
+                                 -IncludeHidden:$IncludeHidden
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
             $($script:localizedData.NetAdapterNameRenamedMessage -f $NewName)
@@ -270,6 +287,9 @@ function Set-TargetResource
 
     .PARAMETER Name
         This is the name of the network adapter to find.
+
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
 
     .PARAMETER PhysicalMediaType
         This is the media type of the network adapter to find.
@@ -315,6 +335,10 @@ function Test-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter()]
         [System.String]
@@ -365,6 +389,7 @@ function Test-TargetResource
     $adapterWithNewName = Find-NetworkAdapter `
         -Name $NewName `
         -Verbose:$Verbose `
+        -IncludeHidden:$IncludeHidden `
         -ErrorAction SilentlyContinue
 
     if ($adapterWithNewName)

--- a/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.schema.mof
@@ -11,5 +11,6 @@ class DSC_NetAdapterName : OMI_BaseResource
     [Write, Description("This is the interface GUID of the network adapter to find.")] String InterfaceGuid;
     [Write, Description("This is the driver description of the network adapter.")] String DriverDescription;
     [Write, Description("This is the interface number of the network adapter if more than one are returned by the parameters.")] UInt32 InterfaceNumber;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Write, Description("This switch will suppress an error occurring if more than one matching adapter matches the parameters passed.")] Boolean IgnoreMultipleMatchingAdapters;
 };

--- a/source/DSCResources/DSC_NetAdapterRdma/DSC_NetAdapterRdma.psm1
+++ b/source/DSCResources/DSC_NetAdapterRdma/DSC_NetAdapterRdma.psm1
@@ -17,6 +17,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER Name
         Specifies the name of network adapter for which RDMA needs
         to be configured.
+
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
 #>
 function Get-TargetResource
 {
@@ -26,7 +29,11 @@ function Get-TargetResource
     (
         [Parameter(Mandatory = $true)]
         [System.String]
-        $Name
+        $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false
     )
 
     $configuration = @{
@@ -37,7 +44,9 @@ function Get-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.GetNetAdapterRdmaMessage -f $Name)
 
-        $netAdapterRdma = Get-NetAdapterRdma -Name $Name -ErrorAction Stop
+        $netAdapterRdma = Get-NetAdapterRdma -Name $Name `
+                                             -IncludeHidden:$IncludeHidden `
+                                             -ErrorAction Stop
     }
     catch
     {
@@ -63,6 +72,9 @@ function Get-TargetResource
         Specifies the name of network adapter for which RDMA needs
         to be configured.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Enabled
         Specifies if the RDMA configuration should be enabled or disabled.
         Defaults to $true.
@@ -78,6 +90,10 @@ function Set-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $IncludeHidden = $false,
+
+        [Parameter()]
+        [System.Boolean]
         $Enabled = $true
     )
 
@@ -85,7 +101,9 @@ function Set-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.GetNetAdapterRdmaMessage -f $Name)
 
-        $netAdapterRdma = Get-NetAdapterRdma -Name $Name -ErrorAction Stop
+        $netAdapterRdma = Get-NetAdapterRdma -Name $Name `
+                                             -IncludeHidden:$IncludeHidden `
+                                             -ErrorAction Stop
     }
     catch
     {
@@ -101,7 +119,9 @@ function Set-TargetResource
         {
             Write-Verbose -Message ($script:localizedData.SetNetAdapterRdmaMessage -f $Name, $Enabled)
 
-            Set-NetAdapterRdma -Name $Name -Enabled $Enabled
+            Set-NetAdapterRdma -Name $Name `
+                               -IncludeHidden:$IncludeHidden `
+                               -Enabled $Enabled
         }
     }
 }
@@ -113,6 +133,9 @@ function Set-TargetResource
     .PARAMETER Name
         Specifies the name of network adapter for which RDMA needs
         to be configured.
+
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
 
     .PARAMETER Enabled
         Specifies if the RDMA configuration should be enabled or disabled.
@@ -130,6 +153,10 @@ function Test-TargetResource
 
         [Parameter()]
         [System.Boolean]
+        $IncludeHidden = $false,
+
+        [Parameter()]
+        [System.Boolean]
         $Enabled = $true
     )
 
@@ -137,7 +164,9 @@ function Test-TargetResource
     {
         Write-Verbose -Message ($script:localizedData.GetNetAdapterRdmaMessage -f $Name)
 
-        $netAdapterRdma = Get-NetAdapterRdma -Name $Name -ErrorAction Stop
+        $netAdapterRdma = Get-NetAdapterRdma -Name $Name `
+                                             -IncludeHidden:$IncludeHidden `
+                                             -ErrorAction Stop
     }
     catch
     {

--- a/source/DSCResources/DSC_NetAdapterRdma/DSC_NetAdapterRdma.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterRdma/DSC_NetAdapterRdma.schema.mof
@@ -2,5 +2,6 @@
 class DSC_NetAdapterRdma : OMI_BaseResource
 {
     [Key, Description("Specifies the name of network adapter for which RDMA needs to be configured.")] String Name;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Write, Description("Specifies if the RDMA configuration should be enabled or disabled. Defaults to $true.")] Boolean Enabled;
 };

--- a/source/DSCResources/DSC_NetAdapterRsc/DSC_NetAdapterRSC.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterRsc/DSC_NetAdapterRSC.schema.mof
@@ -2,6 +2,7 @@
 class DSC_NetAdapterRsc : OMI_BaseResource
 {
     [Key, Description("Specifies the Name of network adapter.")] String Name;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Required, Description("Specifies which protocol to make changes to."), ValueMap{"IPv4","IPv6","All"}, Values{"IPv4","IPv6","All"}] String Protocol;
     [Required, Description("Specifies whether RSC should be enabled or disabled.")] Boolean State;
     [Read, Description("Returns the current state of RSC for IPv4")] String StateIPv4;

--- a/source/DSCResources/DSC_NetAdapterRsc/DSC_NetAdapterRsc.psm1
+++ b/source/DSCResources/DSC_NetAdapterRsc/DSC_NetAdapterRsc.psm1
@@ -17,6 +17,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER Name
         Specifies the Name of the network adapter to check.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Protocol
         Specifies which protocol to target.
 
@@ -32,6 +35,10 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("IPv4", "IPv6", "All")]
@@ -100,6 +107,9 @@ function Get-TargetResource
     .PARAMETER Name
         Specifies the Name of the network adapter to check.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Protocol
         Specifies which protocol to target.
 
@@ -114,6 +124,10 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("IPv4", "IPv6", "All")]
@@ -177,6 +191,9 @@ function Set-TargetResource
     .PARAMETER Name
         Specifies the Name of the network adapter to check.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Protocol
         Specifies which protocol to target.
 
@@ -192,6 +209,10 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet("IPv4", "IPv6", "All")]

--- a/source/DSCResources/DSC_NetAdapterRss/DSC_NetAdapterRss.psm1
+++ b/source/DSCResources/DSC_NetAdapterRss/DSC_NetAdapterRss.psm1
@@ -17,6 +17,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER Name
         Specifies the Name of the network adapter to check.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER State
         Specifies the Rss state for the protocol.
 #>
@@ -30,6 +33,10 @@ function Get-TargetResource
         [String]
         $Name,
 
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
         [Parameter(Mandatory = $true)]
         [Boolean]
         $Enabled
@@ -42,7 +49,9 @@ function Get-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRss -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRss -Name $Name `
+                                        -IncludeHidden:$IncludeHidden `
+                                        -ErrorAction Stop
     }
     catch
     {
@@ -73,6 +82,9 @@ function Get-TargetResource
     .PARAMETER Name
         Specifies the Name of the network adapter to check.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER State
         Specifies the Rss state for the protocol.
 #>
@@ -84,6 +96,10 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [Boolean]
@@ -97,7 +113,9 @@ function Set-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRss -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRss -Name $Name `
+                                        -IncludeHidden:$IncludeHidden `
+                                        -ErrorAction Stop
     }
     catch
     {
@@ -120,7 +138,9 @@ function Set-TargetResource
                             $Name, $Enabled, $($netAdapter.Enabled.ToString()), $($Enabled.ToString()) )
                 ) -join '')
 
-            Set-NetAdapterRss -Name $Name -Enabled:$Enabled
+            Set-NetAdapterRss -Name $Name `
+                              -IncludeHidden:$IncludeHidden `
+                              -Enabled:$Enabled
         }
     }
 }
@@ -131,6 +151,9 @@ function Set-TargetResource
 
     .PARAMETER Name
         Specifies the Name of the network adapter to check.
+
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
 
     .PARAMETER State
         Specifies the Rss state for the protocol.
@@ -145,6 +168,10 @@ function Test-TargetResource
         [String]
         $Name,
 
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
         [Parameter(Mandatory = $true)]
         [Boolean]
         $Enabled
@@ -157,7 +184,9 @@ function Test-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapterRss -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapterRss -Name $Name `
+                                        -IncludeHidden:$IncludeHidden `
+                                        -ErrorAction Stop
     }
     catch
     {

--- a/source/DSCResources/DSC_NetAdapterRss/DSC_NetAdapterRss.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterRss/DSC_NetAdapterRss.schema.mof
@@ -2,5 +2,6 @@
 class DSC_NetAdapterRss : OMI_BaseResource
 {
     [Key, Description("Specifies the Name of network adapter.")] String Name;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Required, Description("Specifies whether RSS should be enabled or disabled.")] Boolean Enabled;
 };

--- a/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.psm1
+++ b/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.psm1
@@ -17,6 +17,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER Name
         Specifies the name of the network adapter.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER State
         Specifies the desired state for the network adapter.
         Not used in Get-TargetResource.
@@ -31,6 +34,10 @@ function Get-TargetResource
         [System.String]
         $Name,
 
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
         [System.String]
@@ -44,7 +51,9 @@ function Get-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapter -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapter -Name $Name `
+                                     -IncludeHidden:$IncludeHidden `
+                                     -ErrorAction Stop
     }
     catch
     {
@@ -90,6 +99,9 @@ function Get-TargetResource
     .PARAMETER Name
         Specifies the name of the network adapter.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER State
         Specifies the desired state for the network adapter.
 #>
@@ -101,6 +113,10 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]
@@ -115,7 +131,9 @@ function Set-TargetResource
 
     try
     {
-        $netAdapter = Get-NetAdapter -Name $Name -ErrorAction Stop
+        $netAdapter = Get-NetAdapter -Name $Name `
+                                     -IncludeHidden:$IncludeHidden `
+                                     -ErrorAction Stop
     }
     catch
     {
@@ -131,11 +149,16 @@ function Set-TargetResource
         {
             if ($State -eq 'Disabled')
             {
-                Disable-NetAdapter -Name $Name -Confirm:$false -ErrorAction Stop
+                Disable-NetAdapter -Name $Name `
+                                   -IncludeHidden:$IncludeHidden `
+                                   -Confirm:$false `
+                                   -ErrorAction Stop
             }
             else
             {
-                Enable-NetAdapter -Name $Name -ErrorAction Stop
+                Enable-NetAdapter -Name $Name `
+                                  -IncludeHidden:$IncludeHidden `
+                                  -ErrorAction Stop
             }
         }
         catch
@@ -155,6 +178,9 @@ function Set-TargetResource
     .PARAMETER Name
         Specifies the name of the network adapter.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER State
         Specifies the state of the network adapter.
 #>
@@ -167,6 +193,10 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Enabled', 'Disabled')]

--- a/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterState/DSC_NetAdapterState.schema.mof
@@ -2,5 +2,6 @@
 class DSC_NetAdapterState : OMI_BaseResource
 {
     [Key, Description("Specifies the name of network adapter.")] String Name;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Required, Description("Specifies the desired state of the network adapter"), ValueMap{"Enabled","Disabled"}, Values{"Enabled","Disabled"}] String State;
 };

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.psm1
@@ -38,6 +38,9 @@ catch
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface. Supports the use of '*' and '%'.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Setting
         Specifies if NetBIOS should be enabled or disabled or obtained from
         the DHCP server (Default). If static IP, Enable NetBIOS.
@@ -53,6 +56,10 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Default', 'Enable', 'Disable')]
@@ -126,6 +133,9 @@ function Get-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface. Supports the use of '*' and '%'.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Setting
         Specifies if NetBIOS should be enabled or disabled or obtained from
         the DHCP server (Default). If static IP, Enable NetBIOS.
@@ -138,6 +148,10 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Default', 'Enable', 'Disable')]
@@ -180,6 +194,7 @@ function Set-TargetResource
 
                 Set-NetAdapterNetbiosOptions -NetworkAdapterObject $netAdapterConfig `
                                              -InterfaceAlias $netAdapterItem.NetConnectionID `
+                                             -IncludeHidden $IncludeHidden `
                                              -Setting $Setting
             }
         }
@@ -205,6 +220,9 @@ function Set-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface. Supports the use of '*' and '%'.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Setting
         Specifies if NetBIOS should be enabled or disabled or obtained from
         the DHCP server (Default). If static IP, Enable NetBIOS.
@@ -218,6 +236,10 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Default', 'Enable', 'Disable')]
@@ -325,6 +347,9 @@ function Get-NetAdapterNetbiosOptionsFromRegistry
     .PARAMETER InterfaceAlias
         Name of the network adapter being configured. Example: Ethernet
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER Setting
         Setting value for this resource which should be one of
         the following: Default, Enable, Disable
@@ -341,6 +366,10 @@ function Set-NetAdapterNetbiosOptions
         [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('Default','Enable','Disable')]

--- a/source/DSCResources/DSC_NetBios/DSC_NetBios.schema.mof
+++ b/source/DSCResources/DSC_NetBios/DSC_NetBios.schema.mof
@@ -3,5 +3,6 @@
 class DSC_NetBios : OMI_BaseResource
 {
     [Key, Description("Specifies the alias of a network interface. Supports the use of '*' and '%'")] String InterfaceAlias;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Required, Description("Specifies if NetBIOS should be enabled or disabled or obtained from the DHCP server (Default). If static IP, Enable NetBIOS."), ValueMap{"Default","Enable","Disable"}, Values{"Default","Enable","Disable"}] String Setting;
 };

--- a/source/DSCResources/DSC_NetConnectionProfile/DSC_NetConnectionProfile.psm1
+++ b/source/DSCResources/DSC_NetConnectionProfile/DSC_NetConnectionProfile.psm1
@@ -16,6 +16,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
 
     .PARAMETER InterfaceAlias
         Specifies the alias for the Interface that is being changed.
+
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
 #>
 function Get-TargetResource
 {
@@ -25,7 +28,11 @@ function Get-TargetResource
     (
         [Parameter(Position = 0, Mandatory = $true)]
         [System.String]
-        $InterfaceAlias
+        $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false
     )
 
     Write-Verbose -Message ( @( "$($MyInvocation.MyCommand): "
@@ -49,6 +56,9 @@ function Get-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias for the Interface that is being changed.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER IPv4Connectivity
         Specifies the IPv4 Connection Value.
 
@@ -66,6 +76,10 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
@@ -99,6 +113,9 @@ function Set-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias for the Interface that is being changed.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER IPv4Connectivity
         Specifies the IPv4 Connection Value.
 
@@ -117,6 +134,10 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
@@ -180,6 +201,9 @@ function Test-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias for the Interface that is being changed.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER IPv4Connectivity
         Specifies the IPv4 Connection Value.
 
@@ -199,6 +223,10 @@ function Assert-ResourceProperty
         $InterfaceAlias,
 
         [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
+        [Parameter()]
         [ValidateSet('Disconnected', 'NoTraffic', 'Subnet', 'LocalNetwork', 'Internet')]
         [System.String]
         $IPv4Connectivity,
@@ -214,7 +242,7 @@ function Assert-ResourceProperty
         $NetworkCategory
     )
 
-    if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    if (-not (Get-NetAdapter -IncludeHidden:$IncludeHidden | Where-Object -Property Name -EQ $InterfaceAlias ))
     {
         New-InvalidOperationException `
             -Message ($script:localizedData.InterfaceNotAvailableError -f $InterfaceAlias)

--- a/source/DSCResources/DSC_NetConnectionProfile/DSC_NetConnectionProfile.schema.mof
+++ b/source/DSCResources/DSC_NetConnectionProfile/DSC_NetConnectionProfile.schema.mof
@@ -2,6 +2,7 @@
 class DSC_NetConnectionProfile : OMI_BaseResource
 {
     [Key, Description("Specifies the alias for the Interface that is being changed.")] string InterfaceAlias;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Write, Description("Sets the Network Category for the interface."), ValueMap{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}, Values{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}] string IPv4Connectivity;
     [Write, Description("Specifies the IPv4 Connection Value."), ValueMap{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}, Values{"Disconnected", "NoTraffic", "Subnet", "LocalNetwork", "Internet"}] string IPv6Connectivity;
     [Write, Description("Specifies the IPv6 Connection Value."), ValueMap{"Public", "Private"}, Values{"Public", "Private"}] string NetworkCategory;

--- a/source/DSCResources/DSC_Route/DSC_Route.psm1
+++ b/source/DSCResources/DSC_Route/DSC_Route.psm1
@@ -17,6 +17,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER AddressFamily
         Specify the IP address family.
 
@@ -38,6 +41,10 @@ function Get-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
@@ -109,6 +116,9 @@ function Get-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER AddressFamily
         Specify the IP address family.
 
@@ -144,6 +154,10 @@ function Set-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
@@ -265,6 +279,9 @@ function Set-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER AddressFamily
         Specify the IP address family.
 
@@ -301,6 +318,10 @@ function Test-TargetResource
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
@@ -444,6 +465,9 @@ function Test-TargetResource
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER AddressFamily
         Specify the IP address family.
 
@@ -478,6 +502,10 @@ function Get-Route
         [ValidateNotNullOrEmpty()]
         [System.String]
         $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
@@ -542,6 +570,9 @@ function Get-Route
     .PARAMETER InterfaceAlias
         Specifies the alias of a network interface.
 
+    .PARAMETER IncludeHidden
+        This switch will causes hidden network adapters to be included in the search.
+
     .PARAMETER AddressFamily
         Specify the IP address family.
 
@@ -578,6 +609,10 @@ function Assert-ResourceProperty
         [System.String]
         $InterfaceAlias,
 
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
         [System.String]
@@ -613,7 +648,7 @@ function Assert-ResourceProperty
     )
 
     # Validate the Adapter exists
-    if (-not (Get-NetAdapter | Where-Object -Property Name -EQ $InterfaceAlias ))
+    if (-not (Get-NetAdapter -IncludeHidden:$IncludeHidden | Where-Object -Property Name -EQ $InterfaceAlias ))
     {
         New-InvalidArgumentException `
             -Message $($($script:localizedData.InterfaceNotAvailableError) -f $InterfaceAlias) `

--- a/source/DSCResources/DSC_Route/DSC_Route.schema.mof
+++ b/source/DSCResources/DSC_Route/DSC_Route.schema.mof
@@ -2,6 +2,7 @@
 class DSC_Route : OMI_BaseResource
 {
     [Key, Description("Specifies the alias of a network interface.")] string InterfaceAlias;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Key, Description("Specifies the IP address family."), ValueMap{"IPv4", "IPv6"},Values{"IPv4", "IPv6"}] string AddressFamily;
     [Key, Description("Specifies a destination prefix of an IP route. A destination prefix consists of an IP address prefix and a prefix length, separated by a slash (/).")] String DestinationPrefix;
     [Key, Description("Specifies the next hop for the IP route.")] String NextHop;

--- a/source/DSCResources/DSC_WinsServerAddress/DSC_WinsServerAddress.schema.mof
+++ b/source/DSCResources/DSC_WinsServerAddress/DSC_WinsServerAddress.schema.mof
@@ -2,5 +2,6 @@
 class DSC_WinsServerAddress : OMI_BaseResource
 {
     [Key, Description("Alias of the network interface for which the WINS server address is set.")] string InterfaceAlias;
+    [Write, Description("This switch will causes hidden network adapters to be included in the search.")] Boolean IncludeHidden;
     [Write, Description("The desired WINS Server address(es). Exclude to remove all WINS servers.")] string Address[];
 };

--- a/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -85,6 +85,9 @@ function Convert-CIDRToSubhetMask
     .PARAMETER Name
         This is the name of network adapter to find.
 
+    .PARAMETER IncludeHidden
+        This switch will include hidden adapters.
+
     .PARAMETER PhysicalMediaType
         This is the media type of the network adapter to find.
 
@@ -123,6 +126,10 @@ function Find-NetworkAdapter
         [Parameter()]
         [System.String]
         $Name,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
 
         [Parameter()]
         [System.String]
@@ -215,13 +222,13 @@ function Find-NetworkAdapter
                 $($script:localizedData.AllNetAdaptersFoundMessage)
             ) -join '')
 
-        $matchingAdapters = @(Get-NetAdapter)
+        $matchingAdapters = @(Get-NetAdapter -IncludeHidden:$IncludeHidden)
     }
     else
     {
         # Join all the filters together
         $adapterFilterScript = '(' + ($adapterFilters -join ' -and ') + ')'
-        $matchingAdapters = @(Get-NetAdapter |
+        $matchingAdapters = @(Get-NetAdapter -IncludeHidden:$IncludeHidden |
             Where-Object -FilterScript ([ScriptBlock]::Create($adapterFilterScript)))
     }
 
@@ -296,6 +303,9 @@ function Find-NetworkAdapter
     .PARAMETER InterfaceAlias
         Alias of the network interface to get the static DNS Server addresses from.
 
+    .PARAMETER IncludeHidden
+        This switch will include hidden adapters.
+
     .PARAMETER AddressFamily
         IP address family.
 #>
@@ -310,6 +320,10 @@ function Get-DnsClientServerStaticAddress
         [System.String]
         $InterfaceAlias,
 
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
         [System.String]
@@ -323,6 +337,7 @@ function Get-DnsClientServerStaticAddress
     # Look up the interface Guid
     $adapter = Get-NetAdapter `
         -InterfaceAlias $InterfaceAlias `
+        -IncludeHidden:$IncludeHidden `
         -ErrorAction SilentlyContinue
 
     if (-not $adapter)
@@ -380,6 +395,9 @@ function Get-DnsClientServerStaticAddress
 
     .PARAMETER InterfaceAlias
         Alias of the network interface to get the static WINS Server addresses from.
+
+    .PARAMETER IncludeHidden
+        This switch will include hidden adapters.
 #>
 function Get-WinsClientServerStaticAddress
 {
@@ -390,13 +408,20 @@ function Get-WinsClientServerStaticAddress
         [Parameter(Mandatory = $true)]
         [ValidateNotNullOrEmpty()]
         [System.String]
-        $InterfaceAlias
+        $InterfaceAlias,
+
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false
     )
 
     Write-Verbose -Message ("$($MyInvocation.MyCommand): $($script:localizedData.GettingWinsServerStaticAddressMessage -f $InterfaceAlias)")
 
     # Look up the interface Guid
-    $adapter = Get-NetAdapter -InterfaceAlias $InterfaceAlias -ErrorAction SilentlyContinue
+    $adapter = Get-NetAdapter `
+        -InterfaceAlias $InterfaceAlias `
+        -IncludeHidden:$IncludeHidden `
+        -ErrorAction SilentlyContinue
 
     if (-not $adapter)
     {
@@ -438,6 +463,12 @@ function Get-WinsClientServerStaticAddress
 
     .PARAMETER InterfaceAlias
         Alias of the network interface to set the static WINS Server addresses on.
+
+    .PARAMETER IncludeHidden
+        This switch will include hidden adapters.
+
+    .PARAMETER Address
+        The WINS server IP addresses to configure.
 #>
 function Set-WinsClientServerStaticAddress
 {
@@ -449,6 +480,10 @@ function Set-WinsClientServerStaticAddress
         [System.String]
         $InterfaceAlias,
 
+        [Parameter()]
+        [System.Boolean]
+        $IncludeHidden = $false,
+
         [Parameter(Mandatory = $true)]
         [AllowEmptyCollection()]
         [System.String[]]
@@ -458,7 +493,10 @@ function Set-WinsClientServerStaticAddress
     Write-Verbose -Message ("$($MyInvocation.MyCommand): $($script:localizedData.SettingWinsServerStaticAddressMessage -f $InterfaceAlias, ($Address -join ', '))")
 
     # Look up the interface Guid
-    $adapter = Get-NetAdapter -InterfaceAlias $InterfaceAlias -ErrorAction SilentlyContinue
+    $adapter = Get-NetAdapter `
+        -InterfaceAlias $InterfaceAlias `
+        -IncludeHidden:$IncludeHidden `
+        -ErrorAction SilentlyContinue
 
     if (-not $adapter)
     {

--- a/tests/Unit/DSC_NetAdapterName.Tests.ps1
+++ b/tests/Unit/DSC_NetAdapterName.Tests.ps1
@@ -85,6 +85,10 @@ try
                 $InputObject,
 
                 [Parameter()]
+                [System.Boolean]
+                $IncludeHidden = $false,
+
+                [Parameter()]
                 [System.String]
                 $NewName
             )

--- a/tests/Unit/DSC_NetAdapterRdma.Tests.ps1
+++ b/tests/Unit/DSC_NetAdapterRdma.Tests.ps1
@@ -99,6 +99,10 @@ try
                     [System.String]
                     $Name,
 
+                    [Parameter()]
+                    [System.Boolean]
+                    $IncludeHidden = $false,
+
                     [Parameter(Mandatory = $true)]
                     [System.Boolean]
                     $Enabled = $true


### PR DESCRIPTION
#### Pull Request (PR) description
NetAdapter module Cmdlets have an -IncludeHidden flag which allows access to adapters which are hidden; expose that flag here.

#### This Pull Request (PR) fixes the following issues
- Fixes #499: solution 1.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->
- [x] Added an entry under the Unreleased section of the change log in the CHANGELOG.md.
      Entry should say what was changed, and how that affects users (if applicable).
- [ ] Resource documentation added/updated in README.md in resource folder.
- [ ] Resource parameter descriptions added/updated in schema.mof
      and comment-based help.
- [ ] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [ ] Unit tests added/updated. See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] Integration tests added/updated (where possible). See [DSC Resource Testing Guidelines](https://github.com/PowerShell/DscResources/blob/master/TestsGuidelines.md).
- [ ] New/changed code adheres to [DSC Resource Style Guidelines](https://github.com/PowerShell/DscResources/blob/master/StyleGuidelines.md) and [Best Practices](https://github.com/PowerShell/DscResources/blob/master/BestPractices.md).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/networkingdsc/495)
<!-- Reviewable:end -->
