### PR TITLE
[NetAdapterRename] Allow rename with HyperV Device Naming

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Updated CHANGELOG.md
   - Renamed NetworkingDSc to NetworkingDsc in CHANGELOG.md - fixes [Issue #513](https://github.com/dsccommunity/NetworkingDsc/issues/513).
+- NetAdapterName
+  - Added new parameter HyperVNetworkAdapterName to filter if device naming is configured on a Hyper-V network adapter.
 
 ## [9.0.0] - 2022-05-30
 

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -24,7 +24,7 @@ stages:
       - job: Package_Module
         displayName: 'Package Module'
         pool:
-          vmImage: 'ubuntu-latest'
+          vmImage: 'windows-latest'
         steps:
           - pwsh: |
               dotnet tool install --global GitVersion.Tool

--- a/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.psm1
+++ b/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.psm1
@@ -42,6 +42,9 @@ $script:localizedData = Get-LocalizedData -DefaultUICulture 'en-US'
     .PARAMETER DriverDescription
         This is the driver description of the network adapter.
 
+    .PARAMETER HyperVNetworkAdapterName
+        This is the name of the network adapter to find if device naming is enabled.
+
     .PARAMETER InterfaceNumber
         This is the interface number of the network adapter if more than one
         are returned by the parameters.
@@ -97,6 +100,10 @@ function Get-TargetResource
         $DriverDescription,
 
         [Parameter()]
+        [System.String]
+        $HyperVNetworkAdapterName,
+
+        [Parameter()]
         [System.UInt32]
         $InterfaceNumber = 1,
 
@@ -139,6 +146,7 @@ function Get-TargetResource
         InterfaceIndex                 = $adapter.InterfaceIndex
         InterfaceGuid                  = $adapter.InterfaceGuid
         DriverDescription              = $adapter.DriverDescription
+        HyperVNetworkAdapterName       = $adapter.HyperVNetworkAdapterName
         InterfaceNumber                = $InterfaceNumber
         IgnoreMultipleMatchingAdapters = $IgnoreMultipleMatchingAdapters
     }
@@ -176,6 +184,9 @@ function Get-TargetResource
 
     .PARAMETER DriverDescription
         This is the driver description of the network adapter.
+
+    .PARAMETER HyperVNetworkAdapterName
+        This is the name of the network adapter to find if device naming is enabled.
 
     .PARAMETER InterfaceNumber
         This is the interface number of the network adapter if more than one
@@ -229,6 +240,10 @@ function Set-TargetResource
         [Parameter()]
         [System.String]
         $DriverDescription,
+
+        [Parameter()]
+        [System.String]
+        $HyperVNetworkAdapterName,
 
         [Parameter()]
         [System.UInt32]
@@ -293,6 +308,9 @@ function Set-TargetResource
     .PARAMETER DriverDescription
         This is the driver description of the network adapter.
 
+    .PARAMETER HyperVNetworkAdapterName
+        This is the name of the network adapter to find if device naming is enabled.
+
     .PARAMETER InterfaceNumber
         This is the interface number of the network adapter if more than one
         are returned by the parameters.
@@ -346,6 +364,10 @@ function Test-TargetResource
         [Parameter()]
         [System.String]
         $DriverDescription,
+
+        [Parameter()]
+        [System.String]
+        $HyperVNetworkAdapterName,
 
         [Parameter()]
         [System.UInt32]

--- a/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.schema.mof
+++ b/source/DSCResources/DSC_NetAdapterName/DSC_NetAdapterName.schema.mof
@@ -10,6 +10,7 @@ class DSC_NetAdapterName : OMI_BaseResource
     [Write, Description("This is the interface index of the network adapter to find.")] UInt32 InterfaceIndex;
     [Write, Description("This is the interface GUID of the network adapter to find.")] String InterfaceGuid;
     [Write, Description("This is the driver description of the network adapter.")] String DriverDescription;
+    [Write, Description("This is the name of the network adapter to find if device naming is enabled.")] String HyperVNetworkAdapterName;
     [Write, Description("This is the interface number of the network adapter if more than one are returned by the parameters.")] UInt32 InterfaceNumber;
     [Write, Description("This switch will suppress an error occurring if more than one matching adapter matches the parameters passed.")] Boolean IgnoreMultipleMatchingAdapters;
 };

--- a/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
+++ b/source/Modules/NetworkingDsc.Common/NetworkingDsc.Common.psm1
@@ -159,6 +159,10 @@ function Find-NetworkAdapter
         $InterfaceNumber = 1,
 
         [Parameter()]
+        [System.String]
+        $HyperVNetworkAdapterName,
+
+        [Parameter()]
         [System.Boolean]
         $IgnoreMultipleMatchingAdapters = $false
     )
