### PR TITLE
Update Pester to 6.0.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `azure-pipelines.yml`
   - Remove windows 2019 image fixes [#540](https://github.com/dsccommunity/NetworkingDsc/issues/540).
+- Update to use Pester v6
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fix integration tests on Server 2022. Fixes [Issue #510](https://github.com/dsccommunity/NetworkingDsc/issues/510).
+- IPAddress
+  - Mandatory was wrongly set to default value, default value which could never be used - resulted in Script Analyzer error.
 
 ## [9.1.0] - 2025-05-11
 

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -10,7 +10,7 @@
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
     Pester                         = @{
-        Version    = '6.0.0-rc1'
+        Version    = '6.0.0-rc4'
         Parameters = @{ AllowPrerelease = $true }
     }
     Plaster                        = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -9,9 +9,7 @@
 
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
-    Pester                         = @{
-        Version = '6.0.0'
-    }
+    Pester                         = 'latest'
     Plaster                        = 'latest'
     ModuleBuilder                  = 'latest'
     ChangelogManagement            = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -10,8 +10,7 @@
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
     Pester                         = @{
-        Version    = '6.0.0-rc4'
-        Parameters = @{ AllowPrerelease = $true }
+        Version = '6.0.0'
     }
     Plaster                        = 'latest'
     ModuleBuilder                  = 'latest'

--- a/RequiredModules.psd1
+++ b/RequiredModules.psd1
@@ -9,7 +9,10 @@
 
     InvokeBuild                    = 'latest'
     PSScriptAnalyzer               = 'latest'
-    Pester                         = 'latest'
+    Pester                         = @{
+        Version    = '6.0.0-rc1'
+        Parameters = @{ AllowPrerelease = $true }
+    }
     Plaster                        = 'latest'
     ModuleBuilder                  = 'latest'
     ChangelogManagement            = 'latest'

--- a/source/DSCResources/DSC_IPAddress/DSC_IPAddress.psm1
+++ b/source/DSCResources/DSC_IPAddress/DSC_IPAddress.psm1
@@ -42,7 +42,7 @@ function Get-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
         [System.String]
-        $AddressFamily = 'IPv4',
+        $AddressFamily,
 
         [Parameter()]
         [System.Boolean]
@@ -109,7 +109,7 @@ function Set-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
         [System.String]
-        $AddressFamily = 'IPv4',
+        $AddressFamily,
 
         [Parameter()]
         [System.Boolean]
@@ -298,7 +298,7 @@ function Test-TargetResource
         [Parameter(Mandatory = $true)]
         [ValidateSet('IPv4', 'IPv6')]
         [System.String]
-        $AddressFamily = 'IPv4',
+        $AddressFamily,
 
         [Parameter()]
         [System.Boolean]

--- a/source/Examples/Resources/NetworkTeamInterface/2-NetworkTeamInterface_RemoveInterface_Config.ps1
+++ b/source/Examples/Resources/NetworkTeamInterface/2-NetworkTeamInterface_RemoveInterface_Config.ps1
@@ -29,11 +29,11 @@ Configuration NetworkTeamInterface_RemoveInterface_Config
     {
         NetworkTeam HostTeam
         {
-          Name = 'HostTeam'
-          TeamingMode = 'SwitchIndependent'
-          LoadBalancingAlgorithm = 'HyperVPort'
-          TeamMembers = 'NIC1','NIC2'
-          Ensure = 'Present'
+            Name = 'HostTeam'
+            TeamingMode = 'SwitchIndependent'
+            LoadBalancingAlgorithm = 'HyperVPort'
+            TeamMembers = 'NIC1','NIC2'
+            Ensure = 'Present'
         }
 
         NetworkTeamInterface NewInterface


### PR DESCRIPTION
Pester **6.0.0 is now released** 🎉 — thanks for letting me pilot the release candidates against your suite.

This updates the earlier release-candidate pin to the final **6.0.0** and keeps the test changes needed to run on Pester 6 (already in this PR). It's the same migration you'd make yourself, so you're welcome to merge it, cherry-pick just the compatibility changes, or use it purely as a reference.

Your unit tests pass on 6.0.0 (WS2022 + WS2025). The remaining red **HQRM** check is this repo's own quality gates (a CHANGELOG-in-diff check + PSScriptAnalyzer rules), unrelated to Pester.

The real-world CI signal from this pilot was genuinely valuable in getting 6.0.0 right. Thanks for the CI time this used, and for maintaining a suite I could test against.

This PR was co-authored by GitHub Copilot.

— Jakub & Copilot

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/dsccommunity/NetworkingDsc/545)
<!-- Reviewable:end -->