@@ -207,6 +211,11 @@ function Find-NetworkAdapter
     if ($PSBoundParameters.ContainsKey('DriverDescription'))
     {
         $adapterFilters += @('($_.DriverDescription -eq $DriverDescription)')
+    } # if
+
+    if ($PSBoundParameters.ContainsKey('HyperVNetworkAdapterName'))
+    {
+        $adapterFilters += @('((Get-NetAdapterAdvancedProperty -Name $_.Name -RegistryKeyword HyperVNetworkAdapterName -ErrorAction SilentlyContinue).DisplayValue -eq $HyperVNetworkAdapterName)')
     } # if
 
     if ($adapterFilters.Count -eq 0)

--- a/tests/Unit/DSC_NetAdapterName.Tests.ps1
+++ b/tests/Unit/DSC_NetAdapterName.Tests.ps1
@@ -42,28 +42,31 @@ try
         $script:adapterInterfaceIndex = 2
         $script:adapterInterfaceGuid = '75670D9B-5879-4DBA-BC99-86CDD33EB66A'
         $script:adapterDriverDescription = 'Hyper-V Virtual Ethernet Adapter'
+        $script:adapterHyperVNetworkAdapterName = 'hv-res-001'
 
         $script:adapterParameters = [PSObject]@{
-            Name                 = $script:adapterName
-            NewName              = $script:newAdapterName
-            PhysicalMediaType    = $script:adapterPhysicalMediaType
-            Status               = $script:adapterStatus
-            MacAddress           = $script:adapterMacAddress
-            InterfaceDescription = $script:adapterInterfaceDescription
-            InterfaceIndex       = $script:adapterInterfaceIndex
-            InterfaceGuid        = $script:adapterInterfaceGuid
-            DriverDescription    = $script:adapterDriverDescription
+            Name                     = $script:adapterName
+            NewName                  = $script:newAdapterName
+            PhysicalMediaType        = $script:adapterPhysicalMediaType
+            Status                   = $script:adapterStatus
+            MacAddress               = $script:adapterMacAddress
+            InterfaceDescription     = $script:adapterInterfaceDescription
+            InterfaceIndex           = $script:adapterInterfaceIndex
+            InterfaceGuid            = $script:adapterInterfaceGuid
+            DriverDescription        = $script:adapterDriverDescription
+            HyperVNetworkAdapterName = $script:adapterHyperVNetworkAdapterName
         }
 
         $script:mockAdapter = [PSObject]@{
-            Name                 = $script:adapterName
-            PhysicalMediaType    = $script:adapterPhysicalMediaType
-            Status               = $script:adapterStatus
-            MacAddress           = $script:adapterMacAddress
-            InterfaceDescription = $script:adapterInterfaceDescription
-            InterfaceIndex       = $script:adapterInterfaceIndex
-            InterfaceGuid        = $script:adapterInterfaceGuid
-            DriverDescription    = $script:adapterDriverDescription
+            Name                      = $script:adapterName
+            PhysicalMediaType         = $script:adapterPhysicalMediaType
+            Status                    = $script:adapterStatus
+            MacAddress                = $script:adapterMacAddress
+            InterfaceDescription      = $script:adapterInterfaceDescription
+            InterfaceIndex            = $script:adapterInterfaceIndex
+            InterfaceGuid             = $script:adapterInterfaceGuid
+            DriverDescription         = $script:adapterDriverDescription
+            HyperVNetworkAdapterName  = $script:adapterHyperVNetworkAdapterName
         }
 
         $script:mockRenamedAdapter = [PSObject]@{
@@ -141,6 +144,7 @@ try
                     $script:result.InterfaceIndex | Should -Be $script:mockAdapter.InterfaceIndex
                     $script:result.InterfaceGuid | Should -Be $script:mockAdapter.InterfaceGuid
                     $script:result.DriverDescription | Should -Be $script:mockAdapter.DriverDescription
+                    $script:result.HyperVNetworkAdapterName | Should -Be $script:mockAdapter.HyperVNetworkAdapterName
                 }
 
                 It 'Should call all the mocks' {


### PR DESCRIPTION
#### Pull Request (PR) description

On Hyper-V VMs, if Device Naming is configured, an advanced property is present that can be used to filter for
a NetAdapter renaming.

#### This Pull Request (PR) fixes the following issues

None

#### Task list

<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those as is.
-->

- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [x] Resource documentation added/updated in README.md.
- [x] Resource parameter descriptions added/updated in README.md, schema.mof
      and comment-based help.
- [x] Comment-based help added/updated.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where possible). See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/NetworkingDsc/523)
<!-- Reviewable:end -->
